### PR TITLE
Share resp metadata w/ Error

### DIFF
--- a/client.go
+++ b/client.go
@@ -239,7 +239,13 @@ func (c *Client) Do(req *http.Request, v interface{}) error {
 	if c.Log.IsLevel(LevelDebug) { // do not waste cpu unless we're at debug level
 		// TODO: How do we want to expose the rate limit info?
 		// Maybe use a chan(RateLimit) for something to get the data?
-		meta := c.parseResponseMetadata(req.URL, res)
+		meta := parseResponseMetadata(res)
+		if meta.Deprecated {
+			c.Log.Errorf("Endpoint %s is deprecated. Use at your own risk!", req.URL.Path)
+		}
+		if meta.Deprecated && meta.DeprecationDate != "" {
+			c.Log.Warnf("Endpoint %s will no longer be available after %s.", req.URL.Path, meta.DeprecationDate)
+		}
 
 		bodyContentType := res.Header.Get("Content-type")
 		if strings.HasPrefix(bodyContentType, "application/json") {

--- a/error.go
+++ b/error.go
@@ -8,13 +8,11 @@ import (
 
 // Error contains basic information about the error
 type Error struct {
-	HTTPStatusCode   int
 	Message          string
 	Type             ErrorType
 	Params           ErrorParams
-	RateLimit        RateLimit
-	RequestID        string
 	TransactionError *TransactionError
+	Response         ResponseMetadata
 }
 
 func (e *Error) Error() string {
@@ -68,13 +66,11 @@ func parseResponseToError(res *http.Response, body []byte) error {
 		var errResp errorResponse
 		if err := json.Unmarshal(body, &errResp); err == nil {
 			return &Error{
-				HTTPStatusCode:   res.StatusCode,
-				RateLimit:        parseRateLimit(res),
-				RequestID:        res.Header.Get("X-Request-Id"),
 				Message:          errResp.Error.Message,
 				Type:             ErrorType(errResp.Error.Type),
 				Params:           errResp.Error.Params,
 				TransactionError: errResp.Error.TransactionError,
+				Response:         parseResponseMetadata(res),
 			}
 		}
 	}
@@ -110,10 +106,8 @@ func parseResponseToError(res *http.Response, body []byte) error {
 	}
 
 	return &Error{
-		HTTPStatusCode: res.StatusCode,
-		RateLimit:      parseRateLimit(res),
-		RequestID:      res.Header.Get("X-Request-Id"),
-		Message:        errMessage,
-		Type:           errType,
+		Message:  errMessage,
+		Type:     errType,
+		Response: parseResponseMetadata(res),
 	}
 }


### PR DESCRIPTION
Changes the Error to use ResponseMetadata. Will be adding some tests next and possibly changing the name from `Response` to something else or maybe make it a method.