### PR TITLE
Error refactoring

### DIFF
--- a/client.go
+++ b/client.go
@@ -56,6 +56,7 @@ var (
 	acceptVersion  = fmt.Sprintf("application/vnd.recurly.%s", APIVersion)
 	recurlyVersion = fmt.Sprintf("recurly.%s", APIVersion)
 	userAgent      = fmt.Sprintf("Recurly/%s; go %s", clientVersion, runtime.Version())
+	pathPattern    = regexp.MustCompile(`{[^}]+}`)
 )
 
 // Client submits API requests to Recurly
@@ -93,12 +94,10 @@ func NewClient(apiKey string, httpClient *http.Client) *Client {
 	}
 }
 
-var PathPattern = regexp.MustCompile(`{[^}]+}`)
-
 // Takes an OpenAPI-style path such as "/accounts/{account_id}/shipping_addresses/{shipping_address_id}"
 // and a list of string arguments to fill the template, and it returns the interpolated path
 func (c *Client) InterpolatePath(path string, params ...string) string {
-	template := PathPattern.ReplaceAllString(path, "%s")
+	template := pathPattern.ReplaceAllString(path, "%s")
 	encodedParams := make([]interface{}, len(params))
 	for i, param := range params {
 		encoded := url.PathEscape(param)
@@ -153,9 +152,8 @@ func BuildUrl(requestURL string, genericParams GenericParams) string {
 			}
 			requestURL = buf.String()
 		}
-	} else {
-		fmt.Println("nil")
 	}
+
 	return requestURL
 }
 

--- a/client_operations.go
+++ b/client_operations.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	//  "net/url"
 )
 
 const (

--- a/client_test.go
+++ b/client_test.go
@@ -1,144 +1,9 @@
 package recurly
 
 import (
-	"bytes"
-	"io"
-	"io/ioutil"
-	"testing"
-	"time"
-
 	"net/http"
+	"testing"
 )
-
-// A wrapper for testing.T
-type T struct {
-	*testing.T
-}
-
-// A helpful method to assert variables are the expected values
-func (t *T) Assert(val interface{}, expected interface{}, label string) {
-	if val != expected {
-		t.Errorf("%v is incorrect. Expected: %v Got: %v", label, val, expected)
-	}
-}
-
-// roundTripFunc is a function used to mock the transport barrier of http.Client
-type roundTripFunc func(req *http.Request) *http.Response
-
-func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req), nil
-}
-
-// A testing "Scenario" is composed of 2 functions:
-//	AssertRequest: asserts the correct request properties are being sent to the transport layer
-//	MakeResponse: returns a canned response to test the response handling code
-type Scenario struct {
-	T             *T
-	AssertRequest func(req *http.Request)
-	MakeResponse  func(req *http.Request) *http.Response
-}
-
-// This method on Scenario gives you a *recurly.Client
-// which implements the testing scenario
-func (s *Scenario) MockHttpClient() *Client {
-	roundTrip := func(req *http.Request) *http.Response {
-		// Check the request has the expected properties
-		s.AssertRequest(req)
-
-		// Assert the default headers on every request
-		expectedAccept := "application/vnd.recurly." + APIVersion
-		header := req.Header
-		s.T.Assert(header.Get("Accept"), expectedAccept, "Request Header \"Accept\"")
-		s.T.Assert(header.Get("Accept-Encoding"), "gzip", "Request Header \"Accept-Encoding\"")
-		s.T.Assert(header.Get("Content-Type"), "application/json; charset=utf-8", "Request Header \"Content-Type\"")
-
-		// Return the canned Response
-		return s.MakeResponse(req)
-	}
-
-	return NewClient("APIKEY", &http.Client{
-		Transport: roundTripFunc(roundTrip),
-	})
-}
-
-// A helpful utility method for creating default
-// http.Responses with Recurly metadata
-func mockResponse(statusCode int, body string) *http.Response {
-	headers := make(http.Header)
-	headers.Add("Content-Type", "application/json; charset=utf-8")
-	headers.Add("Recurly-Version", "recurly"+APIVersion)
-	headers.Add("X-RateLimit-Limit", "2000")
-	headers.Add("X-RateLimit-Remaining", "1999")
-	headers.Add("X-RateLimit-Reset", "1586203320")
-	headers.Add("X-RateLimit-Reset", "1586203320")
-	headers.Add("X-Request-Id", "msy-1234")
-	return &http.Response{
-		StatusCode: statusCode,
-		Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
-		Header:     headers,
-	}
-}
-
-// turns a body (as an io reader) into a string
-func bodyToString(io io.ReadCloser) string {
-	buf := new(bytes.Buffer)
-	buf.ReadFrom(io)
-	return buf.String()
-}
-
-// Resource and SubResource are used as placeholders for
-// Recurly's resources. This accomplishes 2 goals:
-//   1. Keep the test code from coupling to generated code
-//	 2. Easily setup specific type scenarios which may or may not exist in Recurly now
-type Resource struct {
-	Id          string        `json:"id,omitempty"`
-	Integer     int           `json:"int,omitempty"`
-	Float       float64       `json:"float,omitempty"`
-	DateTime    time.Time     `json:"date_time,omitempty"`
-	SubResource SubResource   `json:"sub_resource,omitempty"`
-	StrArray    []string      `json:"str_array,omitempty"`
-	SubArray    []SubResource `json:"sub_array,omitempty"`
-}
-
-type SubResource struct {
-	Id string `json:"id,omitempty"`
-}
-
-type ResourceCreate struct {
-	Params `json:"-"`
-	String string `json:"string,omitempty"`
-}
-
-func (attr *ResourceCreate) toParams() *Params {
-	return &Params{
-		IdempotencyKey: attr.IdempotencyKey,
-		Header:         attr.Header,
-		Context:        attr.Context,
-		Data:           attr,
-	}
-}
-
-// We also implement fake CRUD operations for these fake resources
-// We want to use the Client from the consuming code's perspective
-func (c *Client) GetResource(resourceId string) (*Resource, error) {
-	path := c.InterpolatePath("/resources/{resource_id}", resourceId)
-	result := &Resource{}
-	err := c.Call(http.MethodGet, path, nil, result)
-	if err != nil {
-		return nil, err
-	}
-	return result, err
-}
-
-func (c *Client) CreateResource(body *ResourceCreate) (*Resource, error) {
-	path := c.InterpolatePath("/resources")
-	result := &Resource{}
-	err := c.Call(http.MethodPost, path, body, result)
-	if err != nil {
-		return nil, err
-	}
-	return result, err
-}
 
 func TestGetResource200(test *testing.T) {
 	t := &T{test}
@@ -155,7 +20,7 @@ func TestGetResource200(test *testing.T) {
 			return mockResponse(200, `{"id": "abcd1234"}`)
 		},
 	}
-	client := scenario.MockHttpClient()
+	client := scenario.MockHTTPClient()
 
 	resource, err := client.GetResource("abcd1234")
 	t.Assert(err, nil, "Error not expected")
@@ -171,17 +36,17 @@ func TestGetResource404(test *testing.T) {
 			t.Assert(req.URL.String(), "https://v3.recurly.com/resources/idontexist", "Request URL")
 		},
 		MakeResponse: func(req *http.Request) *http.Response {
-			body := `{ "error": { "type": "not_found", "params": [{ "param": "resource_id" }] }}`
+			body := `{ "error": { "type": "not_found", "message": "\"idontexist\" not found", "params": [{ "param": "resource_id", "message": "not found" }] }}`
 			return mockResponse(404, body)
 		},
 	}
-	client := scenario.MockHttpClient()
+	client := scenario.MockHTTPClient()
 
 	resource, err := client.GetResource("idontexist")
 	if resource != nil {
 		t.Error("Expected Resource to be nil")
 	}
-	t.Assert(err.Error(), "requested object or endpoint not found", "err.Error()")
+	t.Assert(err.Error(), "\"idontexist\" not found", "err.Error()")
 }
 
 func TestCreateResource201(test *testing.T) {
@@ -198,7 +63,7 @@ func TestCreateResource201(test *testing.T) {
 			return mockResponse(201, body)
 		},
 	}
-	client := scenario.MockHttpClient()
+	client := scenario.MockHTTPClient()
 
 	body := &ResourceCreate{
 		String: "hello world",
@@ -229,7 +94,7 @@ func TestCreateResource422(test *testing.T) {
 			return mockResponse(422, body)
 		},
 	}
-	client := scenario.MockHttpClient()
+	client := scenario.MockHTTPClient()
 
 	body := &ResourceCreate{
 		String: "hello world",
@@ -238,5 +103,5 @@ func TestCreateResource422(test *testing.T) {
 	if resource != nil {
 		t.Error("Expected Resource to be nil")
 	}
-	t.Assert(err.Error(), "Invalid request", "err.Error()")
+	t.Assert(err.Error(), "Param 'string' is bad", "err.Error()")
 }

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,270 @@
+package recurly
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func bodyToBytes(io io.ReadCloser) []byte {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(io)
+	return buf.Bytes()
+}
+
+func mockResponseWithoutBody(statusCode int) *http.Response {
+	resp := mockResponse(statusCode, "")
+	resp.Header.Del("Content-Type")
+	return resp
+}
+
+func parseError(resp *http.Response) error {
+	return parseResponseToError(resp, bodyToBytes(resp.Body))
+}
+
+func Test401UnauthorizedError(test *testing.T) {
+	t := &T{test}
+
+	resp := mockResponse(401, `
+		{
+			 "error": {
+				"type": "unauthorized",
+				"message": "Invalid API key"
+			}
+		}`)
+	err := parseError(resp)
+	t.Assert(err.Error(), "Invalid API key", "err.Error()")
+	if e, ok := err.(*Error); ok {
+		t.Assert(e.Type, ErrorTypeUnauthorized, "e.Type")
+		t.Assert(e.Class, ErrorClassClient, "e.Class")
+	}
+
+	// test fallback without body
+	resp = mockResponseWithoutBody(401)
+	err = parseError(resp)
+	t.Assert(err.Error(), "Unauthorized", "err.Error()")
+	if e, ok := err.(*Error); ok {
+		t.Assert(e.Type, ErrorTypeUnauthorized, "e.Type")
+		t.Assert(e.Class, ErrorClassClient, "e.Class")
+	}
+}
+
+func Test403ForbiddenError(test *testing.T) {
+	t := &T{test}
+
+	resp := mockResponse(403, `
+		{
+			 "error": {
+				"type": "forbidden",
+				"message": "API key cannot access this resource"
+			}
+		}`)
+	err := parseError(resp)
+	t.Assert(err.Error(), "API key cannot access this resource", "err.Error()")
+	if e, ok := err.(*Error); ok {
+		t.Assert(e.Type, ErrorTypeForbidden, "e.Type")
+		t.Assert(e.Class, ErrorClassClient, "e.Class")
+	}
+
+	// test fallback without body
+	resp = mockResponseWithoutBody(403)
+	err = parseError(resp)
+	t.Assert(err.Error(), "The API key is not authorized for this resource", "err.Error()")
+	if e, ok := err.(*Error); ok {
+		t.Assert(e.Type, ErrorTypeForbidden, "e.Type")
+		t.Assert(e.Class, ErrorClassClient, "e.Class")
+	}
+}
+
+func Test404NotFoundError(test *testing.T) {
+	t := &T{test}
+
+	resp := mockResponse(404, `
+		{
+			 "error": {
+				"type": "not_found",
+				"message": "It's Not found"
+			}
+		}`)
+	err := parseError(resp)
+	t.Assert(err.Error(), "It's Not found", "err.Error()")
+	if e, ok := err.(*Error); ok {
+		t.Assert(e.Type, ErrorTypeNotFound, "e.Type")
+		t.Assert(e.Class, ErrorClassClient, "e.Class")
+	}
+
+	// test fallback without body
+	resp = mockResponseWithoutBody(404)
+	err = parseError(resp)
+	t.Assert(err.Error(), "Requested object or endpoint not found", "err.Error()")
+	if e, ok := err.(*Error); ok {
+		t.Assert(e.Type, ErrorTypeNotFound, "e.Type")
+		t.Assert(e.Class, ErrorClassClient, "e.Class")
+	}
+}
+func Test422ValidationError(test *testing.T) {
+	t := &T{test}
+
+	resp := mockResponse(422, `
+		{
+			 "error": {
+				"type": "validation",
+				"message": "It's Invalid",
+				"params": [
+					{"param":"property","message":"is invalid"}
+			    ]
+			}
+		}`)
+	err := parseError(resp)
+	t.Assert(err.Error(), "It's Invalid", "err.Error()")
+	if e, ok := err.(*Error); ok {
+		t.Assert(e.Type, ErrorTypeValidation, "e.Type")
+		t.Assert(e.Class, ErrorClassClient, "e.Class")
+		t.Assert(len(e.Params), 1, "e")
+	}
+
+	// test fallback without body
+	resp = mockResponseWithoutBody(422)
+	err = parseError(resp)
+	t.Assert(err.Error(), "Invalid request", "err.Error()")
+	if e, ok := err.(*Error); ok {
+		t.Assert(e.Type, ErrorTypeValidation, "e.Type")
+		t.Assert(e.Class, ErrorClassClient, "e.Class")
+	}
+}
+
+func Test429RateLimitedError(test *testing.T) {
+	t := &T{test}
+
+	resp := mockResponse(429, `
+		{
+			 "error": {
+				"type": "rate_limited",
+				"message": "Too many requests"
+			}
+		}`)
+	err := parseError(resp)
+	t.Assert(err.Error(), "Too many requests", "err.Error()")
+	if e, ok := err.(*Error); ok {
+		t.Assert(e.Type, ErrorTypeRateLimited, "e.Type")
+		t.Assert(e.Class, ErrorClassClient, "e.Class")
+	}
+
+	// test fallback without body
+	resp = mockResponseWithoutBody(429)
+	err = parseError(resp)
+	t.Assert(err.Error(), "You made too many API requests", "err.Error()")
+	if e, ok := err.(*Error); ok {
+		t.Assert(e.Type, ErrorTypeRateLimited, "e.Type")
+		t.Assert(e.Class, ErrorClassClient, "e.Class")
+	}
+}
+
+func Test500InternalServerError(test *testing.T) {
+	t := &T{test}
+
+	resp := mockResponse(500, `
+		{
+			 "error": {
+				"type": "internal_server_error",
+				"message": "Unknown Server Error"
+			}
+		}`)
+	err := parseError(resp)
+	t.Assert(err.Error(), "Unknown Server Error", "err.Error()")
+	if e, ok := err.(*Error); ok {
+		t.Assert(e.Type, ErrorTypeInternalServer, "e.Type")
+		t.Assert(e.Class, ErrorClassServer, "e.Class")
+	}
+
+	// test fallback without body
+	resp = mockResponseWithoutBody(500)
+	err = parseError(resp)
+	t.Assert(err.Error(), "Server experienced an error", "err.Error()")
+	if e, ok := err.(*Error); ok {
+		t.Assert(e.Type, ErrorTypeInternalServer, "e.Type")
+		t.Assert(e.Class, ErrorClassServer, "e.Class")
+	}
+}
+
+func Test502BadGatewatError(test *testing.T) {
+	t := &T{test}
+
+	resp := mockResponse(502, `
+		{
+			 "error": {
+				"type": "bad_gateway",
+				"message": "A bad gateway"
+			}
+		}`)
+	err := parseError(resp)
+	t.Assert(err.Error(), "A bad gateway", "err.Error()")
+	if e, ok := err.(*Error); ok {
+		t.Assert(e.Type, ErrorTypeBadGateway, "e.Type")
+		t.Assert(e.Class, ErrorClassServer, "e.Class")
+	}
+
+	// test fallback without body
+	resp = mockResponseWithoutBody(502)
+	err = parseError(resp)
+	t.Assert(err.Error(), "Error contacting server", "err.Error()")
+	if e, ok := err.(*Error); ok {
+		t.Assert(e.Type, ErrorTypeBadGateway, "e.Type")
+		t.Assert(e.Class, ErrorClassServer, "e.Class")
+	}
+}
+
+func Test503ServiceUnavailableError(test *testing.T) {
+	t := &T{test}
+
+	resp := mockResponse(503, `
+		{
+			 "error": {
+				"type": "service_unavailable",
+				"message": "The service is unavailable"
+			}
+		}`)
+	err := parseError(resp)
+	t.Assert(err.Error(), "The service is unavailable", "err.Error()")
+	if e, ok := err.(*Error); ok {
+		t.Assert(e.Type, ErrorTypeServiceUnavailable, "e.Type")
+		t.Assert(e.Class, ErrorClassServer, "e.Class")
+	}
+
+	// test fallback without body
+	resp = mockResponseWithoutBody(503)
+	err = parseError(resp)
+	t.Assert(err.Error(), "Service unavailable", "err.Error()")
+	if e, ok := err.(*Error); ok {
+		t.Assert(e.Type, ErrorTypeServiceUnavailable, "e.Type")
+		t.Assert(e.Class, ErrorClassServer, "e.Class")
+	}
+}
+
+func Test504GatewayTimeoutError(test *testing.T) {
+	t := &T{test}
+
+	resp := mockResponse(504, `
+		{
+			 "error": {
+				"type": "timeout",
+				"message": "The request timed out"
+			}
+		}`)
+	err := parseError(resp)
+	t.Assert(err.Error(), "The request timed out", "err.Error()")
+	if e, ok := err.(*Error); ok {
+		t.Assert(e.Type, ErrorTypeTimeout, "e.Type")
+		t.Assert(e.Class, ErrorClassServer, "e.Class")
+	}
+
+	// test fallback without body
+	resp = mockResponseWithoutBody(504)
+	err = parseError(resp)
+	t.Assert(err.Error(), "Request timed out", "err.Error()")
+	if e, ok := err.(*Error); ok {
+		t.Assert(e.Type, ErrorTypeTimeout, "e.Type")
+		t.Assert(e.Class, ErrorClassServer, "e.Class")
+	}
+}

--- a/recurly_test.go
+++ b/recurly_test.go
@@ -1,0 +1,145 @@
+package recurly
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// A wrapper for testing.T
+type T struct {
+	*testing.T
+}
+
+// A helpful method to assert variables are the expected values
+func (t *T) Assert(val interface{}, expected interface{}, label string) {
+	if val != expected {
+		t.Errorf("%v is incorrect. Expected: %v Got: %v", label, expected, val)
+	}
+}
+
+// roundTripFunc is a function used to mock the transport barrier of http.Client
+type roundTripFunc func(req *http.Request) *http.Response
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+// A testing "Scenario" is composed of 2 functions:
+//	AssertRequest: asserts the correct request properties are being sent to the transport layer
+//	MakeResponse: returns a canned response to test the response handling code
+type Scenario struct {
+	T             *T
+	AssertRequest func(req *http.Request)
+	MakeResponse  func(req *http.Request) *http.Response
+}
+
+// This method on Scenario gives you a *recurly.Client
+// which implements the testing scenario
+func (s *Scenario) MockHTTPClient() *Client {
+	roundTrip := func(req *http.Request) *http.Response {
+		// Check the request has the expected properties
+		s.AssertRequest(req)
+
+		// Assert the default headers on every request
+		expectedAccept := "application/vnd.recurly." + APIVersion
+		header := req.Header
+		s.T.Assert(header.Get("Accept"), expectedAccept, "Request Header \"Accept\"")
+		s.T.Assert(header.Get("Accept-Encoding"), "gzip", "Request Header \"Accept-Encoding\"")
+		s.T.Assert(header.Get("Content-Type"), "application/json; charset=utf-8", "Request Header \"Content-Type\"")
+
+		// Return the canned Response
+		return s.MakeResponse(req)
+	}
+
+	client := NewClient("APIKEY", &http.Client{
+		Transport: roundTripFunc(roundTrip),
+	})
+
+	// override the loger to keep noise down
+	client.Log = NewLogger(LevelWarn)
+
+	return client
+}
+
+// A helpful utility method for creating default
+// http.Responses with Recurly metadata
+func mockResponse(statusCode int, body string) *http.Response {
+	headers := make(http.Header)
+	headers.Add("Content-Type", "application/json; charset=utf-8")
+	headers.Add("Recurly-Version", "recurly"+APIVersion)
+	headers.Add("X-RateLimit-Limit", "2000")
+	headers.Add("X-RateLimit-Remaining", "1999")
+	headers.Add("X-RateLimit-Reset", "1586203320")
+	headers.Add("X-RateLimit-Reset", "1586203320")
+	headers.Add("X-Request-Id", "msy-1234")
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+		Header:     headers,
+	}
+}
+
+// turns a body (as an io reader) into a string
+func bodyToString(io io.ReadCloser) string {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(io)
+	return buf.String()
+}
+
+// Resource and SubResource are used as placeholders for
+// Recurly's resources. This accomplishes 2 goals:
+//   1. Keep the test code from coupling to generated code
+//	 2. Easily setup specific type scenarios which may or may not exist in Recurly now
+type Resource struct {
+	Id          string        `json:"id,omitempty"`
+	Integer     int           `json:"int,omitempty"`
+	Float       float64       `json:"float,omitempty"`
+	DateTime    time.Time     `json:"date_time,omitempty"`
+	SubResource SubResource   `json:"sub_resource,omitempty"`
+	StrArray    []string      `json:"str_array,omitempty"`
+	SubArray    []SubResource `json:"sub_array,omitempty"`
+}
+
+type SubResource struct {
+	Id string `json:"id,omitempty"`
+}
+
+type ResourceCreate struct {
+	Params `json:"-"`
+	String string `json:"string,omitempty"`
+}
+
+func (attr *ResourceCreate) toParams() *Params {
+	return &Params{
+		IdempotencyKey: attr.IdempotencyKey,
+		Header:         attr.Header,
+		Context:        attr.Context,
+		Data:           attr,
+	}
+}
+
+// We also implement fake CRUD operations for these fake resources
+// We want to use the Client from the consuming code's perspective
+func (c *Client) GetResource(resourceId string) (*Resource, error) {
+	path := c.InterpolatePath("/resources/{resource_id}", resourceId)
+	result := &Resource{}
+	err := c.Call(http.MethodGet, path, nil, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, err
+}
+
+func (c *Client) CreateResource(body *ResourceCreate) (*Resource, error) {
+	path := c.InterpolatePath("/resources")
+	result := &Resource{}
+	err := c.Call(http.MethodPost, path, body, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, err
+}


### PR DESCRIPTION
Doing some refactoring of the error interface and adding tests for error parsing.

Switching will look something like this now:

```go
	account, err := client.CreateAccount(accountReq)
	if err != nil {
		if e, ok := err.(*recurly.Error); ok {
			switch e.Type {
			case recurly.ErrorTypeValidation:
				fmt.Printf("A validation error: %v", e)
			default:
				fmt.Printf("Something else: %v", e)
			}
		}
	}
```

