### PR TITLE
Ensure that path parameters are not empty strings

### DIFF
--- a/client.go
+++ b/client.go
@@ -106,7 +106,7 @@ func validatePathParameters(params []string) error {
 		return &Error{
 			Message: "Operation parameters cannot be empty strings",
 			Class:   ErrorClassClient,
-			Type:    ErrorTypeValidation,
+			Type:    ErrorTypeBadRequest,
 		}
 	}
 	return nil

--- a/client.go
+++ b/client.go
@@ -103,7 +103,11 @@ func validatePathParameters(params []string) error {
 		}
 	}
 	if len(invalidParams) > 0 {
-		return fmt.Errorf("Parameters cannot be empty strings")
+		return &Error{
+			Message: "Operation parameters cannot be empty strings",
+			Class:   ErrorClassClient,
+			Type:    ErrorTypeValidation,
+		}
 	}
 	return nil
 }

--- a/client.go
+++ b/client.go
@@ -95,16 +95,33 @@ func newClient(apiKey string, httpClient *http.Client) *Client {
 	}
 }
 
+func validatePathParameters(params []string) error {
+	invalidParams := []string{}
+	for _, param := range params {
+		if len(strings.TrimSpace(param)) == 0 {
+			invalidParams = append(invalidParams, param)
+		}
+	}
+	if len(invalidParams) > 0 {
+		return fmt.Errorf("Parameters cannot be empty strings")
+	}
+	return nil
+}
+
 // Takes an OpenAPI-style path such as "/accounts/{account_id}/shipping_addresses/{shipping_address_id}"
 // and a list of string arguments to fill the template, and it returns the interpolated path
-func (c *Client) InterpolatePath(path string, params ...string) string {
+func (c *Client) InterpolatePath(path string, params ...string) (string, error) {
+	err := validatePathParameters(params)
+	if err != nil {
+		return "", err
+	}
 	template := pathPattern.ReplaceAllString(path, "%s")
 	encodedParams := make([]interface{}, len(params))
 	for i, param := range params {
 		encoded := url.PathEscape(param)
 		encodedParams[i] = encoded
 	}
-	return fmt.Sprintf(template, encodedParams...)
+	return fmt.Sprintf(template, encodedParams...), nil
 }
 
 // HttpCaller is the generic http interface used by the Client

--- a/client_operations.go
+++ b/client_operations.go
@@ -317,6 +317,9 @@ func (list *ListSitesParams) URLParams() []KeyValue {
 }
 
 // ListSites List sites
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_sites
+//
 // Returns: A list of sites.
 func (c *Client) ListSites(params *ListSitesParams) (*SiteList, error) {
 	path, err := c.InterpolatePath("/sites")
@@ -336,6 +339,9 @@ func (c *Client) ListSites(params *ListSitesParams) (*SiteList, error) {
 }
 
 // GetSite Fetch a site
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_site
+//
 // Returns: A site.
 func (c *Client) GetSite(siteId string) (*Site, error) {
 	path, err := c.InterpolatePath("/sites/{site_id}", siteId)
@@ -446,6 +452,9 @@ func (list *ListAccountsParams) URLParams() []KeyValue {
 }
 
 // ListAccounts List a site's accounts
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_accounts
+//
 // Returns: A list of the site's accounts.
 func (c *Client) ListAccounts(params *ListAccountsParams) (*AccountList, error) {
 	path, err := c.InterpolatePath("/accounts")
@@ -465,6 +474,9 @@ func (c *Client) ListAccounts(params *ListAccountsParams) (*AccountList, error) 
 }
 
 // CreateAccount Create an account
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_account
+//
 // Returns: An account.
 func (c *Client) CreateAccount(body *AccountCreate) (*Account, error) {
 	path, err := c.InterpolatePath("/accounts")
@@ -480,6 +492,9 @@ func (c *Client) CreateAccount(body *AccountCreate) (*Account, error) {
 }
 
 // GetAccount Fetch an account
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_account
+//
 // Returns: An account.
 func (c *Client) GetAccount(accountId string) (*Account, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}", accountId)
@@ -495,6 +510,9 @@ func (c *Client) GetAccount(accountId string) (*Account, error) {
 }
 
 // UpdateAccount Modify an account
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_account
+//
 // Returns: An account.
 func (c *Client) UpdateAccount(accountId string, body *AccountUpdate) (*Account, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}", accountId)
@@ -510,6 +528,9 @@ func (c *Client) UpdateAccount(accountId string, body *AccountUpdate) (*Account,
 }
 
 // DeactivateAccount Deactivate an account
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/deactivate_account
+//
 // Returns: An account.
 func (c *Client) DeactivateAccount(accountId string) (*Account, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}", accountId)
@@ -525,6 +546,9 @@ func (c *Client) DeactivateAccount(accountId string) (*Account, error) {
 }
 
 // GetAccountAcquisition Fetch an account's acquisition data
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_account_acquisition
+//
 // Returns: An account's acquisition data.
 func (c *Client) GetAccountAcquisition(accountId string) (*AccountAcquisition, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/acquisition", accountId)
@@ -540,6 +564,9 @@ func (c *Client) GetAccountAcquisition(accountId string) (*AccountAcquisition, e
 }
 
 // UpdateAccountAcquisition Update an account's acquisition data
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_account_acquisition
+//
 // Returns: An account's updated acquisition data.
 func (c *Client) UpdateAccountAcquisition(accountId string, body *AccountAcquisitionUpdatable) (*AccountAcquisition, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/acquisition", accountId)
@@ -555,6 +582,9 @@ func (c *Client) UpdateAccountAcquisition(accountId string, body *AccountAcquisi
 }
 
 // RemoveAccountAcquisition Remove an account's acquisition data
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_account_acquisition
+//
 // Returns: Acquisition data was succesfully deleted.
 func (c *Client) RemoveAccountAcquisition(accountId string) (*Empty, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/acquisition", accountId)
@@ -570,6 +600,9 @@ func (c *Client) RemoveAccountAcquisition(accountId string) (*Empty, error) {
 }
 
 // ReactivateAccount Reactivate an inactive account
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/reactivate_account
+//
 // Returns: An account.
 func (c *Client) ReactivateAccount(accountId string) (*Account, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/reactivate", accountId)
@@ -585,6 +618,9 @@ func (c *Client) ReactivateAccount(accountId string) (*Account, error) {
 }
 
 // GetAccountBalance Fetch an account's balance and past due status
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_account_balance
+//
 // Returns: An account's balance.
 func (c *Client) GetAccountBalance(accountId string) (*AccountBalance, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/balance", accountId)
@@ -600,6 +636,9 @@ func (c *Client) GetAccountBalance(accountId string) (*AccountBalance, error) {
 }
 
 // GetBillingInfo Fetch an account's billing information
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_billing_info
+//
 // Returns: An account's billing information.
 func (c *Client) GetBillingInfo(accountId string) (*BillingInfo, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/billing_info", accountId)
@@ -615,6 +654,9 @@ func (c *Client) GetBillingInfo(accountId string) (*BillingInfo, error) {
 }
 
 // UpdateBillingInfo Set an account's billing information
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_billing_info
+//
 // Returns: Updated billing information.
 func (c *Client) UpdateBillingInfo(accountId string, body *BillingInfoCreate) (*BillingInfo, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/billing_info", accountId)
@@ -630,6 +672,9 @@ func (c *Client) UpdateBillingInfo(accountId string, body *BillingInfoCreate) (*
 }
 
 // RemoveBillingInfo Remove an account's billing information
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_billing_info
+//
 // Returns: Billing information deleted
 func (c *Client) RemoveBillingInfo(accountId string) (*Empty, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/billing_info", accountId)
@@ -704,6 +749,9 @@ func (list *ListAccountCouponRedemptionsParams) URLParams() []KeyValue {
 }
 
 // ListAccountCouponRedemptions Show the coupon redemptions for an account
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_account_coupon_redemptions
+//
 // Returns: A list of the the coupon redemptions on an account.
 func (c *Client) ListAccountCouponRedemptions(accountId string, params *ListAccountCouponRedemptionsParams) (*CouponRedemptionList, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/coupon_redemptions", accountId)
@@ -723,6 +771,9 @@ func (c *Client) ListAccountCouponRedemptions(accountId string, params *ListAcco
 }
 
 // GetActiveCouponRedemption Show the coupon redemption that is active on an account
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_active_coupon_redemption
+//
 // Returns: An active coupon redemption on an account.
 func (c *Client) GetActiveCouponRedemption(accountId string) (*CouponRedemption, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/coupon_redemptions/active", accountId)
@@ -738,6 +789,9 @@ func (c *Client) GetActiveCouponRedemption(accountId string) (*CouponRedemption,
 }
 
 // CreateCouponRedemption Generate an active coupon redemption on an account
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_coupon_redemption
+//
 // Returns: Returns the new coupon redemption.
 func (c *Client) CreateCouponRedemption(accountId string, body *CouponRedemptionCreate) (*CouponRedemption, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/coupon_redemptions/active", accountId)
@@ -753,6 +807,9 @@ func (c *Client) CreateCouponRedemption(accountId string, body *CouponRedemption
 }
 
 // RemoveCouponRedemption Delete the active coupon redemption from an account
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_coupon_redemption
+//
 // Returns: Coupon redemption deleted.
 func (c *Client) RemoveCouponRedemption(accountId string) (*CouponRedemption, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/coupon_redemptions/active", accountId)
@@ -826,6 +883,9 @@ func (list *ListAccountCreditPaymentsParams) URLParams() []KeyValue {
 }
 
 // ListAccountCreditPayments List an account's credit payments
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_account_credit_payments
+//
 // Returns: A list of the account's credit payments.
 func (c *Client) ListAccountCreditPayments(accountId string, params *ListAccountCreditPaymentsParams) (*CreditPaymentList, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/credit_payments", accountId)
@@ -929,6 +989,9 @@ func (list *ListAccountInvoicesParams) URLParams() []KeyValue {
 }
 
 // ListAccountInvoices List an account's invoices
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_account_invoices
+//
 // Returns: A list of the account's invoices.
 func (c *Client) ListAccountInvoices(accountId string, params *ListAccountInvoicesParams) (*InvoiceList, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/invoices", accountId)
@@ -948,6 +1011,9 @@ func (c *Client) ListAccountInvoices(accountId string, params *ListAccountInvoic
 }
 
 // CreateInvoice Create an invoice for pending line items
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_invoice
+//
 // Returns: Returns the new invoices.
 func (c *Client) CreateInvoice(accountId string, body *InvoiceCreate) (*InvoiceCollection, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/invoices", accountId)
@@ -963,6 +1029,9 @@ func (c *Client) CreateInvoice(accountId string, body *InvoiceCreate) (*InvoiceC
 }
 
 // PreviewInvoice Preview new invoice for pending line items
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/preview_invoice
+//
 // Returns: Returns the invoice previews.
 func (c *Client) PreviewInvoice(accountId string, body *InvoiceCreate) (*InvoiceCollection, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/invoices/preview", accountId)
@@ -1072,6 +1141,9 @@ func (list *ListAccountLineItemsParams) URLParams() []KeyValue {
 }
 
 // ListAccountLineItems List an account's line items
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_account_line_items
+//
 // Returns: A list of the account's line items.
 func (c *Client) ListAccountLineItems(accountId string, params *ListAccountLineItemsParams) (*LineItemList, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/line_items", accountId)
@@ -1091,6 +1163,9 @@ func (c *Client) ListAccountLineItems(accountId string, params *ListAccountLineI
 }
 
 // CreateLineItem Create a new line item for the account
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_line_item
+//
 // Returns: Returns the new line item.
 func (c *Client) CreateLineItem(accountId string, body *LineItemCreate) (*LineItem, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/line_items", accountId)
@@ -1140,6 +1215,9 @@ func (list *ListAccountNotesParams) URLParams() []KeyValue {
 }
 
 // ListAccountNotes Fetch a list of an account's notes
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_account_notes
+//
 // Returns: A list of an account's notes.
 func (c *Client) ListAccountNotes(accountId string, params *ListAccountNotesParams) (*AccountNoteList, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/notes", accountId)
@@ -1159,6 +1237,9 @@ func (c *Client) ListAccountNotes(accountId string, params *ListAccountNotesPara
 }
 
 // GetAccountNote Fetch an account note
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_account_note
+//
 // Returns: An account note.
 func (c *Client) GetAccountNote(accountId string, accountNoteId string) (*AccountNote, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/notes/{account_note_id}", accountId, accountNoteId)
@@ -1247,6 +1328,9 @@ func (list *ListShippingAddressesParams) URLParams() []KeyValue {
 }
 
 // ListShippingAddresses Fetch a list of an account's shipping addresses
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_shipping_addresses
+//
 // Returns: A list of an account's shipping addresses.
 func (c *Client) ListShippingAddresses(accountId string, params *ListShippingAddressesParams) (*ShippingAddressList, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/shipping_addresses", accountId)
@@ -1266,6 +1350,9 @@ func (c *Client) ListShippingAddresses(accountId string, params *ListShippingAdd
 }
 
 // CreateShippingAddress Create a new shipping address for the account
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_shipping_address
+//
 // Returns: Returns the new shipping address.
 func (c *Client) CreateShippingAddress(accountId string, body *ShippingAddressCreate) (*ShippingAddress, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/shipping_addresses", accountId)
@@ -1281,6 +1368,9 @@ func (c *Client) CreateShippingAddress(accountId string, body *ShippingAddressCr
 }
 
 // GetShippingAddress Fetch an account's shipping address
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_shipping_address
+//
 // Returns: A shipping address.
 func (c *Client) GetShippingAddress(accountId string, shippingAddressId string) (*ShippingAddress, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", accountId, shippingAddressId)
@@ -1296,6 +1386,9 @@ func (c *Client) GetShippingAddress(accountId string, shippingAddressId string) 
 }
 
 // UpdateShippingAddress Update an account's shipping address
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_shipping_address
+//
 // Returns: The updated shipping address.
 func (c *Client) UpdateShippingAddress(accountId string, shippingAddressId string, body *ShippingAddressUpdate) (*ShippingAddress, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", accountId, shippingAddressId)
@@ -1311,6 +1404,9 @@ func (c *Client) UpdateShippingAddress(accountId string, shippingAddressId strin
 }
 
 // RemoveShippingAddress Remove an account's shipping address
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_shipping_address
+//
 // Returns: Shipping address deleted.
 func (c *Client) RemoveShippingAddress(accountId string, shippingAddressId string) (*Empty, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", accountId, shippingAddressId)
@@ -1409,6 +1505,9 @@ func (list *ListAccountSubscriptionsParams) URLParams() []KeyValue {
 }
 
 // ListAccountSubscriptions List an account's subscriptions
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_account_subscriptions
+//
 // Returns: A list of the account's subscriptions.
 func (c *Client) ListAccountSubscriptions(accountId string, params *ListAccountSubscriptionsParams) (*SubscriptionList, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/subscriptions", accountId)
@@ -1515,6 +1614,9 @@ func (list *ListAccountTransactionsParams) URLParams() []KeyValue {
 }
 
 // ListAccountTransactions List an account's transactions
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_account_transactions
+//
 // Returns: A list of the account's transactions.
 func (c *Client) ListAccountTransactions(accountId string, params *ListAccountTransactionsParams) (*TransactionList, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/transactions", accountId)
@@ -1629,6 +1731,9 @@ func (list *ListChildAccountsParams) URLParams() []KeyValue {
 }
 
 // ListChildAccounts List an account's child accounts
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_child_accounts
+//
 // Returns: A list of an account's child accounts.
 func (c *Client) ListChildAccounts(accountId string, params *ListChildAccountsParams) (*AccountList, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/accounts", accountId)
@@ -1721,6 +1826,9 @@ func (list *ListAccountAcquisitionParams) URLParams() []KeyValue {
 }
 
 // ListAccountAcquisition List a site's account acquisition data
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_account_acquisition
+//
 // Returns: A list of the site's account acquisition data.
 func (c *Client) ListAccountAcquisition(params *ListAccountAcquisitionParams) (*AccountAcquisitionList, error) {
 	path, err := c.InterpolatePath("/acquisitions")
@@ -1813,6 +1921,9 @@ func (list *ListCouponsParams) URLParams() []KeyValue {
 }
 
 // ListCoupons List a site's coupons
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_coupons
+//
 // Returns: A list of the site's coupons.
 func (c *Client) ListCoupons(params *ListCouponsParams) (*CouponList, error) {
 	path, err := c.InterpolatePath("/coupons")
@@ -1832,6 +1943,9 @@ func (c *Client) ListCoupons(params *ListCouponsParams) (*CouponList, error) {
 }
 
 // CreateCoupon Create a new coupon
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_coupon
+//
 // Returns: A new coupon.
 func (c *Client) CreateCoupon(body *CouponCreate) (*Coupon, error) {
 	path, err := c.InterpolatePath("/coupons")
@@ -1847,6 +1961,9 @@ func (c *Client) CreateCoupon(body *CouponCreate) (*Coupon, error) {
 }
 
 // GetCoupon Fetch a coupon
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_coupon
+//
 // Returns: A coupon.
 func (c *Client) GetCoupon(couponId string) (*Coupon, error) {
 	path, err := c.InterpolatePath("/coupons/{coupon_id}", couponId)
@@ -1862,6 +1979,9 @@ func (c *Client) GetCoupon(couponId string) (*Coupon, error) {
 }
 
 // UpdateCoupon Update an active coupon
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_coupon
+//
 // Returns: The updated coupon.
 func (c *Client) UpdateCoupon(couponId string, body *CouponUpdate) (*Coupon, error) {
 	path, err := c.InterpolatePath("/coupons/{coupon_id}", couponId)
@@ -1877,6 +1997,9 @@ func (c *Client) UpdateCoupon(couponId string, body *CouponUpdate) (*Coupon, err
 }
 
 // DeactivateCoupon Expire a coupon
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/deactivate_coupon
+//
 // Returns: The expired Coupon
 func (c *Client) DeactivateCoupon(couponId string) (*Coupon, error) {
 	path, err := c.InterpolatePath("/coupons/{coupon_id}", couponId)
@@ -1965,6 +2088,9 @@ func (list *ListUniqueCouponCodesParams) URLParams() []KeyValue {
 }
 
 // ListUniqueCouponCodes List unique coupon codes associated with a bulk coupon
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_unique_coupon_codes
+//
 // Returns: A list of unique coupon codes that were generated
 func (c *Client) ListUniqueCouponCodes(couponId string, params *ListUniqueCouponCodesParams) (*UniqueCouponCodeList, error) {
 	path, err := c.InterpolatePath("/coupons/{coupon_id}/unique_coupon_codes", couponId)
@@ -2042,6 +2168,9 @@ func (list *ListCreditPaymentsParams) URLParams() []KeyValue {
 }
 
 // ListCreditPayments List a site's credit payments
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_credit_payments
+//
 // Returns: A list of the site's credit payments.
 func (c *Client) ListCreditPayments(params *ListCreditPaymentsParams) (*CreditPaymentList, error) {
 	path, err := c.InterpolatePath("/credit_payments")
@@ -2061,6 +2190,9 @@ func (c *Client) ListCreditPayments(params *ListCreditPaymentsParams) (*CreditPa
 }
 
 // GetCreditPayment Fetch a credit payment
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_credit_payment
+//
 // Returns: A credit payment.
 func (c *Client) GetCreditPayment(creditPaymentId string) (*CreditPayment, error) {
 	path, err := c.InterpolatePath("/credit_payments/{credit_payment_id}", creditPaymentId)
@@ -2156,6 +2288,9 @@ func (list *ListCustomFieldDefinitionsParams) URLParams() []KeyValue {
 }
 
 // ListCustomFieldDefinitions List a site's custom field definitions
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_custom_field_definitions
+//
 // Returns: A list of the site's custom field definitions.
 func (c *Client) ListCustomFieldDefinitions(params *ListCustomFieldDefinitionsParams) (*CustomFieldDefinitionList, error) {
 	path, err := c.InterpolatePath("/custom_field_definitions")
@@ -2175,6 +2310,9 @@ func (c *Client) ListCustomFieldDefinitions(params *ListCustomFieldDefinitionsPa
 }
 
 // GetCustomFieldDefinition Fetch an custom field definition
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_custom_field_definition
+//
 // Returns: An custom field definition.
 func (c *Client) GetCustomFieldDefinition(customFieldDefinitionId string) (*CustomFieldDefinition, error) {
 	path, err := c.InterpolatePath("/custom_field_definitions/{custom_field_definition_id}", customFieldDefinitionId)
@@ -2270,6 +2408,9 @@ func (list *ListItemsParams) URLParams() []KeyValue {
 }
 
 // ListItems List a site's items
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_items
+//
 // Returns: A list of the site's items.
 func (c *Client) ListItems(params *ListItemsParams) (*ItemList, error) {
 	path, err := c.InterpolatePath("/items")
@@ -2289,6 +2430,9 @@ func (c *Client) ListItems(params *ListItemsParams) (*ItemList, error) {
 }
 
 // CreateItem Create a new item
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_item
+//
 // Returns: A new item.
 func (c *Client) CreateItem(body *ItemCreate) (*Item, error) {
 	path, err := c.InterpolatePath("/items")
@@ -2304,6 +2448,9 @@ func (c *Client) CreateItem(body *ItemCreate) (*Item, error) {
 }
 
 // GetItem Fetch an item
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_item
+//
 // Returns: An item.
 func (c *Client) GetItem(itemId string) (*Item, error) {
 	path, err := c.InterpolatePath("/items/{item_id}", itemId)
@@ -2319,6 +2466,9 @@ func (c *Client) GetItem(itemId string) (*Item, error) {
 }
 
 // UpdateItem Update an active item
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_item
+//
 // Returns: The updated item.
 func (c *Client) UpdateItem(itemId string, body *ItemUpdate) (*Item, error) {
 	path, err := c.InterpolatePath("/items/{item_id}", itemId)
@@ -2334,6 +2484,9 @@ func (c *Client) UpdateItem(itemId string, body *ItemUpdate) (*Item, error) {
 }
 
 // DeactivateItem Deactivate an item
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/deactivate_item
+//
 // Returns: An item.
 func (c *Client) DeactivateItem(itemId string) (*Item, error) {
 	path, err := c.InterpolatePath("/items/{item_id}", itemId)
@@ -2349,6 +2502,9 @@ func (c *Client) DeactivateItem(itemId string) (*Item, error) {
 }
 
 // ReactivateItem Reactivate an inactive item
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/reactivate_item
+//
 // Returns: An item.
 func (c *Client) ReactivateItem(itemId string) (*Item, error) {
 	path, err := c.InterpolatePath("/items/{item_id}/reactivate", itemId)
@@ -2584,6 +2740,9 @@ func (list *ListInvoicesParams) URLParams() []KeyValue {
 }
 
 // ListInvoices List a site's invoices
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_invoices
+//
 // Returns: A list of the site's invoices.
 func (c *Client) ListInvoices(params *ListInvoicesParams) (*InvoiceList, error) {
 	path, err := c.InterpolatePath("/invoices")
@@ -2603,6 +2762,9 @@ func (c *Client) ListInvoices(params *ListInvoicesParams) (*InvoiceList, error) 
 }
 
 // GetInvoice Fetch an invoice
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_invoice
+//
 // Returns: An invoice.
 func (c *Client) GetInvoice(invoiceId string) (*Invoice, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}", invoiceId)
@@ -2618,6 +2780,9 @@ func (c *Client) GetInvoice(invoiceId string) (*Invoice, error) {
 }
 
 // PutInvoice Update an invoice
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/put_invoice
+//
 // Returns: An invoice.
 func (c *Client) PutInvoice(invoiceId string, body *InvoiceUpdatable) (*Invoice, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}", invoiceId)
@@ -2649,6 +2814,9 @@ func (list *CollectInvoiceParams) toParams() *Params {
 }
 
 // CollectInvoice Collect a pending or past due, automatic invoice
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/collect_invoice
+//
 // Returns: The updated invoice.
 func (c *Client) CollectInvoice(invoiceId string, params *CollectInvoiceParams) (*Invoice, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/collect", invoiceId)
@@ -2664,6 +2832,9 @@ func (c *Client) CollectInvoice(invoiceId string, params *CollectInvoiceParams) 
 }
 
 // FailInvoice Mark an open invoice as failed
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/fail_invoice
+//
 // Returns: The updated invoice.
 func (c *Client) FailInvoice(invoiceId string) (*Invoice, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/mark_failed", invoiceId)
@@ -2679,6 +2850,9 @@ func (c *Client) FailInvoice(invoiceId string) (*Invoice, error) {
 }
 
 // MarkInvoiceSuccessful Mark an open invoice as successful
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/mark_invoice_successful
+//
 // Returns: The updated invoice.
 func (c *Client) MarkInvoiceSuccessful(invoiceId string) (*Invoice, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/mark_successful", invoiceId)
@@ -2694,6 +2868,9 @@ func (c *Client) MarkInvoiceSuccessful(invoiceId string) (*Invoice, error) {
 }
 
 // ReopenInvoice Reopen a closed, manual invoice
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/reopen_invoice
+//
 // Returns: The updated invoice.
 func (c *Client) ReopenInvoice(invoiceId string) (*Invoice, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/reopen", invoiceId)
@@ -2709,6 +2886,9 @@ func (c *Client) ReopenInvoice(invoiceId string) (*Invoice, error) {
 }
 
 // VoidInvoice Void a credit invoice.
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/void_invoice
+//
 // Returns: The updated invoice.
 func (c *Client) VoidInvoice(invoiceId string) (*Invoice, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/void", invoiceId)
@@ -2830,6 +3010,9 @@ func (list *ListInvoiceLineItemsParams) URLParams() []KeyValue {
 }
 
 // ListInvoiceLineItems List an invoice's line items
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_invoice_line_items
+//
 // Returns: A list of the invoice's line items.
 func (c *Client) ListInvoiceLineItems(invoiceId string, params *ListInvoiceLineItemsParams) (*LineItemList, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/line_items", invoiceId)
@@ -2908,6 +3091,9 @@ func (list *ListInvoiceCouponRedemptionsParams) URLParams() []KeyValue {
 }
 
 // ListInvoiceCouponRedemptions Show the coupon redemptions applied to an invoice
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_invoice_coupon_redemptions
+//
 // Returns: A list of the the coupon redemptions associated with the invoice.
 func (c *Client) ListInvoiceCouponRedemptions(invoiceId string, params *ListInvoiceCouponRedemptionsParams) (*CouponRedemptionList, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/coupon_redemptions", invoiceId)
@@ -2927,6 +3113,9 @@ func (c *Client) ListInvoiceCouponRedemptions(invoiceId string, params *ListInvo
 }
 
 // ListRelatedInvoices List an invoice's related credit or charge invoices
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_related_invoices
+//
 // Returns: A list of the credit or charge invoices associated with the invoice.
 <<<<<<< HEAD
 func (c *Client) ListRelatedInvoices(invoiceId string) *InvoiceList {
@@ -2947,6 +3136,9 @@ func (c *Client) ListRelatedInvoices(invoiceId string) (*InvoiceList, error) {
 }
 
 // RefundInvoice Refund an invoice
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/refund_invoice
+//
 // Returns: Returns the new credit invoice.
 func (c *Client) RefundInvoice(invoiceId string, body *InvoiceRefund) (*Invoice, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/refund", invoiceId)
@@ -3056,6 +3248,9 @@ func (list *ListLineItemsParams) URLParams() []KeyValue {
 }
 
 // ListLineItems List a site's line items
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_line_items
+//
 // Returns: A list of the site's line items.
 func (c *Client) ListLineItems(params *ListLineItemsParams) (*LineItemList, error) {
 	path, err := c.InterpolatePath("/line_items")
@@ -3075,6 +3270,9 @@ func (c *Client) ListLineItems(params *ListLineItemsParams) (*LineItemList, erro
 }
 
 // GetLineItem Fetch a line item
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_line_item
+//
 // Returns: A line item.
 func (c *Client) GetLineItem(lineItemId string) (*LineItem, error) {
 	path, err := c.InterpolatePath("/line_items/{line_item_id}", lineItemId)
@@ -3090,6 +3288,9 @@ func (c *Client) GetLineItem(lineItemId string) (*LineItem, error) {
 }
 
 // RemoveLineItem Delete an uninvoiced line item
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_line_item
+//
 // Returns: Line item deleted.
 func (c *Client) RemoveLineItem(lineItemId string) (*Empty, error) {
 	path, err := c.InterpolatePath("/line_items/{line_item_id}", lineItemId)
@@ -3185,6 +3386,9 @@ func (list *ListPlansParams) URLParams() []KeyValue {
 }
 
 // ListPlans List a site's plans
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_plans
+//
 // Returns: A list of plans.
 func (c *Client) ListPlans(params *ListPlansParams) (*PlanList, error) {
 	path, err := c.InterpolatePath("/plans")
@@ -3204,6 +3408,9 @@ func (c *Client) ListPlans(params *ListPlansParams) (*PlanList, error) {
 }
 
 // CreatePlan Create a plan
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_plan
+//
 // Returns: A plan.
 func (c *Client) CreatePlan(body *PlanCreate) (*Plan, error) {
 	path, err := c.InterpolatePath("/plans")
@@ -3219,6 +3426,9 @@ func (c *Client) CreatePlan(body *PlanCreate) (*Plan, error) {
 }
 
 // GetPlan Fetch a plan
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_plan
+//
 // Returns: A plan.
 func (c *Client) GetPlan(planId string) (*Plan, error) {
 	path, err := c.InterpolatePath("/plans/{plan_id}", planId)
@@ -3234,6 +3444,9 @@ func (c *Client) GetPlan(planId string) (*Plan, error) {
 }
 
 // UpdatePlan Update a plan
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_plan
+//
 // Returns: A plan.
 func (c *Client) UpdatePlan(planId string, body *PlanUpdate) (*Plan, error) {
 	path, err := c.InterpolatePath("/plans/{plan_id}", planId)
@@ -3249,6 +3462,9 @@ func (c *Client) UpdatePlan(planId string, body *PlanUpdate) (*Plan, error) {
 }
 
 // RemovePlan Remove a plan
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_plan
+//
 // Returns: Plan deleted
 func (c *Client) RemovePlan(planId string) (*Plan, error) {
 	path, err := c.InterpolatePath("/plans/{plan_id}", planId)
@@ -3344,6 +3560,9 @@ func (list *ListPlanAddOnsParams) URLParams() []KeyValue {
 }
 
 // ListPlanAddOns List a plan's add-ons
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_plan_add_ons
+//
 // Returns: A list of add-ons.
 func (c *Client) ListPlanAddOns(planId string, params *ListPlanAddOnsParams) (*AddOnList, error) {
 	path, err := c.InterpolatePath("/plans/{plan_id}/add_ons", planId)
@@ -3363,6 +3582,9 @@ func (c *Client) ListPlanAddOns(planId string, params *ListPlanAddOnsParams) (*A
 }
 
 // CreatePlanAddOn Create an add-on
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_plan_add_on
+//
 // Returns: An add-on.
 func (c *Client) CreatePlanAddOn(planId string, body *AddOnCreate) (*AddOn, error) {
 	path, err := c.InterpolatePath("/plans/{plan_id}/add_ons", planId)
@@ -3378,6 +3600,9 @@ func (c *Client) CreatePlanAddOn(planId string, body *AddOnCreate) (*AddOn, erro
 }
 
 // GetPlanAddOn Fetch a plan's add-on
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_plan_add_on
+//
 // Returns: An add-on.
 func (c *Client) GetPlanAddOn(planId string, addOnId string) (*AddOn, error) {
 	path, err := c.InterpolatePath("/plans/{plan_id}/add_ons/{add_on_id}", planId, addOnId)
@@ -3393,6 +3618,9 @@ func (c *Client) GetPlanAddOn(planId string, addOnId string) (*AddOn, error) {
 }
 
 // UpdatePlanAddOn Update an add-on
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_plan_add_on
+//
 // Returns: An add-on.
 func (c *Client) UpdatePlanAddOn(planId string, addOnId string, body *AddOnUpdate) (*AddOn, error) {
 	path, err := c.InterpolatePath("/plans/{plan_id}/add_ons/{add_on_id}", planId, addOnId)
@@ -3408,6 +3636,9 @@ func (c *Client) UpdatePlanAddOn(planId string, addOnId string, body *AddOnUpdat
 }
 
 // RemovePlanAddOn Remove an add-on
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_plan_add_on
+//
 // Returns: Add-on deleted
 func (c *Client) RemovePlanAddOn(planId string, addOnId string) (*AddOn, error) {
 	path, err := c.InterpolatePath("/plans/{plan_id}/add_ons/{add_on_id}", planId, addOnId)
@@ -3503,6 +3734,9 @@ func (list *ListAddOnsParams) URLParams() []KeyValue {
 }
 
 // ListAddOns List a site's add-ons
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_add_ons
+//
 // Returns: A list of add-ons.
 func (c *Client) ListAddOns(params *ListAddOnsParams) (*AddOnList, error) {
 	path, err := c.InterpolatePath("/add_ons")
@@ -3522,6 +3756,9 @@ func (c *Client) ListAddOns(params *ListAddOnsParams) (*AddOnList, error) {
 }
 
 // GetAddOn Fetch an add-on
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_add_on
+//
 // Returns: An add-on.
 func (c *Client) GetAddOn(addOnId string) (*AddOn, error) {
 	path, err := c.InterpolatePath("/add_ons/{add_on_id}", addOnId)
@@ -3610,6 +3847,9 @@ func (list *ListShippingMethodsParams) URLParams() []KeyValue {
 }
 
 // ListShippingMethods List a site's shipping methods
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_shipping_methods
+//
 // Returns: A list of the site's shipping methods.
 func (c *Client) ListShippingMethods(params *ListShippingMethodsParams) (*ShippingMethodList, error) {
 	path, err := c.InterpolatePath("/shipping_methods")
@@ -3641,7 +3881,14 @@ func (c *Client) CreateShippingMethod(body *ShippingMethodCreate) (*ShippingMeth
 }
 
 // GetShippingMethod Fetch a shipping method
+<<<<<<< HEAD
 // Returns: A shipping method.
+=======
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_shipping_method
+//
+// Returns: A shipping_method.
+>>>>>>> fd7ddc1... Regenerating function docs
 func (c *Client) GetShippingMethod(id string) (*ShippingMethod, error) {
 	path, err := c.InterpolatePath("/shipping_methods/{id}", id)
 	if err != nil {
@@ -3763,6 +4010,9 @@ func (list *ListSubscriptionsParams) URLParams() []KeyValue {
 }
 
 // ListSubscriptions List a site's subscriptions
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_subscriptions
+//
 // Returns: A list of the site's subscriptions.
 func (c *Client) ListSubscriptions(params *ListSubscriptionsParams) (*SubscriptionList, error) {
 	path, err := c.InterpolatePath("/subscriptions")
@@ -3782,6 +4032,9 @@ func (c *Client) ListSubscriptions(params *ListSubscriptionsParams) (*Subscripti
 }
 
 // CreateSubscription Create a new subscription
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_subscription
+//
 // Returns: A subscription.
 func (c *Client) CreateSubscription(body *SubscriptionCreate) (*Subscription, error) {
 	path, err := c.InterpolatePath("/subscriptions")
@@ -3797,6 +4050,9 @@ func (c *Client) CreateSubscription(body *SubscriptionCreate) (*Subscription, er
 }
 
 // GetSubscription Fetch a subscription
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_subscription
+//
 // Returns: A subscription.
 func (c *Client) GetSubscription(subscriptionId string) (*Subscription, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}", subscriptionId)
@@ -3812,6 +4068,9 @@ func (c *Client) GetSubscription(subscriptionId string) (*Subscription, error) {
 }
 
 // ModifySubscription Modify a subscription
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/modify_subscription
+//
 // Returns: A subscription.
 func (c *Client) ModifySubscription(subscriptionId string, body *SubscriptionUpdate) (*Subscription, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}", subscriptionId)
@@ -3858,6 +4117,9 @@ func (list *TerminateSubscriptionParams) URLParams() []KeyValue {
 }
 
 // TerminateSubscription Terminate a subscription
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/terminate_subscription
+//
 // Returns: An expired subscription.
 func (c *Client) TerminateSubscription(subscriptionId string, params *TerminateSubscriptionParams) (*Subscription, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}", subscriptionId)
@@ -3889,6 +4151,9 @@ func (list *CancelSubscriptionParams) toParams() *Params {
 }
 
 // CancelSubscription Cancel a subscription
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/cancel_subscription
+//
 // Returns: A canceled or failed subscription.
 func (c *Client) CancelSubscription(subscriptionId string, params *CancelSubscriptionParams) (*Subscription, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/cancel", subscriptionId)
@@ -3904,6 +4169,9 @@ func (c *Client) CancelSubscription(subscriptionId string, params *CancelSubscri
 }
 
 // ReactivateSubscription Reactivate a canceled subscription
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/reactivate_subscription
+//
 // Returns: An active subscription.
 func (c *Client) ReactivateSubscription(subscriptionId string) (*Subscription, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/reactivate", subscriptionId)
@@ -3919,6 +4187,9 @@ func (c *Client) ReactivateSubscription(subscriptionId string) (*Subscription, e
 }
 
 // PauseSubscription Pause subscription
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/pause_subscription
+//
 // Returns: A subscription.
 func (c *Client) PauseSubscription(subscriptionId string, body *SubscriptionPause) (*Subscription, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/pause", subscriptionId)
@@ -3934,6 +4205,9 @@ func (c *Client) PauseSubscription(subscriptionId string, body *SubscriptionPaus
 }
 
 // ResumeSubscription Resume subscription
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/resume_subscription
+//
 // Returns: A subscription.
 func (c *Client) ResumeSubscription(subscriptionId string) (*Subscription, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/resume", subscriptionId)
@@ -3949,6 +4223,9 @@ func (c *Client) ResumeSubscription(subscriptionId string) (*Subscription, error
 }
 
 // ConvertTrial Convert trial subscription
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/convert_trial
+//
 // Returns: A subscription.
 func (c *Client) ConvertTrial(subscriptionId string) (*Subscription, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/convert_trial", subscriptionId)
@@ -3964,6 +4241,9 @@ func (c *Client) ConvertTrial(subscriptionId string) (*Subscription, error) {
 }
 
 // GetSubscriptionChange Fetch a subscription's pending change
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_subscription_change
+//
 // Returns: A subscription's pending change.
 func (c *Client) GetSubscriptionChange(subscriptionId string) (*SubscriptionChange, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/change", subscriptionId)
@@ -3979,6 +4259,9 @@ func (c *Client) GetSubscriptionChange(subscriptionId string) (*SubscriptionChan
 }
 
 // CreateSubscriptionChange Create a new subscription change
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_subscription_change
+//
 // Returns: A subscription change.
 func (c *Client) CreateSubscriptionChange(subscriptionId string, body *SubscriptionChangeCreate) (*SubscriptionChange, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/change", subscriptionId)
@@ -3994,6 +4277,9 @@ func (c *Client) CreateSubscriptionChange(subscriptionId string, body *Subscript
 }
 
 // RemoveSubscriptionChange Delete the pending subscription change
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_subscription_change
+//
 // Returns: Subscription change was deleted.
 func (c *Client) RemoveSubscriptionChange(subscriptionId string) (*Empty, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/change", subscriptionId)
@@ -4105,6 +4391,9 @@ func (list *ListSubscriptionInvoicesParams) URLParams() []KeyValue {
 }
 
 // ListSubscriptionInvoices List a subscription's invoices
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_subscription_invoices
+//
 // Returns: A list of the subscription's invoices.
 func (c *Client) ListSubscriptionInvoices(subscriptionId string, params *ListSubscriptionInvoicesParams) (*InvoiceList, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/invoices", subscriptionId)
@@ -4218,6 +4507,9 @@ func (list *ListSubscriptionLineItemsParams) URLParams() []KeyValue {
 }
 
 // ListSubscriptionLineItems List a subscription's line items
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_subscription_line_items
+//
 // Returns: A list of the subscription's line items.
 func (c *Client) ListSubscriptionLineItems(subscriptionId string, params *ListSubscriptionLineItemsParams) (*LineItemList, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/line_items", subscriptionId)
@@ -4296,6 +4588,9 @@ func (list *ListSubscriptionCouponRedemptionsParams) URLParams() []KeyValue {
 }
 
 // ListSubscriptionCouponRedemptions Show the coupon redemptions for a subscription
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_subscription_coupon_redemptions
+//
 // Returns: A list of the the coupon redemptions on a subscription.
 func (c *Client) ListSubscriptionCouponRedemptions(subscriptionId string, params *ListSubscriptionCouponRedemptionsParams) (*CouponRedemptionList, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/coupon_redemptions", subscriptionId)
@@ -4538,6 +4833,9 @@ func (list *ListTransactionsParams) URLParams() []KeyValue {
 }
 
 // ListTransactions List a site's transactions
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_transactions
+//
 // Returns: A list of the site's transactions.
 func (c *Client) ListTransactions(params *ListTransactionsParams) (*TransactionList, error) {
 	path, err := c.InterpolatePath("/transactions")
@@ -4557,6 +4855,9 @@ func (c *Client) ListTransactions(params *ListTransactionsParams) (*TransactionL
 }
 
 // GetTransaction Fetch a transaction
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_transaction
+//
 // Returns: A transaction.
 func (c *Client) GetTransaction(transactionId string) (*Transaction, error) {
 	path, err := c.InterpolatePath("/transactions/{transaction_id}", transactionId)
@@ -4572,6 +4873,9 @@ func (c *Client) GetTransaction(transactionId string) (*Transaction, error) {
 }
 
 // GetUniqueCouponCode Fetch a unique coupon code
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_unique_coupon_code
+//
 // Returns: A unique coupon code.
 func (c *Client) GetUniqueCouponCode(uniqueCouponCodeId string) (*UniqueCouponCode, error) {
 	path, err := c.InterpolatePath("/unique_coupon_codes/{unique_coupon_code_id}", uniqueCouponCodeId)
@@ -4587,6 +4891,9 @@ func (c *Client) GetUniqueCouponCode(uniqueCouponCodeId string) (*UniqueCouponCo
 }
 
 // DeactivateUniqueCouponCode Deactivate a unique coupon code
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/deactivate_unique_coupon_code
+//
 // Returns: A unique coupon code.
 func (c *Client) DeactivateUniqueCouponCode(uniqueCouponCodeId string) (*UniqueCouponCode, error) {
 	path, err := c.InterpolatePath("/unique_coupon_codes/{unique_coupon_code_id}", uniqueCouponCodeId)
@@ -4602,6 +4909,9 @@ func (c *Client) DeactivateUniqueCouponCode(uniqueCouponCodeId string) (*UniqueC
 }
 
 // ReactivateUniqueCouponCode Restore a unique coupon code
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/reactivate_unique_coupon_code
+//
 // Returns: A unique coupon code.
 func (c *Client) ReactivateUniqueCouponCode(uniqueCouponCodeId string) (*UniqueCouponCode, error) {
 	path, err := c.InterpolatePath("/unique_coupon_codes/{unique_coupon_code_id}/restore", uniqueCouponCodeId)
@@ -4617,6 +4927,9 @@ func (c *Client) ReactivateUniqueCouponCode(uniqueCouponCodeId string) (*UniqueC
 }
 
 // CreatePurchase Create a new purchase
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_purchase
+//
 // Returns: Returns the new invoices
 func (c *Client) CreatePurchase(body *PurchaseCreate) (*InvoiceCollection, error) {
 	path, err := c.InterpolatePath("/purchases")
@@ -4632,6 +4945,9 @@ func (c *Client) CreatePurchase(body *PurchaseCreate) (*InvoiceCollection, error
 }
 
 // PreviewPurchase Preview a new purchase
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/preview_purchase
+//
 // Returns: Returns preview of the new invoices
 func (c *Client) PreviewPurchase(body *PurchaseCreate) (*InvoiceCollection, error) {
 	path, err := c.InterpolatePath("/purchases/preview")

--- a/client_operations.go
+++ b/client_operations.go
@@ -318,18 +318,32 @@ func (list *ListSitesParams) URLParams() []KeyValue {
 
 // ListSites List sites
 // Returns: A list of sites.
-func (c *Client) ListSites(params *ListSitesParams) *SiteList {
-	path := "/sites"
+func (c *Client) ListSites(params *ListSitesParams) (*SiteList, error) {
+	path, err := c.InterpolatePath("/sites")
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewSiteList(c, path)
+=======
+	return &SiteList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // GetSite Fetch a site
 // Returns: A site.
 func (c *Client) GetSite(siteId string) (*Site, error) {
-	path := c.InterpolatePath("/sites/{site_id}", siteId)
+	path, err := c.InterpolatePath("/sites/{site_id}", siteId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Site{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -433,18 +447,32 @@ func (list *ListAccountsParams) URLParams() []KeyValue {
 
 // ListAccounts List a site's accounts
 // Returns: A list of the site's accounts.
-func (c *Client) ListAccounts(params *ListAccountsParams) *AccountList {
-	path := "/accounts"
+func (c *Client) ListAccounts(params *ListAccountsParams) (*AccountList, error) {
+	path, err := c.InterpolatePath("/accounts")
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewAccountList(c, path)
+=======
+	return &AccountList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // CreateAccount Create an account
 // Returns: An account.
 func (c *Client) CreateAccount(body *AccountCreate) (*Account, error) {
-	path := c.InterpolatePath("/accounts")
+	path, err := c.InterpolatePath("/accounts")
+	if err != nil {
+		return nil, err
+	}
 	result := &Account{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -454,9 +482,12 @@ func (c *Client) CreateAccount(body *AccountCreate) (*Account, error) {
 // GetAccount Fetch an account
 // Returns: An account.
 func (c *Client) GetAccount(accountId string) (*Account, error) {
-	path := c.InterpolatePath("/accounts/{account_id}", accountId)
+	path, err := c.InterpolatePath("/accounts/{account_id}", accountId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Account{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -466,9 +497,12 @@ func (c *Client) GetAccount(accountId string) (*Account, error) {
 // UpdateAccount Modify an account
 // Returns: An account.
 func (c *Client) UpdateAccount(accountId string, body *AccountUpdate) (*Account, error) {
-	path := c.InterpolatePath("/accounts/{account_id}", accountId)
+	path, err := c.InterpolatePath("/accounts/{account_id}", accountId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Account{}
-	err := c.Call(http.MethodPut, path, body, result)
+	err = c.Call(http.MethodPut, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -478,9 +512,12 @@ func (c *Client) UpdateAccount(accountId string, body *AccountUpdate) (*Account,
 // DeactivateAccount Deactivate an account
 // Returns: An account.
 func (c *Client) DeactivateAccount(accountId string) (*Account, error) {
-	path := c.InterpolatePath("/accounts/{account_id}", accountId)
+	path, err := c.InterpolatePath("/accounts/{account_id}", accountId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Account{}
-	err := c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(http.MethodDelete, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -490,9 +527,12 @@ func (c *Client) DeactivateAccount(accountId string) (*Account, error) {
 // GetAccountAcquisition Fetch an account's acquisition data
 // Returns: An account's acquisition data.
 func (c *Client) GetAccountAcquisition(accountId string) (*AccountAcquisition, error) {
-	path := c.InterpolatePath("/accounts/{account_id}/acquisition", accountId)
+	path, err := c.InterpolatePath("/accounts/{account_id}/acquisition", accountId)
+	if err != nil {
+		return nil, err
+	}
 	result := &AccountAcquisition{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -502,9 +542,12 @@ func (c *Client) GetAccountAcquisition(accountId string) (*AccountAcquisition, e
 // UpdateAccountAcquisition Update an account's acquisition data
 // Returns: An account's updated acquisition data.
 func (c *Client) UpdateAccountAcquisition(accountId string, body *AccountAcquisitionUpdatable) (*AccountAcquisition, error) {
-	path := c.InterpolatePath("/accounts/{account_id}/acquisition", accountId)
+	path, err := c.InterpolatePath("/accounts/{account_id}/acquisition", accountId)
+	if err != nil {
+		return nil, err
+	}
 	result := &AccountAcquisition{}
-	err := c.Call(http.MethodPut, path, body, result)
+	err = c.Call(http.MethodPut, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -514,9 +557,12 @@ func (c *Client) UpdateAccountAcquisition(accountId string, body *AccountAcquisi
 // RemoveAccountAcquisition Remove an account's acquisition data
 // Returns: Acquisition data was succesfully deleted.
 func (c *Client) RemoveAccountAcquisition(accountId string) (*Empty, error) {
-	path := c.InterpolatePath("/accounts/{account_id}/acquisition", accountId)
+	path, err := c.InterpolatePath("/accounts/{account_id}/acquisition", accountId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Empty{}
-	err := c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(http.MethodDelete, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -526,9 +572,12 @@ func (c *Client) RemoveAccountAcquisition(accountId string) (*Empty, error) {
 // ReactivateAccount Reactivate an inactive account
 // Returns: An account.
 func (c *Client) ReactivateAccount(accountId string) (*Account, error) {
-	path := c.InterpolatePath("/accounts/{account_id}/reactivate", accountId)
+	path, err := c.InterpolatePath("/accounts/{account_id}/reactivate", accountId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Account{}
-	err := c.Call(http.MethodPut, path, nil, result)
+	err = c.Call(http.MethodPut, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -538,9 +587,12 @@ func (c *Client) ReactivateAccount(accountId string) (*Account, error) {
 // GetAccountBalance Fetch an account's balance and past due status
 // Returns: An account's balance.
 func (c *Client) GetAccountBalance(accountId string) (*AccountBalance, error) {
-	path := c.InterpolatePath("/accounts/{account_id}/balance", accountId)
+	path, err := c.InterpolatePath("/accounts/{account_id}/balance", accountId)
+	if err != nil {
+		return nil, err
+	}
 	result := &AccountBalance{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -550,9 +602,12 @@ func (c *Client) GetAccountBalance(accountId string) (*AccountBalance, error) {
 // GetBillingInfo Fetch an account's billing information
 // Returns: An account's billing information.
 func (c *Client) GetBillingInfo(accountId string) (*BillingInfo, error) {
-	path := c.InterpolatePath("/accounts/{account_id}/billing_info", accountId)
+	path, err := c.InterpolatePath("/accounts/{account_id}/billing_info", accountId)
+	if err != nil {
+		return nil, err
+	}
 	result := &BillingInfo{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -562,9 +617,12 @@ func (c *Client) GetBillingInfo(accountId string) (*BillingInfo, error) {
 // UpdateBillingInfo Set an account's billing information
 // Returns: Updated billing information.
 func (c *Client) UpdateBillingInfo(accountId string, body *BillingInfoCreate) (*BillingInfo, error) {
-	path := c.InterpolatePath("/accounts/{account_id}/billing_info", accountId)
+	path, err := c.InterpolatePath("/accounts/{account_id}/billing_info", accountId)
+	if err != nil {
+		return nil, err
+	}
 	result := &BillingInfo{}
-	err := c.Call(http.MethodPut, path, body, result)
+	err = c.Call(http.MethodPut, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -574,9 +632,12 @@ func (c *Client) UpdateBillingInfo(accountId string, body *BillingInfoCreate) (*
 // RemoveBillingInfo Remove an account's billing information
 // Returns: Billing information deleted
 func (c *Client) RemoveBillingInfo(accountId string) (*Empty, error) {
-	path := c.InterpolatePath("/accounts/{account_id}/billing_info", accountId)
+	path, err := c.InterpolatePath("/accounts/{account_id}/billing_info", accountId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Empty{}
-	err := c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(http.MethodDelete, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -644,18 +705,32 @@ func (list *ListAccountCouponRedemptionsParams) URLParams() []KeyValue {
 
 // ListAccountCouponRedemptions Show the coupon redemptions for an account
 // Returns: A list of the the coupon redemptions on an account.
-func (c *Client) ListAccountCouponRedemptions(accountId string, params *ListAccountCouponRedemptionsParams) *CouponRedemptionList {
-	path := c.InterpolatePath("/accounts/{account_id}/coupon_redemptions", accountId)
+func (c *Client) ListAccountCouponRedemptions(accountId string, params *ListAccountCouponRedemptionsParams) (*CouponRedemptionList, error) {
+	path, err := c.InterpolatePath("/accounts/{account_id}/coupon_redemptions", accountId)
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewCouponRedemptionList(c, path)
+=======
+	return &CouponRedemptionList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // GetActiveCouponRedemption Show the coupon redemption that is active on an account
 // Returns: An active coupon redemption on an account.
 func (c *Client) GetActiveCouponRedemption(accountId string) (*CouponRedemption, error) {
-	path := c.InterpolatePath("/accounts/{account_id}/coupon_redemptions/active", accountId)
+	path, err := c.InterpolatePath("/accounts/{account_id}/coupon_redemptions/active", accountId)
+	if err != nil {
+		return nil, err
+	}
 	result := &CouponRedemption{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -665,9 +740,12 @@ func (c *Client) GetActiveCouponRedemption(accountId string) (*CouponRedemption,
 // CreateCouponRedemption Generate an active coupon redemption on an account
 // Returns: Returns the new coupon redemption.
 func (c *Client) CreateCouponRedemption(accountId string, body *CouponRedemptionCreate) (*CouponRedemption, error) {
-	path := c.InterpolatePath("/accounts/{account_id}/coupon_redemptions/active", accountId)
+	path, err := c.InterpolatePath("/accounts/{account_id}/coupon_redemptions/active", accountId)
+	if err != nil {
+		return nil, err
+	}
 	result := &CouponRedemption{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -677,9 +755,12 @@ func (c *Client) CreateCouponRedemption(accountId string, body *CouponRedemption
 // RemoveCouponRedemption Delete the active coupon redemption from an account
 // Returns: Coupon redemption deleted.
 func (c *Client) RemoveCouponRedemption(accountId string) (*CouponRedemption, error) {
-	path := c.InterpolatePath("/accounts/{account_id}/coupon_redemptions/active", accountId)
+	path, err := c.InterpolatePath("/accounts/{account_id}/coupon_redemptions/active", accountId)
+	if err != nil {
+		return nil, err
+	}
 	result := &CouponRedemption{}
-	err := c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(http.MethodDelete, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -746,10 +827,21 @@ func (list *ListAccountCreditPaymentsParams) URLParams() []KeyValue {
 
 // ListAccountCreditPayments List an account's credit payments
 // Returns: A list of the account's credit payments.
-func (c *Client) ListAccountCreditPayments(accountId string, params *ListAccountCreditPaymentsParams) *CreditPaymentList {
-	path := c.InterpolatePath("/accounts/{account_id}/credit_payments", accountId)
+func (c *Client) ListAccountCreditPayments(accountId string, params *ListAccountCreditPaymentsParams) (*CreditPaymentList, error) {
+	path, err := c.InterpolatePath("/accounts/{account_id}/credit_payments", accountId)
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewCreditPaymentList(c, path)
+=======
+	return &CreditPaymentList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 type ListAccountInvoicesParams struct {
@@ -838,18 +930,32 @@ func (list *ListAccountInvoicesParams) URLParams() []KeyValue {
 
 // ListAccountInvoices List an account's invoices
 // Returns: A list of the account's invoices.
-func (c *Client) ListAccountInvoices(accountId string, params *ListAccountInvoicesParams) *InvoiceList {
-	path := c.InterpolatePath("/accounts/{account_id}/invoices", accountId)
+func (c *Client) ListAccountInvoices(accountId string, params *ListAccountInvoicesParams) (*InvoiceList, error) {
+	path, err := c.InterpolatePath("/accounts/{account_id}/invoices", accountId)
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewInvoiceList(c, path)
+=======
+	return &InvoiceList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // CreateInvoice Create an invoice for pending line items
 // Returns: Returns the new invoices.
 func (c *Client) CreateInvoice(accountId string, body *InvoiceCreate) (*InvoiceCollection, error) {
-	path := c.InterpolatePath("/accounts/{account_id}/invoices", accountId)
+	path, err := c.InterpolatePath("/accounts/{account_id}/invoices", accountId)
+	if err != nil {
+		return nil, err
+	}
 	result := &InvoiceCollection{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -859,9 +965,12 @@ func (c *Client) CreateInvoice(accountId string, body *InvoiceCreate) (*InvoiceC
 // PreviewInvoice Preview new invoice for pending line items
 // Returns: Returns the invoice previews.
 func (c *Client) PreviewInvoice(accountId string, body *InvoiceCreate) (*InvoiceCollection, error) {
-	path := c.InterpolatePath("/accounts/{account_id}/invoices/preview", accountId)
+	path, err := c.InterpolatePath("/accounts/{account_id}/invoices/preview", accountId)
+	if err != nil {
+		return nil, err
+	}
 	result := &InvoiceCollection{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -964,18 +1073,32 @@ func (list *ListAccountLineItemsParams) URLParams() []KeyValue {
 
 // ListAccountLineItems List an account's line items
 // Returns: A list of the account's line items.
-func (c *Client) ListAccountLineItems(accountId string, params *ListAccountLineItemsParams) *LineItemList {
-	path := c.InterpolatePath("/accounts/{account_id}/line_items", accountId)
+func (c *Client) ListAccountLineItems(accountId string, params *ListAccountLineItemsParams) (*LineItemList, error) {
+	path, err := c.InterpolatePath("/accounts/{account_id}/line_items", accountId)
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewLineItemList(c, path)
+=======
+	return &LineItemList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // CreateLineItem Create a new line item for the account
 // Returns: Returns the new line item.
 func (c *Client) CreateLineItem(accountId string, body *LineItemCreate) (*LineItem, error) {
-	path := c.InterpolatePath("/accounts/{account_id}/line_items", accountId)
+	path, err := c.InterpolatePath("/accounts/{account_id}/line_items", accountId)
+	if err != nil {
+		return nil, err
+	}
 	result := &LineItem{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1018,18 +1141,32 @@ func (list *ListAccountNotesParams) URLParams() []KeyValue {
 
 // ListAccountNotes Fetch a list of an account's notes
 // Returns: A list of an account's notes.
-func (c *Client) ListAccountNotes(accountId string, params *ListAccountNotesParams) *AccountNoteList {
-	path := c.InterpolatePath("/accounts/{account_id}/notes", accountId)
+func (c *Client) ListAccountNotes(accountId string, params *ListAccountNotesParams) (*AccountNoteList, error) {
+	path, err := c.InterpolatePath("/accounts/{account_id}/notes", accountId)
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewAccountNoteList(c, path)
+=======
+	return &AccountNoteList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // GetAccountNote Fetch an account note
 // Returns: An account note.
 func (c *Client) GetAccountNote(accountId string, accountNoteId string) (*AccountNote, error) {
-	path := c.InterpolatePath("/accounts/{account_id}/notes/{account_note_id}", accountId, accountNoteId)
+	path, err := c.InterpolatePath("/accounts/{account_id}/notes/{account_note_id}", accountId, accountNoteId)
+	if err != nil {
+		return nil, err
+	}
 	result := &AccountNote{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1111,18 +1248,32 @@ func (list *ListShippingAddressesParams) URLParams() []KeyValue {
 
 // ListShippingAddresses Fetch a list of an account's shipping addresses
 // Returns: A list of an account's shipping addresses.
-func (c *Client) ListShippingAddresses(accountId string, params *ListShippingAddressesParams) *ShippingAddressList {
-	path := c.InterpolatePath("/accounts/{account_id}/shipping_addresses", accountId)
+func (c *Client) ListShippingAddresses(accountId string, params *ListShippingAddressesParams) (*ShippingAddressList, error) {
+	path, err := c.InterpolatePath("/accounts/{account_id}/shipping_addresses", accountId)
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewShippingAddressList(c, path)
+=======
+	return &ShippingAddressList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // CreateShippingAddress Create a new shipping address for the account
 // Returns: Returns the new shipping address.
 func (c *Client) CreateShippingAddress(accountId string, body *ShippingAddressCreate) (*ShippingAddress, error) {
-	path := c.InterpolatePath("/accounts/{account_id}/shipping_addresses", accountId)
+	path, err := c.InterpolatePath("/accounts/{account_id}/shipping_addresses", accountId)
+	if err != nil {
+		return nil, err
+	}
 	result := &ShippingAddress{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1132,9 +1283,12 @@ func (c *Client) CreateShippingAddress(accountId string, body *ShippingAddressCr
 // GetShippingAddress Fetch an account's shipping address
 // Returns: A shipping address.
 func (c *Client) GetShippingAddress(accountId string, shippingAddressId string) (*ShippingAddress, error) {
-	path := c.InterpolatePath("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", accountId, shippingAddressId)
+	path, err := c.InterpolatePath("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", accountId, shippingAddressId)
+	if err != nil {
+		return nil, err
+	}
 	result := &ShippingAddress{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1144,9 +1298,12 @@ func (c *Client) GetShippingAddress(accountId string, shippingAddressId string) 
 // UpdateShippingAddress Update an account's shipping address
 // Returns: The updated shipping address.
 func (c *Client) UpdateShippingAddress(accountId string, shippingAddressId string, body *ShippingAddressUpdate) (*ShippingAddress, error) {
-	path := c.InterpolatePath("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", accountId, shippingAddressId)
+	path, err := c.InterpolatePath("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", accountId, shippingAddressId)
+	if err != nil {
+		return nil, err
+	}
 	result := &ShippingAddress{}
-	err := c.Call(http.MethodPut, path, body, result)
+	err = c.Call(http.MethodPut, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1156,9 +1313,12 @@ func (c *Client) UpdateShippingAddress(accountId string, shippingAddressId strin
 // RemoveShippingAddress Remove an account's shipping address
 // Returns: Shipping address deleted.
 func (c *Client) RemoveShippingAddress(accountId string, shippingAddressId string) (*Empty, error) {
-	path := c.InterpolatePath("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", accountId, shippingAddressId)
+	path, err := c.InterpolatePath("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", accountId, shippingAddressId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Empty{}
-	err := c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(http.MethodDelete, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1250,10 +1410,21 @@ func (list *ListAccountSubscriptionsParams) URLParams() []KeyValue {
 
 // ListAccountSubscriptions List an account's subscriptions
 // Returns: A list of the account's subscriptions.
-func (c *Client) ListAccountSubscriptions(accountId string, params *ListAccountSubscriptionsParams) *SubscriptionList {
-	path := c.InterpolatePath("/accounts/{account_id}/subscriptions", accountId)
+func (c *Client) ListAccountSubscriptions(accountId string, params *ListAccountSubscriptionsParams) (*SubscriptionList, error) {
+	path, err := c.InterpolatePath("/accounts/{account_id}/subscriptions", accountId)
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewSubscriptionList(c, path)
+=======
+	return &SubscriptionList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 type ListAccountTransactionsParams struct {
@@ -1345,10 +1516,21 @@ func (list *ListAccountTransactionsParams) URLParams() []KeyValue {
 
 // ListAccountTransactions List an account's transactions
 // Returns: A list of the account's transactions.
-func (c *Client) ListAccountTransactions(accountId string, params *ListAccountTransactionsParams) *TransactionList {
-	path := c.InterpolatePath("/accounts/{account_id}/transactions", accountId)
+func (c *Client) ListAccountTransactions(accountId string, params *ListAccountTransactionsParams) (*TransactionList, error) {
+	path, err := c.InterpolatePath("/accounts/{account_id}/transactions", accountId)
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewTransactionList(c, path)
+=======
+	return &TransactionList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 type ListChildAccountsParams struct {
@@ -1448,10 +1630,21 @@ func (list *ListChildAccountsParams) URLParams() []KeyValue {
 
 // ListChildAccounts List an account's child accounts
 // Returns: A list of an account's child accounts.
-func (c *Client) ListChildAccounts(accountId string, params *ListChildAccountsParams) *AccountList {
-	path := c.InterpolatePath("/accounts/{account_id}/accounts", accountId)
+func (c *Client) ListChildAccounts(accountId string, params *ListChildAccountsParams) (*AccountList, error) {
+	path, err := c.InterpolatePath("/accounts/{account_id}/accounts", accountId)
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewAccountList(c, path)
+=======
+	return &AccountList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 type ListAccountAcquisitionParams struct {
@@ -1529,10 +1722,21 @@ func (list *ListAccountAcquisitionParams) URLParams() []KeyValue {
 
 // ListAccountAcquisition List a site's account acquisition data
 // Returns: A list of the site's account acquisition data.
-func (c *Client) ListAccountAcquisition(params *ListAccountAcquisitionParams) *AccountAcquisitionList {
-	path := "/acquisitions"
+func (c *Client) ListAccountAcquisition(params *ListAccountAcquisitionParams) (*AccountAcquisitionList, error) {
+	path, err := c.InterpolatePath("/acquisitions")
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewAccountAcquisitionList(c, path)
+=======
+	return &AccountAcquisitionList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 type ListCouponsParams struct {
@@ -1610,18 +1814,32 @@ func (list *ListCouponsParams) URLParams() []KeyValue {
 
 // ListCoupons List a site's coupons
 // Returns: A list of the site's coupons.
-func (c *Client) ListCoupons(params *ListCouponsParams) *CouponList {
-	path := "/coupons"
+func (c *Client) ListCoupons(params *ListCouponsParams) (*CouponList, error) {
+	path, err := c.InterpolatePath("/coupons")
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewCouponList(c, path)
+=======
+	return &CouponList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // CreateCoupon Create a new coupon
 // Returns: A new coupon.
 func (c *Client) CreateCoupon(body *CouponCreate) (*Coupon, error) {
-	path := c.InterpolatePath("/coupons")
+	path, err := c.InterpolatePath("/coupons")
+	if err != nil {
+		return nil, err
+	}
 	result := &Coupon{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1631,9 +1849,12 @@ func (c *Client) CreateCoupon(body *CouponCreate) (*Coupon, error) {
 // GetCoupon Fetch a coupon
 // Returns: A coupon.
 func (c *Client) GetCoupon(couponId string) (*Coupon, error) {
-	path := c.InterpolatePath("/coupons/{coupon_id}", couponId)
+	path, err := c.InterpolatePath("/coupons/{coupon_id}", couponId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Coupon{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1643,9 +1864,12 @@ func (c *Client) GetCoupon(couponId string) (*Coupon, error) {
 // UpdateCoupon Update an active coupon
 // Returns: The updated coupon.
 func (c *Client) UpdateCoupon(couponId string, body *CouponUpdate) (*Coupon, error) {
-	path := c.InterpolatePath("/coupons/{coupon_id}", couponId)
+	path, err := c.InterpolatePath("/coupons/{coupon_id}", couponId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Coupon{}
-	err := c.Call(http.MethodPut, path, body, result)
+	err = c.Call(http.MethodPut, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1655,9 +1879,12 @@ func (c *Client) UpdateCoupon(couponId string, body *CouponUpdate) (*Coupon, err
 // DeactivateCoupon Expire a coupon
 // Returns: The expired Coupon
 func (c *Client) DeactivateCoupon(couponId string) (*Coupon, error) {
-	path := c.InterpolatePath("/coupons/{coupon_id}", couponId)
+	path, err := c.InterpolatePath("/coupons/{coupon_id}", couponId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Coupon{}
-	err := c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(http.MethodDelete, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1739,10 +1966,21 @@ func (list *ListUniqueCouponCodesParams) URLParams() []KeyValue {
 
 // ListUniqueCouponCodes List unique coupon codes associated with a bulk coupon
 // Returns: A list of unique coupon codes that were generated
-func (c *Client) ListUniqueCouponCodes(couponId string, params *ListUniqueCouponCodesParams) *UniqueCouponCodeList {
-	path := c.InterpolatePath("/coupons/{coupon_id}/unique_coupon_codes", couponId)
+func (c *Client) ListUniqueCouponCodes(couponId string, params *ListUniqueCouponCodesParams) (*UniqueCouponCodeList, error) {
+	path, err := c.InterpolatePath("/coupons/{coupon_id}/unique_coupon_codes", couponId)
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewUniqueCouponCodeList(c, path)
+=======
+	return &UniqueCouponCodeList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 type ListCreditPaymentsParams struct {
@@ -1805,18 +2043,32 @@ func (list *ListCreditPaymentsParams) URLParams() []KeyValue {
 
 // ListCreditPayments List a site's credit payments
 // Returns: A list of the site's credit payments.
-func (c *Client) ListCreditPayments(params *ListCreditPaymentsParams) *CreditPaymentList {
-	path := "/credit_payments"
+func (c *Client) ListCreditPayments(params *ListCreditPaymentsParams) (*CreditPaymentList, error) {
+	path, err := c.InterpolatePath("/credit_payments")
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewCreditPaymentList(c, path)
+=======
+	return &CreditPaymentList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // GetCreditPayment Fetch a credit payment
 // Returns: A credit payment.
 func (c *Client) GetCreditPayment(creditPaymentId string) (*CreditPayment, error) {
-	path := c.InterpolatePath("/credit_payments/{credit_payment_id}", creditPaymentId)
+	path, err := c.InterpolatePath("/credit_payments/{credit_payment_id}", creditPaymentId)
+	if err != nil {
+		return nil, err
+	}
 	result := &CreditPayment{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1905,18 +2157,32 @@ func (list *ListCustomFieldDefinitionsParams) URLParams() []KeyValue {
 
 // ListCustomFieldDefinitions List a site's custom field definitions
 // Returns: A list of the site's custom field definitions.
-func (c *Client) ListCustomFieldDefinitions(params *ListCustomFieldDefinitionsParams) *CustomFieldDefinitionList {
-	path := "/custom_field_definitions"
+func (c *Client) ListCustomFieldDefinitions(params *ListCustomFieldDefinitionsParams) (*CustomFieldDefinitionList, error) {
+	path, err := c.InterpolatePath("/custom_field_definitions")
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewCustomFieldDefinitionList(c, path)
+=======
+	return &CustomFieldDefinitionList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // GetCustomFieldDefinition Fetch an custom field definition
 // Returns: An custom field definition.
 func (c *Client) GetCustomFieldDefinition(customFieldDefinitionId string) (*CustomFieldDefinition, error) {
-	path := c.InterpolatePath("/custom_field_definitions/{custom_field_definition_id}", customFieldDefinitionId)
+	path, err := c.InterpolatePath("/custom_field_definitions/{custom_field_definition_id}", customFieldDefinitionId)
+	if err != nil {
+		return nil, err
+	}
 	result := &CustomFieldDefinition{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2005,18 +2271,32 @@ func (list *ListItemsParams) URLParams() []KeyValue {
 
 // ListItems List a site's items
 // Returns: A list of the site's items.
-func (c *Client) ListItems(params *ListItemsParams) *ItemList {
-	path := "/items"
+func (c *Client) ListItems(params *ListItemsParams) (*ItemList, error) {
+	path, err := c.InterpolatePath("/items")
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewItemList(c, path)
+=======
+	return &ItemList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // CreateItem Create a new item
 // Returns: A new item.
 func (c *Client) CreateItem(body *ItemCreate) (*Item, error) {
-	path := c.InterpolatePath("/items")
+	path, err := c.InterpolatePath("/items")
+	if err != nil {
+		return nil, err
+	}
 	result := &Item{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2026,9 +2306,12 @@ func (c *Client) CreateItem(body *ItemCreate) (*Item, error) {
 // GetItem Fetch an item
 // Returns: An item.
 func (c *Client) GetItem(itemId string) (*Item, error) {
-	path := c.InterpolatePath("/items/{item_id}", itemId)
+	path, err := c.InterpolatePath("/items/{item_id}", itemId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Item{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2038,9 +2321,12 @@ func (c *Client) GetItem(itemId string) (*Item, error) {
 // UpdateItem Update an active item
 // Returns: The updated item.
 func (c *Client) UpdateItem(itemId string, body *ItemUpdate) (*Item, error) {
-	path := c.InterpolatePath("/items/{item_id}", itemId)
+	path, err := c.InterpolatePath("/items/{item_id}", itemId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Item{}
-	err := c.Call(http.MethodPut, path, body, result)
+	err = c.Call(http.MethodPut, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2050,9 +2336,12 @@ func (c *Client) UpdateItem(itemId string, body *ItemUpdate) (*Item, error) {
 // DeactivateItem Deactivate an item
 // Returns: An item.
 func (c *Client) DeactivateItem(itemId string) (*Item, error) {
-	path := c.InterpolatePath("/items/{item_id}", itemId)
+	path, err := c.InterpolatePath("/items/{item_id}", itemId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Item{}
-	err := c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(http.MethodDelete, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2062,9 +2351,12 @@ func (c *Client) DeactivateItem(itemId string) (*Item, error) {
 // ReactivateItem Reactivate an inactive item
 // Returns: An item.
 func (c *Client) ReactivateItem(itemId string) (*Item, error) {
-	path := c.InterpolatePath("/items/{item_id}/reactivate", itemId)
+	path, err := c.InterpolatePath("/items/{item_id}/reactivate", itemId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Item{}
-	err := c.Call(http.MethodPut, path, nil, result)
+	err = c.Call(http.MethodPut, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2293,18 +2585,32 @@ func (list *ListInvoicesParams) URLParams() []KeyValue {
 
 // ListInvoices List a site's invoices
 // Returns: A list of the site's invoices.
-func (c *Client) ListInvoices(params *ListInvoicesParams) *InvoiceList {
-	path := "/invoices"
+func (c *Client) ListInvoices(params *ListInvoicesParams) (*InvoiceList, error) {
+	path, err := c.InterpolatePath("/invoices")
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewInvoiceList(c, path)
+=======
+	return &InvoiceList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // GetInvoice Fetch an invoice
 // Returns: An invoice.
 func (c *Client) GetInvoice(invoiceId string) (*Invoice, error) {
-	path := c.InterpolatePath("/invoices/{invoice_id}", invoiceId)
+	path, err := c.InterpolatePath("/invoices/{invoice_id}", invoiceId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Invoice{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2314,9 +2620,12 @@ func (c *Client) GetInvoice(invoiceId string) (*Invoice, error) {
 // PutInvoice Update an invoice
 // Returns: An invoice.
 func (c *Client) PutInvoice(invoiceId string, body *InvoiceUpdatable) (*Invoice, error) {
-	path := c.InterpolatePath("/invoices/{invoice_id}", invoiceId)
+	path, err := c.InterpolatePath("/invoices/{invoice_id}", invoiceId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Invoice{}
-	err := c.Call(http.MethodPut, path, body, result)
+	err = c.Call(http.MethodPut, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2342,9 +2651,12 @@ func (list *CollectInvoiceParams) toParams() *Params {
 // CollectInvoice Collect a pending or past due, automatic invoice
 // Returns: The updated invoice.
 func (c *Client) CollectInvoice(invoiceId string, params *CollectInvoiceParams) (*Invoice, error) {
-	path := c.InterpolatePath("/invoices/{invoice_id}/collect", invoiceId)
+	path, err := c.InterpolatePath("/invoices/{invoice_id}/collect", invoiceId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Invoice{}
-	err := c.Call(http.MethodPut, path, params, result)
+	err = c.Call(http.MethodPut, path, params, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2354,9 +2666,12 @@ func (c *Client) CollectInvoice(invoiceId string, params *CollectInvoiceParams) 
 // FailInvoice Mark an open invoice as failed
 // Returns: The updated invoice.
 func (c *Client) FailInvoice(invoiceId string) (*Invoice, error) {
-	path := c.InterpolatePath("/invoices/{invoice_id}/mark_failed", invoiceId)
+	path, err := c.InterpolatePath("/invoices/{invoice_id}/mark_failed", invoiceId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Invoice{}
-	err := c.Call(http.MethodPut, path, nil, result)
+	err = c.Call(http.MethodPut, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2366,9 +2681,12 @@ func (c *Client) FailInvoice(invoiceId string) (*Invoice, error) {
 // MarkInvoiceSuccessful Mark an open invoice as successful
 // Returns: The updated invoice.
 func (c *Client) MarkInvoiceSuccessful(invoiceId string) (*Invoice, error) {
-	path := c.InterpolatePath("/invoices/{invoice_id}/mark_successful", invoiceId)
+	path, err := c.InterpolatePath("/invoices/{invoice_id}/mark_successful", invoiceId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Invoice{}
-	err := c.Call(http.MethodPut, path, nil, result)
+	err = c.Call(http.MethodPut, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2378,9 +2696,12 @@ func (c *Client) MarkInvoiceSuccessful(invoiceId string) (*Invoice, error) {
 // ReopenInvoice Reopen a closed, manual invoice
 // Returns: The updated invoice.
 func (c *Client) ReopenInvoice(invoiceId string) (*Invoice, error) {
-	path := c.InterpolatePath("/invoices/{invoice_id}/reopen", invoiceId)
+	path, err := c.InterpolatePath("/invoices/{invoice_id}/reopen", invoiceId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Invoice{}
-	err := c.Call(http.MethodPut, path, nil, result)
+	err = c.Call(http.MethodPut, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2390,9 +2711,12 @@ func (c *Client) ReopenInvoice(invoiceId string) (*Invoice, error) {
 // VoidInvoice Void a credit invoice.
 // Returns: The updated invoice.
 func (c *Client) VoidInvoice(invoiceId string) (*Invoice, error) {
-	path := c.InterpolatePath("/invoices/{invoice_id}/void", invoiceId)
+	path, err := c.InterpolatePath("/invoices/{invoice_id}/void", invoiceId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Invoice{}
-	err := c.Call(http.MethodPut, path, nil, result)
+	err = c.Call(http.MethodPut, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2507,10 +2831,21 @@ func (list *ListInvoiceLineItemsParams) URLParams() []KeyValue {
 
 // ListInvoiceLineItems List an invoice's line items
 // Returns: A list of the invoice's line items.
-func (c *Client) ListInvoiceLineItems(invoiceId string, params *ListInvoiceLineItemsParams) *LineItemList {
-	path := c.InterpolatePath("/invoices/{invoice_id}/line_items", invoiceId)
+func (c *Client) ListInvoiceLineItems(invoiceId string, params *ListInvoiceLineItemsParams) (*LineItemList, error) {
+	path, err := c.InterpolatePath("/invoices/{invoice_id}/line_items", invoiceId)
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewLineItemList(c, path)
+=======
+	return &LineItemList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 type ListInvoiceCouponRedemptionsParams struct {
@@ -2574,25 +2909,52 @@ func (list *ListInvoiceCouponRedemptionsParams) URLParams() []KeyValue {
 
 // ListInvoiceCouponRedemptions Show the coupon redemptions applied to an invoice
 // Returns: A list of the the coupon redemptions associated with the invoice.
-func (c *Client) ListInvoiceCouponRedemptions(invoiceId string, params *ListInvoiceCouponRedemptionsParams) *CouponRedemptionList {
-	path := c.InterpolatePath("/invoices/{invoice_id}/coupon_redemptions", invoiceId)
+func (c *Client) ListInvoiceCouponRedemptions(invoiceId string, params *ListInvoiceCouponRedemptionsParams) (*CouponRedemptionList, error) {
+	path, err := c.InterpolatePath("/invoices/{invoice_id}/coupon_redemptions", invoiceId)
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewCouponRedemptionList(c, path)
+=======
+	return &CouponRedemptionList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // ListRelatedInvoices List an invoice's related credit or charge invoices
 // Returns: A list of the credit or charge invoices associated with the invoice.
+<<<<<<< HEAD
 func (c *Client) ListRelatedInvoices(invoiceId string) *InvoiceList {
 	path := c.InterpolatePath("/invoices/{invoice_id}/related_invoices", invoiceId)
 	return NewInvoiceList(c, path)
+=======
+func (c *Client) ListRelatedInvoices(invoiceId string) (*InvoiceList, error) {
+	path, err := c.InterpolatePath("/invoices/{invoice_id}/related_invoices", invoiceId)
+	if err != nil {
+		return nil, err
+	}
+	return &InvoiceList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // RefundInvoice Refund an invoice
 // Returns: Returns the new credit invoice.
 func (c *Client) RefundInvoice(invoiceId string, body *InvoiceRefund) (*Invoice, error) {
-	path := c.InterpolatePath("/invoices/{invoice_id}/refund", invoiceId)
+	path, err := c.InterpolatePath("/invoices/{invoice_id}/refund", invoiceId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Invoice{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2695,18 +3057,32 @@ func (list *ListLineItemsParams) URLParams() []KeyValue {
 
 // ListLineItems List a site's line items
 // Returns: A list of the site's line items.
-func (c *Client) ListLineItems(params *ListLineItemsParams) *LineItemList {
-	path := "/line_items"
+func (c *Client) ListLineItems(params *ListLineItemsParams) (*LineItemList, error) {
+	path, err := c.InterpolatePath("/line_items")
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewLineItemList(c, path)
+=======
+	return &LineItemList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // GetLineItem Fetch a line item
 // Returns: A line item.
 func (c *Client) GetLineItem(lineItemId string) (*LineItem, error) {
-	path := c.InterpolatePath("/line_items/{line_item_id}", lineItemId)
+	path, err := c.InterpolatePath("/line_items/{line_item_id}", lineItemId)
+	if err != nil {
+		return nil, err
+	}
 	result := &LineItem{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2716,9 +3092,12 @@ func (c *Client) GetLineItem(lineItemId string) (*LineItem, error) {
 // RemoveLineItem Delete an uninvoiced line item
 // Returns: Line item deleted.
 func (c *Client) RemoveLineItem(lineItemId string) (*Empty, error) {
-	path := c.InterpolatePath("/line_items/{line_item_id}", lineItemId)
+	path, err := c.InterpolatePath("/line_items/{line_item_id}", lineItemId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Empty{}
-	err := c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(http.MethodDelete, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2807,18 +3186,32 @@ func (list *ListPlansParams) URLParams() []KeyValue {
 
 // ListPlans List a site's plans
 // Returns: A list of plans.
-func (c *Client) ListPlans(params *ListPlansParams) *PlanList {
-	path := "/plans"
+func (c *Client) ListPlans(params *ListPlansParams) (*PlanList, error) {
+	path, err := c.InterpolatePath("/plans")
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewPlanList(c, path)
+=======
+	return &PlanList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // CreatePlan Create a plan
 // Returns: A plan.
 func (c *Client) CreatePlan(body *PlanCreate) (*Plan, error) {
-	path := c.InterpolatePath("/plans")
+	path, err := c.InterpolatePath("/plans")
+	if err != nil {
+		return nil, err
+	}
 	result := &Plan{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2828,9 +3221,12 @@ func (c *Client) CreatePlan(body *PlanCreate) (*Plan, error) {
 // GetPlan Fetch a plan
 // Returns: A plan.
 func (c *Client) GetPlan(planId string) (*Plan, error) {
-	path := c.InterpolatePath("/plans/{plan_id}", planId)
+	path, err := c.InterpolatePath("/plans/{plan_id}", planId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Plan{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2840,9 +3236,12 @@ func (c *Client) GetPlan(planId string) (*Plan, error) {
 // UpdatePlan Update a plan
 // Returns: A plan.
 func (c *Client) UpdatePlan(planId string, body *PlanUpdate) (*Plan, error) {
-	path := c.InterpolatePath("/plans/{plan_id}", planId)
+	path, err := c.InterpolatePath("/plans/{plan_id}", planId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Plan{}
-	err := c.Call(http.MethodPut, path, body, result)
+	err = c.Call(http.MethodPut, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2852,9 +3251,12 @@ func (c *Client) UpdatePlan(planId string, body *PlanUpdate) (*Plan, error) {
 // RemovePlan Remove a plan
 // Returns: Plan deleted
 func (c *Client) RemovePlan(planId string) (*Plan, error) {
-	path := c.InterpolatePath("/plans/{plan_id}", planId)
+	path, err := c.InterpolatePath("/plans/{plan_id}", planId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Plan{}
-	err := c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(http.MethodDelete, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2943,18 +3345,32 @@ func (list *ListPlanAddOnsParams) URLParams() []KeyValue {
 
 // ListPlanAddOns List a plan's add-ons
 // Returns: A list of add-ons.
-func (c *Client) ListPlanAddOns(planId string, params *ListPlanAddOnsParams) *AddOnList {
-	path := c.InterpolatePath("/plans/{plan_id}/add_ons", planId)
+func (c *Client) ListPlanAddOns(planId string, params *ListPlanAddOnsParams) (*AddOnList, error) {
+	path, err := c.InterpolatePath("/plans/{plan_id}/add_ons", planId)
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewAddOnList(c, path)
+=======
+	return &AddOnList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // CreatePlanAddOn Create an add-on
 // Returns: An add-on.
 func (c *Client) CreatePlanAddOn(planId string, body *AddOnCreate) (*AddOn, error) {
-	path := c.InterpolatePath("/plans/{plan_id}/add_ons", planId)
+	path, err := c.InterpolatePath("/plans/{plan_id}/add_ons", planId)
+	if err != nil {
+		return nil, err
+	}
 	result := &AddOn{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2964,9 +3380,12 @@ func (c *Client) CreatePlanAddOn(planId string, body *AddOnCreate) (*AddOn, erro
 // GetPlanAddOn Fetch a plan's add-on
 // Returns: An add-on.
 func (c *Client) GetPlanAddOn(planId string, addOnId string) (*AddOn, error) {
-	path := c.InterpolatePath("/plans/{plan_id}/add_ons/{add_on_id}", planId, addOnId)
+	path, err := c.InterpolatePath("/plans/{plan_id}/add_ons/{add_on_id}", planId, addOnId)
+	if err != nil {
+		return nil, err
+	}
 	result := &AddOn{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2976,9 +3395,12 @@ func (c *Client) GetPlanAddOn(planId string, addOnId string) (*AddOn, error) {
 // UpdatePlanAddOn Update an add-on
 // Returns: An add-on.
 func (c *Client) UpdatePlanAddOn(planId string, addOnId string, body *AddOnUpdate) (*AddOn, error) {
-	path := c.InterpolatePath("/plans/{plan_id}/add_ons/{add_on_id}", planId, addOnId)
+	path, err := c.InterpolatePath("/plans/{plan_id}/add_ons/{add_on_id}", planId, addOnId)
+	if err != nil {
+		return nil, err
+	}
 	result := &AddOn{}
-	err := c.Call(http.MethodPut, path, body, result)
+	err = c.Call(http.MethodPut, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2988,9 +3410,12 @@ func (c *Client) UpdatePlanAddOn(planId string, addOnId string, body *AddOnUpdat
 // RemovePlanAddOn Remove an add-on
 // Returns: Add-on deleted
 func (c *Client) RemovePlanAddOn(planId string, addOnId string) (*AddOn, error) {
-	path := c.InterpolatePath("/plans/{plan_id}/add_ons/{add_on_id}", planId, addOnId)
+	path, err := c.InterpolatePath("/plans/{plan_id}/add_ons/{add_on_id}", planId, addOnId)
+	if err != nil {
+		return nil, err
+	}
 	result := &AddOn{}
-	err := c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(http.MethodDelete, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3079,18 +3504,32 @@ func (list *ListAddOnsParams) URLParams() []KeyValue {
 
 // ListAddOns List a site's add-ons
 // Returns: A list of add-ons.
-func (c *Client) ListAddOns(params *ListAddOnsParams) *AddOnList {
-	path := "/add_ons"
+func (c *Client) ListAddOns(params *ListAddOnsParams) (*AddOnList, error) {
+	path, err := c.InterpolatePath("/add_ons")
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewAddOnList(c, path)
+=======
+	return &AddOnList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // GetAddOn Fetch an add-on
 // Returns: An add-on.
 func (c *Client) GetAddOn(addOnId string) (*AddOn, error) {
-	path := c.InterpolatePath("/add_ons/{add_on_id}", addOnId)
+	path, err := c.InterpolatePath("/add_ons/{add_on_id}", addOnId)
+	if err != nil {
+		return nil, err
+	}
 	result := &AddOn{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3172,9 +3611,13 @@ func (list *ListShippingMethodsParams) URLParams() []KeyValue {
 
 // ListShippingMethods List a site's shipping methods
 // Returns: A list of the site's shipping methods.
-func (c *Client) ListShippingMethods(params *ListShippingMethodsParams) *ShippingMethodList {
-	path := "/shipping_methods"
+func (c *Client) ListShippingMethods(params *ListShippingMethodsParams) (*ShippingMethodList, error) {
+	path, err := c.InterpolatePath("/shipping_methods")
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewShippingMethodList(c, path)
 }
 
@@ -3188,14 +3631,24 @@ func (c *Client) CreateShippingMethod(body *ShippingMethodCreate) (*ShippingMeth
 		return nil, err
 	}
 	return result, err
+=======
+	return &ShippingMethodList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // GetShippingMethod Fetch a shipping method
 // Returns: A shipping method.
 func (c *Client) GetShippingMethod(id string) (*ShippingMethod, error) {
-	path := c.InterpolatePath("/shipping_methods/{id}", id)
+	path, err := c.InterpolatePath("/shipping_methods/{id}", id)
+	if err != nil {
+		return nil, err
+	}
 	result := &ShippingMethod{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3311,18 +3764,32 @@ func (list *ListSubscriptionsParams) URLParams() []KeyValue {
 
 // ListSubscriptions List a site's subscriptions
 // Returns: A list of the site's subscriptions.
-func (c *Client) ListSubscriptions(params *ListSubscriptionsParams) *SubscriptionList {
-	path := "/subscriptions"
+func (c *Client) ListSubscriptions(params *ListSubscriptionsParams) (*SubscriptionList, error) {
+	path, err := c.InterpolatePath("/subscriptions")
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewSubscriptionList(c, path)
+=======
+	return &SubscriptionList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // CreateSubscription Create a new subscription
 // Returns: A subscription.
 func (c *Client) CreateSubscription(body *SubscriptionCreate) (*Subscription, error) {
-	path := c.InterpolatePath("/subscriptions")
+	path, err := c.InterpolatePath("/subscriptions")
+	if err != nil {
+		return nil, err
+	}
 	result := &Subscription{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3332,9 +3799,12 @@ func (c *Client) CreateSubscription(body *SubscriptionCreate) (*Subscription, er
 // GetSubscription Fetch a subscription
 // Returns: A subscription.
 func (c *Client) GetSubscription(subscriptionId string) (*Subscription, error) {
-	path := c.InterpolatePath("/subscriptions/{subscription_id}", subscriptionId)
+	path, err := c.InterpolatePath("/subscriptions/{subscription_id}", subscriptionId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Subscription{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3344,9 +3814,12 @@ func (c *Client) GetSubscription(subscriptionId string) (*Subscription, error) {
 // ModifySubscription Modify a subscription
 // Returns: A subscription.
 func (c *Client) ModifySubscription(subscriptionId string, body *SubscriptionUpdate) (*Subscription, error) {
-	path := c.InterpolatePath("/subscriptions/{subscription_id}", subscriptionId)
+	path, err := c.InterpolatePath("/subscriptions/{subscription_id}", subscriptionId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Subscription{}
-	err := c.Call(http.MethodPut, path, body, result)
+	err = c.Call(http.MethodPut, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3387,9 +3860,12 @@ func (list *TerminateSubscriptionParams) URLParams() []KeyValue {
 // TerminateSubscription Terminate a subscription
 // Returns: An expired subscription.
 func (c *Client) TerminateSubscription(subscriptionId string, params *TerminateSubscriptionParams) (*Subscription, error) {
-	path := c.InterpolatePath("/subscriptions/{subscription_id}", subscriptionId)
+	path, err := c.InterpolatePath("/subscriptions/{subscription_id}", subscriptionId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Subscription{}
-	err := c.Call(http.MethodDelete, path, params, result)
+	err = c.Call(http.MethodDelete, path, params, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3415,9 +3891,12 @@ func (list *CancelSubscriptionParams) toParams() *Params {
 // CancelSubscription Cancel a subscription
 // Returns: A canceled or failed subscription.
 func (c *Client) CancelSubscription(subscriptionId string, params *CancelSubscriptionParams) (*Subscription, error) {
-	path := c.InterpolatePath("/subscriptions/{subscription_id}/cancel", subscriptionId)
+	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/cancel", subscriptionId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Subscription{}
-	err := c.Call(http.MethodPut, path, params, result)
+	err = c.Call(http.MethodPut, path, params, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3427,9 +3906,12 @@ func (c *Client) CancelSubscription(subscriptionId string, params *CancelSubscri
 // ReactivateSubscription Reactivate a canceled subscription
 // Returns: An active subscription.
 func (c *Client) ReactivateSubscription(subscriptionId string) (*Subscription, error) {
-	path := c.InterpolatePath("/subscriptions/{subscription_id}/reactivate", subscriptionId)
+	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/reactivate", subscriptionId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Subscription{}
-	err := c.Call(http.MethodPut, path, nil, result)
+	err = c.Call(http.MethodPut, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3439,9 +3921,12 @@ func (c *Client) ReactivateSubscription(subscriptionId string) (*Subscription, e
 // PauseSubscription Pause subscription
 // Returns: A subscription.
 func (c *Client) PauseSubscription(subscriptionId string, body *SubscriptionPause) (*Subscription, error) {
-	path := c.InterpolatePath("/subscriptions/{subscription_id}/pause", subscriptionId)
+	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/pause", subscriptionId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Subscription{}
-	err := c.Call(http.MethodPut, path, body, result)
+	err = c.Call(http.MethodPut, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3451,9 +3936,12 @@ func (c *Client) PauseSubscription(subscriptionId string, body *SubscriptionPaus
 // ResumeSubscription Resume subscription
 // Returns: A subscription.
 func (c *Client) ResumeSubscription(subscriptionId string) (*Subscription, error) {
-	path := c.InterpolatePath("/subscriptions/{subscription_id}/resume", subscriptionId)
+	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/resume", subscriptionId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Subscription{}
-	err := c.Call(http.MethodPut, path, nil, result)
+	err = c.Call(http.MethodPut, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3463,9 +3951,12 @@ func (c *Client) ResumeSubscription(subscriptionId string) (*Subscription, error
 // ConvertTrial Convert trial subscription
 // Returns: A subscription.
 func (c *Client) ConvertTrial(subscriptionId string) (*Subscription, error) {
-	path := c.InterpolatePath("/subscriptions/{subscription_id}/convert_trial", subscriptionId)
+	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/convert_trial", subscriptionId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Subscription{}
-	err := c.Call(http.MethodPut, path, nil, result)
+	err = c.Call(http.MethodPut, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3475,9 +3966,12 @@ func (c *Client) ConvertTrial(subscriptionId string) (*Subscription, error) {
 // GetSubscriptionChange Fetch a subscription's pending change
 // Returns: A subscription's pending change.
 func (c *Client) GetSubscriptionChange(subscriptionId string) (*SubscriptionChange, error) {
-	path := c.InterpolatePath("/subscriptions/{subscription_id}/change", subscriptionId)
+	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/change", subscriptionId)
+	if err != nil {
+		return nil, err
+	}
 	result := &SubscriptionChange{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3487,9 +3981,12 @@ func (c *Client) GetSubscriptionChange(subscriptionId string) (*SubscriptionChan
 // CreateSubscriptionChange Create a new subscription change
 // Returns: A subscription change.
 func (c *Client) CreateSubscriptionChange(subscriptionId string, body *SubscriptionChangeCreate) (*SubscriptionChange, error) {
-	path := c.InterpolatePath("/subscriptions/{subscription_id}/change", subscriptionId)
+	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/change", subscriptionId)
+	if err != nil {
+		return nil, err
+	}
 	result := &SubscriptionChange{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3499,9 +3996,12 @@ func (c *Client) CreateSubscriptionChange(subscriptionId string, body *Subscript
 // RemoveSubscriptionChange Delete the pending subscription change
 // Returns: Subscription change was deleted.
 func (c *Client) RemoveSubscriptionChange(subscriptionId string) (*Empty, error) {
-	path := c.InterpolatePath("/subscriptions/{subscription_id}/change", subscriptionId)
+	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/change", subscriptionId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Empty{}
-	err := c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(http.MethodDelete, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3606,10 +4106,21 @@ func (list *ListSubscriptionInvoicesParams) URLParams() []KeyValue {
 
 // ListSubscriptionInvoices List a subscription's invoices
 // Returns: A list of the subscription's invoices.
-func (c *Client) ListSubscriptionInvoices(subscriptionId string, params *ListSubscriptionInvoicesParams) *InvoiceList {
-	path := c.InterpolatePath("/subscriptions/{subscription_id}/invoices", subscriptionId)
+func (c *Client) ListSubscriptionInvoices(subscriptionId string, params *ListSubscriptionInvoicesParams) (*InvoiceList, error) {
+	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/invoices", subscriptionId)
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewInvoiceList(c, path)
+=======
+	return &InvoiceList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 type ListSubscriptionLineItemsParams struct {
@@ -3708,10 +4219,21 @@ func (list *ListSubscriptionLineItemsParams) URLParams() []KeyValue {
 
 // ListSubscriptionLineItems List a subscription's line items
 // Returns: A list of the subscription's line items.
-func (c *Client) ListSubscriptionLineItems(subscriptionId string, params *ListSubscriptionLineItemsParams) *LineItemList {
-	path := c.InterpolatePath("/subscriptions/{subscription_id}/line_items", subscriptionId)
+func (c *Client) ListSubscriptionLineItems(subscriptionId string, params *ListSubscriptionLineItemsParams) (*LineItemList, error) {
+	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/line_items", subscriptionId)
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewLineItemList(c, path)
+=======
+	return &LineItemList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 type ListSubscriptionCouponRedemptionsParams struct {
@@ -3775,9 +4297,13 @@ func (list *ListSubscriptionCouponRedemptionsParams) URLParams() []KeyValue {
 
 // ListSubscriptionCouponRedemptions Show the coupon redemptions for a subscription
 // Returns: A list of the the coupon redemptions on a subscription.
-func (c *Client) ListSubscriptionCouponRedemptions(subscriptionId string, params *ListSubscriptionCouponRedemptionsParams) *CouponRedemptionList {
-	path := c.InterpolatePath("/subscriptions/{subscription_id}/coupon_redemptions", subscriptionId)
+func (c *Client) ListSubscriptionCouponRedemptions(subscriptionId string, params *ListSubscriptionCouponRedemptionsParams) (*CouponRedemptionList, error) {
+	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/coupon_redemptions", subscriptionId)
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewCouponRedemptionList(c, path)
 }
 
@@ -3915,6 +4441,13 @@ func (c *Client) RemoveUsage(usageId string) (*Empty, error) {
 		return nil, err
 	}
 	return result, err
+=======
+	return &CouponRedemptionList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 type ListTransactionsParams struct {
@@ -4006,18 +4539,32 @@ func (list *ListTransactionsParams) URLParams() []KeyValue {
 
 // ListTransactions List a site's transactions
 // Returns: A list of the site's transactions.
-func (c *Client) ListTransactions(params *ListTransactionsParams) *TransactionList {
-	path := "/transactions"
+func (c *Client) ListTransactions(params *ListTransactionsParams) (*TransactionList, error) {
+	path, err := c.InterpolatePath("/transactions")
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
+<<<<<<< HEAD
 	return NewTransactionList(c, path)
+=======
+	return &TransactionList{
+		client:       c,
+		nextPagePath: path,
+		HasMore:      true,
+	}, nil
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // GetTransaction Fetch a transaction
 // Returns: A transaction.
 func (c *Client) GetTransaction(transactionId string) (*Transaction, error) {
-	path := c.InterpolatePath("/transactions/{transaction_id}", transactionId)
+	path, err := c.InterpolatePath("/transactions/{transaction_id}", transactionId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Transaction{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4027,9 +4574,12 @@ func (c *Client) GetTransaction(transactionId string) (*Transaction, error) {
 // GetUniqueCouponCode Fetch a unique coupon code
 // Returns: A unique coupon code.
 func (c *Client) GetUniqueCouponCode(uniqueCouponCodeId string) (*UniqueCouponCode, error) {
-	path := c.InterpolatePath("/unique_coupon_codes/{unique_coupon_code_id}", uniqueCouponCodeId)
+	path, err := c.InterpolatePath("/unique_coupon_codes/{unique_coupon_code_id}", uniqueCouponCodeId)
+	if err != nil {
+		return nil, err
+	}
 	result := &UniqueCouponCode{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4039,9 +4589,12 @@ func (c *Client) GetUniqueCouponCode(uniqueCouponCodeId string) (*UniqueCouponCo
 // DeactivateUniqueCouponCode Deactivate a unique coupon code
 // Returns: A unique coupon code.
 func (c *Client) DeactivateUniqueCouponCode(uniqueCouponCodeId string) (*UniqueCouponCode, error) {
-	path := c.InterpolatePath("/unique_coupon_codes/{unique_coupon_code_id}", uniqueCouponCodeId)
+	path, err := c.InterpolatePath("/unique_coupon_codes/{unique_coupon_code_id}", uniqueCouponCodeId)
+	if err != nil {
+		return nil, err
+	}
 	result := &UniqueCouponCode{}
-	err := c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(http.MethodDelete, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4051,9 +4604,12 @@ func (c *Client) DeactivateUniqueCouponCode(uniqueCouponCodeId string) (*UniqueC
 // ReactivateUniqueCouponCode Restore a unique coupon code
 // Returns: A unique coupon code.
 func (c *Client) ReactivateUniqueCouponCode(uniqueCouponCodeId string) (*UniqueCouponCode, error) {
-	path := c.InterpolatePath("/unique_coupon_codes/{unique_coupon_code_id}/restore", uniqueCouponCodeId)
+	path, err := c.InterpolatePath("/unique_coupon_codes/{unique_coupon_code_id}/restore", uniqueCouponCodeId)
+	if err != nil {
+		return nil, err
+	}
 	result := &UniqueCouponCode{}
-	err := c.Call(http.MethodPut, path, nil, result)
+	err = c.Call(http.MethodPut, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4063,9 +4619,12 @@ func (c *Client) ReactivateUniqueCouponCode(uniqueCouponCodeId string) (*UniqueC
 // CreatePurchase Create a new purchase
 // Returns: Returns the new invoices
 func (c *Client) CreatePurchase(body *PurchaseCreate) (*InvoiceCollection, error) {
-	path := c.InterpolatePath("/purchases")
+	path, err := c.InterpolatePath("/purchases")
+	if err != nil {
+		return nil, err
+	}
 	result := &InvoiceCollection{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4075,9 +4634,12 @@ func (c *Client) CreatePurchase(body *PurchaseCreate) (*InvoiceCollection, error
 // PreviewPurchase Preview a new purchase
 // Returns: Returns preview of the new invoices
 func (c *Client) PreviewPurchase(body *PurchaseCreate) (*InvoiceCollection, error) {
-	path := c.InterpolatePath("/purchases/preview")
+	path, err := c.InterpolatePath("/purchases/preview")
+	if err != nil {
+		return nil, err
+	}
 	result := &InvoiceCollection{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}

--- a/client_operations.go
+++ b/client_operations.go
@@ -13,11 +13,11 @@ const (
 )
 
 type ClientInterface interface {
-	ListSites(params *ListSitesParams) *SiteList
+	ListSites(params *ListSitesParams) (*SiteList, error)
 
 	GetSite(siteId string) (*Site, error)
 
-	ListAccounts(params *ListAccountsParams) *AccountList
+	ListAccounts(params *ListAccountsParams) (*AccountList, error)
 
 	CreateAccount(body *AccountCreate) (*Account, error)
 
@@ -43,7 +43,7 @@ type ClientInterface interface {
 
 	RemoveBillingInfo(accountId string) (*Empty, error)
 
-	ListAccountCouponRedemptions(accountId string, params *ListAccountCouponRedemptionsParams) *CouponRedemptionList
+	ListAccountCouponRedemptions(accountId string, params *ListAccountCouponRedemptionsParams) (*CouponRedemptionList, error)
 
 	GetActiveCouponRedemption(accountId string) (*CouponRedemption, error)
 
@@ -51,23 +51,23 @@ type ClientInterface interface {
 
 	RemoveCouponRedemption(accountId string) (*CouponRedemption, error)
 
-	ListAccountCreditPayments(accountId string, params *ListAccountCreditPaymentsParams) *CreditPaymentList
+	ListAccountCreditPayments(accountId string, params *ListAccountCreditPaymentsParams) (*CreditPaymentList, error)
 
-	ListAccountInvoices(accountId string, params *ListAccountInvoicesParams) *InvoiceList
+	ListAccountInvoices(accountId string, params *ListAccountInvoicesParams) (*InvoiceList, error)
 
 	CreateInvoice(accountId string, body *InvoiceCreate) (*InvoiceCollection, error)
 
 	PreviewInvoice(accountId string, body *InvoiceCreate) (*InvoiceCollection, error)
 
-	ListAccountLineItems(accountId string, params *ListAccountLineItemsParams) *LineItemList
+	ListAccountLineItems(accountId string, params *ListAccountLineItemsParams) (*LineItemList, error)
 
 	CreateLineItem(accountId string, body *LineItemCreate) (*LineItem, error)
 
-	ListAccountNotes(accountId string, params *ListAccountNotesParams) *AccountNoteList
+	ListAccountNotes(accountId string, params *ListAccountNotesParams) (*AccountNoteList, error)
 
 	GetAccountNote(accountId string, accountNoteId string) (*AccountNote, error)
 
-	ListShippingAddresses(accountId string, params *ListShippingAddressesParams) *ShippingAddressList
+	ListShippingAddresses(accountId string, params *ListShippingAddressesParams) (*ShippingAddressList, error)
 
 	CreateShippingAddress(accountId string, body *ShippingAddressCreate) (*ShippingAddress, error)
 
@@ -77,15 +77,15 @@ type ClientInterface interface {
 
 	RemoveShippingAddress(accountId string, shippingAddressId string) (*Empty, error)
 
-	ListAccountSubscriptions(accountId string, params *ListAccountSubscriptionsParams) *SubscriptionList
+	ListAccountSubscriptions(accountId string, params *ListAccountSubscriptionsParams) (*SubscriptionList, error)
 
-	ListAccountTransactions(accountId string, params *ListAccountTransactionsParams) *TransactionList
+	ListAccountTransactions(accountId string, params *ListAccountTransactionsParams) (*TransactionList, error)
 
-	ListChildAccounts(accountId string, params *ListChildAccountsParams) *AccountList
+	ListChildAccounts(accountId string, params *ListChildAccountsParams) (*AccountList, error)
 
-	ListAccountAcquisition(params *ListAccountAcquisitionParams) *AccountAcquisitionList
+	ListAccountAcquisition(params *ListAccountAcquisitionParams) (*AccountAcquisitionList, error)
 
-	ListCoupons(params *ListCouponsParams) *CouponList
+	ListCoupons(params *ListCouponsParams) (*CouponList, error)
 
 	CreateCoupon(body *CouponCreate) (*Coupon, error)
 
@@ -95,17 +95,17 @@ type ClientInterface interface {
 
 	DeactivateCoupon(couponId string) (*Coupon, error)
 
-	ListUniqueCouponCodes(couponId string, params *ListUniqueCouponCodesParams) *UniqueCouponCodeList
+	ListUniqueCouponCodes(couponId string, params *ListUniqueCouponCodesParams) (*UniqueCouponCodeList, error)
 
-	ListCreditPayments(params *ListCreditPaymentsParams) *CreditPaymentList
+	ListCreditPayments(params *ListCreditPaymentsParams) (*CreditPaymentList, error)
 
 	GetCreditPayment(creditPaymentId string) (*CreditPayment, error)
 
-	ListCustomFieldDefinitions(params *ListCustomFieldDefinitionsParams) *CustomFieldDefinitionList
+	ListCustomFieldDefinitions(params *ListCustomFieldDefinitionsParams) (*CustomFieldDefinitionList, error)
 
 	GetCustomFieldDefinition(customFieldDefinitionId string) (*CustomFieldDefinition, error)
 
-	ListItems(params *ListItemsParams) *ItemList
+	ListItems(params *ListItemsParams) (*ItemList, error)
 
 	CreateItem(body *ItemCreate) (*Item, error)
 
@@ -117,7 +117,7 @@ type ClientInterface interface {
 
 	ReactivateItem(itemId string) (*Item, error)
 
-	ListMeasuredUnit(params *ListMeasuredUnitParams) *MeasuredUnitList
+	ListMeasuredUnit(params *ListMeasuredUnitParams) (*MeasuredUnitList, error)
 
 	CreateMeasuredUnit(body *MeasuredUnitCreate) (*MeasuredUnit, error)
 
@@ -127,7 +127,7 @@ type ClientInterface interface {
 
 	RemoveMeasuredUnit(measuredUnitId string) (*MeasuredUnit, error)
 
-	ListInvoices(params *ListInvoicesParams) *InvoiceList
+	ListInvoices(params *ListInvoicesParams) (*InvoiceList, error)
 
 	GetInvoice(invoiceId string) (*Invoice, error)
 
@@ -145,21 +145,21 @@ type ClientInterface interface {
 
 	RecordExternalTransaction(invoiceId string, body *ExternalTransaction) (*Transaction, error)
 
-	ListInvoiceLineItems(invoiceId string, params *ListInvoiceLineItemsParams) *LineItemList
+	ListInvoiceLineItems(invoiceId string, params *ListInvoiceLineItemsParams) (*LineItemList, error)
 
-	ListInvoiceCouponRedemptions(invoiceId string, params *ListInvoiceCouponRedemptionsParams) *CouponRedemptionList
+	ListInvoiceCouponRedemptions(invoiceId string, params *ListInvoiceCouponRedemptionsParams) (*CouponRedemptionList, error)
 
-	ListRelatedInvoices(invoiceId string) *InvoiceList
+	ListRelatedInvoices(invoiceId string) (*InvoiceList, error)
 
 	RefundInvoice(invoiceId string, body *InvoiceRefund) (*Invoice, error)
 
-	ListLineItems(params *ListLineItemsParams) *LineItemList
+	ListLineItems(params *ListLineItemsParams) (*LineItemList, error)
 
 	GetLineItem(lineItemId string) (*LineItem, error)
 
 	RemoveLineItem(lineItemId string) (*Empty, error)
 
-	ListPlans(params *ListPlansParams) *PlanList
+	ListPlans(params *ListPlansParams) (*PlanList, error)
 
 	CreatePlan(body *PlanCreate) (*Plan, error)
 
@@ -169,7 +169,7 @@ type ClientInterface interface {
 
 	RemovePlan(planId string) (*Plan, error)
 
-	ListPlanAddOns(planId string, params *ListPlanAddOnsParams) *AddOnList
+	ListPlanAddOns(planId string, params *ListPlanAddOnsParams) (*AddOnList, error)
 
 	CreatePlanAddOn(planId string, body *AddOnCreate) (*AddOn, error)
 
@@ -179,11 +179,11 @@ type ClientInterface interface {
 
 	RemovePlanAddOn(planId string, addOnId string) (*AddOn, error)
 
-	ListAddOns(params *ListAddOnsParams) *AddOnList
+	ListAddOns(params *ListAddOnsParams) (*AddOnList, error)
 
 	GetAddOn(addOnId string) (*AddOn, error)
 
-	ListShippingMethods(params *ListShippingMethodsParams) *ShippingMethodList
+	ListShippingMethods(params *ListShippingMethodsParams) (*ShippingMethodList, error)
 
 	CreateShippingMethod(body *ShippingMethodCreate) (*ShippingMethod, error)
 
@@ -193,7 +193,7 @@ type ClientInterface interface {
 
 	DeactivateShippingMethod(shippingMethodId string) (*ShippingMethod, error)
 
-	ListSubscriptions(params *ListSubscriptionsParams) *SubscriptionList
+	ListSubscriptions(params *ListSubscriptionsParams) (*SubscriptionList, error)
 
 	CreateSubscription(body *SubscriptionCreate) (*Subscription, error)
 
@@ -221,13 +221,13 @@ type ClientInterface interface {
 
 	PreviewSubscriptionChange(subscriptionId string, body *SubscriptionChangeCreate) (*SubscriptionChangePreview, error)
 
-	ListSubscriptionInvoices(subscriptionId string, params *ListSubscriptionInvoicesParams) *InvoiceList
+	ListSubscriptionInvoices(subscriptionId string, params *ListSubscriptionInvoicesParams) (*InvoiceList, error)
 
-	ListSubscriptionLineItems(subscriptionId string, params *ListSubscriptionLineItemsParams) *LineItemList
+	ListSubscriptionLineItems(subscriptionId string, params *ListSubscriptionLineItemsParams) (*LineItemList, error)
 
-	ListSubscriptionCouponRedemptions(subscriptionId string, params *ListSubscriptionCouponRedemptionsParams) *CouponRedemptionList
+	ListSubscriptionCouponRedemptions(subscriptionId string, params *ListSubscriptionCouponRedemptionsParams) (*CouponRedemptionList, error)
 
-	ListUsage(subscriptionId string, addOnId string, params *ListUsageParams) *UsageList
+	ListUsage(subscriptionId string, addOnId string, params *ListUsageParams) (*UsageList, error)
 
 	CreateUsage(subscriptionId string, addOnId string, body *UsageCreate) (*Usage, error)
 
@@ -237,7 +237,7 @@ type ClientInterface interface {
 
 	RemoveUsage(usageId string) (*Empty, error)
 
-	ListTransactions(params *ListTransactionsParams) *TransactionList
+	ListTransactions(params *ListTransactionsParams) (*TransactionList, error)
 
 	GetTransaction(transactionId string) (*Transaction, error)
 
@@ -327,15 +327,7 @@ func (c *Client) ListSites(params *ListSitesParams) (*SiteList, error) {
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewSiteList(c, path)
-=======
-	return &SiteList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewSiteList(c, path), nil
 }
 
 // GetSite Fetch a site
@@ -462,15 +454,7 @@ func (c *Client) ListAccounts(params *ListAccountsParams) (*AccountList, error) 
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewAccountList(c, path)
-=======
-	return &AccountList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewAccountList(c, path), nil
 }
 
 // CreateAccount Create an account
@@ -759,15 +743,7 @@ func (c *Client) ListAccountCouponRedemptions(accountId string, params *ListAcco
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewCouponRedemptionList(c, path)
-=======
-	return &CouponRedemptionList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewCouponRedemptionList(c, path), nil
 }
 
 // GetActiveCouponRedemption Show the coupon redemption that is active on an account
@@ -893,15 +869,7 @@ func (c *Client) ListAccountCreditPayments(accountId string, params *ListAccount
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewCreditPaymentList(c, path)
-=======
-	return &CreditPaymentList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewCreditPaymentList(c, path), nil
 }
 
 type ListAccountInvoicesParams struct {
@@ -999,15 +967,7 @@ func (c *Client) ListAccountInvoices(accountId string, params *ListAccountInvoic
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewInvoiceList(c, path)
-=======
-	return &InvoiceList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewInvoiceList(c, path), nil
 }
 
 // CreateInvoice Create an invoice for pending line items
@@ -1151,15 +1111,7 @@ func (c *Client) ListAccountLineItems(accountId string, params *ListAccountLineI
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewLineItemList(c, path)
-=======
-	return &LineItemList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewLineItemList(c, path), nil
 }
 
 // CreateLineItem Create a new line item for the account
@@ -1225,15 +1177,7 @@ func (c *Client) ListAccountNotes(accountId string, params *ListAccountNotesPara
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewAccountNoteList(c, path)
-=======
-	return &AccountNoteList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewAccountNoteList(c, path), nil
 }
 
 // GetAccountNote Fetch an account note
@@ -1338,15 +1282,7 @@ func (c *Client) ListShippingAddresses(accountId string, params *ListShippingAdd
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewShippingAddressList(c, path)
-=======
-	return &ShippingAddressList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewShippingAddressList(c, path), nil
 }
 
 // CreateShippingAddress Create a new shipping address for the account
@@ -1515,15 +1451,7 @@ func (c *Client) ListAccountSubscriptions(accountId string, params *ListAccountS
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewSubscriptionList(c, path)
-=======
-	return &SubscriptionList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewSubscriptionList(c, path), nil
 }
 
 type ListAccountTransactionsParams struct {
@@ -1624,15 +1552,7 @@ func (c *Client) ListAccountTransactions(accountId string, params *ListAccountTr
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewTransactionList(c, path)
-=======
-	return &TransactionList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewTransactionList(c, path), nil
 }
 
 type ListChildAccountsParams struct {
@@ -1741,15 +1661,7 @@ func (c *Client) ListChildAccounts(accountId string, params *ListChildAccountsPa
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewAccountList(c, path)
-=======
-	return &AccountList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewAccountList(c, path), nil
 }
 
 type ListAccountAcquisitionParams struct {
@@ -1836,15 +1748,7 @@ func (c *Client) ListAccountAcquisition(params *ListAccountAcquisitionParams) (*
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewAccountAcquisitionList(c, path)
-=======
-	return &AccountAcquisitionList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewAccountAcquisitionList(c, path), nil
 }
 
 type ListCouponsParams struct {
@@ -1931,15 +1835,7 @@ func (c *Client) ListCoupons(params *ListCouponsParams) (*CouponList, error) {
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewCouponList(c, path)
-=======
-	return &CouponList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewCouponList(c, path), nil
 }
 
 // CreateCoupon Create a new coupon
@@ -2098,15 +1994,7 @@ func (c *Client) ListUniqueCouponCodes(couponId string, params *ListUniqueCoupon
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewUniqueCouponCodeList(c, path)
-=======
-	return &UniqueCouponCodeList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewUniqueCouponCodeList(c, path), nil
 }
 
 type ListCreditPaymentsParams struct {
@@ -2178,15 +2066,7 @@ func (c *Client) ListCreditPayments(params *ListCreditPaymentsParams) (*CreditPa
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewCreditPaymentList(c, path)
-=======
-	return &CreditPaymentList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewCreditPaymentList(c, path), nil
 }
 
 // GetCreditPayment Fetch a credit payment
@@ -2298,15 +2178,7 @@ func (c *Client) ListCustomFieldDefinitions(params *ListCustomFieldDefinitionsPa
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewCustomFieldDefinitionList(c, path)
-=======
-	return &CustomFieldDefinitionList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewCustomFieldDefinitionList(c, path), nil
 }
 
 // GetCustomFieldDefinition Fetch an custom field definition
@@ -2418,15 +2290,7 @@ func (c *Client) ListItems(params *ListItemsParams) (*ItemList, error) {
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewItemList(c, path)
-=======
-	return &ItemList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewItemList(c, path), nil
 }
 
 // CreateItem Create a new item
@@ -2600,19 +2464,31 @@ func (list *ListMeasuredUnitParams) URLParams() []KeyValue {
 }
 
 // ListMeasuredUnit List a site's measured units
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_measured_unit
+//
 // Returns: A list of the site's measured units.
-func (c *Client) ListMeasuredUnit(params *ListMeasuredUnitParams) *MeasuredUnitList {
-	path := "/measured_units"
+func (c *Client) ListMeasuredUnit(params *ListMeasuredUnitParams) (*MeasuredUnitList, error) {
+	path, err := c.InterpolatePath("/measured_units")
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
-	return NewMeasuredUnitList(c, path)
+	return NewMeasuredUnitList(c, path), nil
 }
 
 // CreateMeasuredUnit Create a new measured unit
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_measured_unit
+//
 // Returns: A new measured unit.
 func (c *Client) CreateMeasuredUnit(body *MeasuredUnitCreate) (*MeasuredUnit, error) {
-	path := c.InterpolatePath("/measured_units")
+	path, err := c.InterpolatePath("/measured_units")
+	if err != nil {
+		return nil, err
+	}
 	result := &MeasuredUnit{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2620,11 +2496,17 @@ func (c *Client) CreateMeasuredUnit(body *MeasuredUnitCreate) (*MeasuredUnit, er
 }
 
 // GetMeasuredUnit Fetch a measured unit
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_measured_unit
+//
 // Returns: An item.
 func (c *Client) GetMeasuredUnit(measuredUnitId string) (*MeasuredUnit, error) {
-	path := c.InterpolatePath("/measured_units/{measured_unit_id}", measuredUnitId)
+	path, err := c.InterpolatePath("/measured_units/{measured_unit_id}", measuredUnitId)
+	if err != nil {
+		return nil, err
+	}
 	result := &MeasuredUnit{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2632,11 +2514,17 @@ func (c *Client) GetMeasuredUnit(measuredUnitId string) (*MeasuredUnit, error) {
 }
 
 // UpdateMeasuredUnit Update a measured unit
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_measured_unit
+//
 // Returns: The updated measured_unit.
 func (c *Client) UpdateMeasuredUnit(measuredUnitId string, body *MeasuredUnitUpdate) (*MeasuredUnit, error) {
-	path := c.InterpolatePath("/measured_units/{measured_unit_id}", measuredUnitId)
+	path, err := c.InterpolatePath("/measured_units/{measured_unit_id}", measuredUnitId)
+	if err != nil {
+		return nil, err
+	}
 	result := &MeasuredUnit{}
-	err := c.Call(http.MethodPut, path, body, result)
+	err = c.Call(http.MethodPut, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2644,11 +2532,17 @@ func (c *Client) UpdateMeasuredUnit(measuredUnitId string, body *MeasuredUnitUpd
 }
 
 // RemoveMeasuredUnit Remove a measured unit
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_measured_unit
+//
 // Returns: A measured unit.
 func (c *Client) RemoveMeasuredUnit(measuredUnitId string) (*MeasuredUnit, error) {
-	path := c.InterpolatePath("/measured_units/{measured_unit_id}", measuredUnitId)
+	path, err := c.InterpolatePath("/measured_units/{measured_unit_id}", measuredUnitId)
+	if err != nil {
+		return nil, err
+	}
 	result := &MeasuredUnit{}
-	err := c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(http.MethodDelete, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2750,15 +2644,7 @@ func (c *Client) ListInvoices(params *ListInvoicesParams) (*InvoiceList, error) 
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewInvoiceList(c, path)
-=======
-	return &InvoiceList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewInvoiceList(c, path), nil
 }
 
 // GetInvoice Fetch an invoice
@@ -2904,11 +2790,17 @@ func (c *Client) VoidInvoice(invoiceId string) (*Invoice, error) {
 }
 
 // RecordExternalTransaction Record an external payment for a manual invoices.
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/record_external_transaction
+//
 // Returns: The recorded transaction.
 func (c *Client) RecordExternalTransaction(invoiceId string, body *ExternalTransaction) (*Transaction, error) {
-	path := c.InterpolatePath("/invoices/{invoice_id}/transactions", invoiceId)
+	path, err := c.InterpolatePath("/invoices/{invoice_id}/transactions", invoiceId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Transaction{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3020,15 +2912,7 @@ func (c *Client) ListInvoiceLineItems(invoiceId string, params *ListInvoiceLineI
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewLineItemList(c, path)
-=======
-	return &LineItemList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewLineItemList(c, path), nil
 }
 
 type ListInvoiceCouponRedemptionsParams struct {
@@ -3101,15 +2985,7 @@ func (c *Client) ListInvoiceCouponRedemptions(invoiceId string, params *ListInvo
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewCouponRedemptionList(c, path)
-=======
-	return &CouponRedemptionList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewCouponRedemptionList(c, path), nil
 }
 
 // ListRelatedInvoices List an invoice's related credit or charge invoices
@@ -3117,22 +2993,12 @@ func (c *Client) ListInvoiceCouponRedemptions(invoiceId string, params *ListInvo
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_related_invoices
 //
 // Returns: A list of the credit or charge invoices associated with the invoice.
-<<<<<<< HEAD
-func (c *Client) ListRelatedInvoices(invoiceId string) *InvoiceList {
-	path := c.InterpolatePath("/invoices/{invoice_id}/related_invoices", invoiceId)
-	return NewInvoiceList(c, path)
-=======
 func (c *Client) ListRelatedInvoices(invoiceId string) (*InvoiceList, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/related_invoices", invoiceId)
 	if err != nil {
 		return nil, err
 	}
-	return &InvoiceList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewInvoiceList(c, path), nil
 }
 
 // RefundInvoice Refund an invoice
@@ -3258,15 +3124,7 @@ func (c *Client) ListLineItems(params *ListLineItemsParams) (*LineItemList, erro
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewLineItemList(c, path)
-=======
-	return &LineItemList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewLineItemList(c, path), nil
 }
 
 // GetLineItem Fetch a line item
@@ -3396,15 +3254,7 @@ func (c *Client) ListPlans(params *ListPlansParams) (*PlanList, error) {
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewPlanList(c, path)
-=======
-	return &PlanList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewPlanList(c, path), nil
 }
 
 // CreatePlan Create a plan
@@ -3570,15 +3420,7 @@ func (c *Client) ListPlanAddOns(planId string, params *ListPlanAddOnsParams) (*A
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewAddOnList(c, path)
-=======
-	return &AddOnList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewAddOnList(c, path), nil
 }
 
 // CreatePlanAddOn Create an add-on
@@ -3744,15 +3586,7 @@ func (c *Client) ListAddOns(params *ListAddOnsParams) (*AddOnList, error) {
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewAddOnList(c, path)
-=======
-	return &AddOnList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewAddOnList(c, path), nil
 }
 
 // GetAddOn Fetch an add-on
@@ -3857,38 +3691,32 @@ func (c *Client) ListShippingMethods(params *ListShippingMethodsParams) (*Shippi
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewShippingMethodList(c, path)
+	return NewShippingMethodList(c, path), nil
 }
 
 // CreateShippingMethod Create a new shipping method
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_shipping_method
+//
 // Returns: A new shipping method.
 func (c *Client) CreateShippingMethod(body *ShippingMethodCreate) (*ShippingMethod, error) {
-	path := c.InterpolatePath("/shipping_methods")
+	path, err := c.InterpolatePath("/shipping_methods")
+	if err != nil {
+		return nil, err
+	}
 	result := &ShippingMethod{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
-=======
-	return &ShippingMethodList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 // GetShippingMethod Fetch a shipping method
-<<<<<<< HEAD
-// Returns: A shipping method.
-=======
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_shipping_method
 //
-// Returns: A shipping_method.
->>>>>>> fd7ddc1... Regenerating function docs
+// Returns: A shipping method.
 func (c *Client) GetShippingMethod(id string) (*ShippingMethod, error) {
 	path, err := c.InterpolatePath("/shipping_methods/{id}", id)
 	if err != nil {
@@ -3903,11 +3731,17 @@ func (c *Client) GetShippingMethod(id string) (*ShippingMethod, error) {
 }
 
 // UpdateShippingMethod Update an active Shipping Method
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_shipping_method
+//
 // Returns: The updated shipping method.
 func (c *Client) UpdateShippingMethod(shippingMethodId string, body *ShippingMethodUpdate) (*ShippingMethod, error) {
-	path := c.InterpolatePath("/shipping_methods/{shipping_method_id}", shippingMethodId)
+	path, err := c.InterpolatePath("/shipping_methods/{shipping_method_id}", shippingMethodId)
+	if err != nil {
+		return nil, err
+	}
 	result := &ShippingMethod{}
-	err := c.Call(http.MethodPut, path, body, result)
+	err = c.Call(http.MethodPut, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3915,11 +3749,17 @@ func (c *Client) UpdateShippingMethod(shippingMethodId string, body *ShippingMet
 }
 
 // DeactivateShippingMethod Deactivate a shipping method
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/deactivate_shipping_method
+//
 // Returns: A shipping method.
 func (c *Client) DeactivateShippingMethod(shippingMethodId string) (*ShippingMethod, error) {
-	path := c.InterpolatePath("/shipping_methods/{shipping_method_id}", shippingMethodId)
+	path, err := c.InterpolatePath("/shipping_methods/{shipping_method_id}", shippingMethodId)
+	if err != nil {
+		return nil, err
+	}
 	result := &ShippingMethod{}
-	err := c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(http.MethodDelete, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4020,15 +3860,7 @@ func (c *Client) ListSubscriptions(params *ListSubscriptionsParams) (*Subscripti
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewSubscriptionList(c, path)
-=======
-	return &SubscriptionList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewSubscriptionList(c, path), nil
 }
 
 // CreateSubscription Create a new subscription
@@ -4295,11 +4127,17 @@ func (c *Client) RemoveSubscriptionChange(subscriptionId string) (*Empty, error)
 }
 
 // PreviewSubscriptionChange Preview a new subscription change
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/preview_subscription_change
+//
 // Returns: A subscription change.
 func (c *Client) PreviewSubscriptionChange(subscriptionId string, body *SubscriptionChangeCreate) (*SubscriptionChangePreview, error) {
-	path := c.InterpolatePath("/subscriptions/{subscription_id}/change/preview", subscriptionId)
+	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/change/preview", subscriptionId)
+	if err != nil {
+		return nil, err
+	}
 	result := &SubscriptionChangePreview{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4401,15 +4239,7 @@ func (c *Client) ListSubscriptionInvoices(subscriptionId string, params *ListSub
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewInvoiceList(c, path)
-=======
-	return &InvoiceList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewInvoiceList(c, path), nil
 }
 
 type ListSubscriptionLineItemsParams struct {
@@ -4517,15 +4347,7 @@ func (c *Client) ListSubscriptionLineItems(subscriptionId string, params *ListSu
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewLineItemList(c, path)
-=======
-	return &LineItemList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewLineItemList(c, path), nil
 }
 
 type ListSubscriptionCouponRedemptionsParams struct {
@@ -4598,8 +4420,7 @@ func (c *Client) ListSubscriptionCouponRedemptions(subscriptionId string, params
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewCouponRedemptionList(c, path)
+	return NewCouponRedemptionList(c, path), nil
 }
 
 type ListUsageParams struct {
@@ -4683,19 +4504,31 @@ func (list *ListUsageParams) URLParams() []KeyValue {
 }
 
 // ListUsage List a subscription add-on's usage records
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_usage
+//
 // Returns: A list of the subscription add-on's usage records.
-func (c *Client) ListUsage(subscriptionId string, addOnId string, params *ListUsageParams) *UsageList {
-	path := c.InterpolatePath("/subscriptions/{subscription_id}/add_ons/{add_on_id}/usage", subscriptionId, addOnId)
+func (c *Client) ListUsage(subscriptionId string, addOnId string, params *ListUsageParams) (*UsageList, error) {
+	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/add_ons/{add_on_id}/usage", subscriptionId, addOnId)
+	if err != nil {
+		return nil, err
+	}
 	path = BuildUrl(path, params)
-	return NewUsageList(c, path)
+	return NewUsageList(c, path), nil
 }
 
 // CreateUsage Log a usage record on this subscription add-on
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_usage
+//
 // Returns: The created usage record.
 func (c *Client) CreateUsage(subscriptionId string, addOnId string, body *UsageCreate) (*Usage, error) {
-	path := c.InterpolatePath("/subscriptions/{subscription_id}/add_ons/{add_on_id}/usage", subscriptionId, addOnId)
+	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/add_ons/{add_on_id}/usage", subscriptionId, addOnId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Usage{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4703,11 +4536,17 @@ func (c *Client) CreateUsage(subscriptionId string, addOnId string, body *UsageC
 }
 
 // GetUsage Get a usage record
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_usage
+//
 // Returns: The usage record.
 func (c *Client) GetUsage(usageId string) (*Usage, error) {
-	path := c.InterpolatePath("/usage/{usage_id}", usageId)
+	path, err := c.InterpolatePath("/usage/{usage_id}", usageId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Usage{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4715,11 +4554,17 @@ func (c *Client) GetUsage(usageId string) (*Usage, error) {
 }
 
 // UpdateUsage Update a usage record
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_usage
+//
 // Returns: The updated usage record.
 func (c *Client) UpdateUsage(usageId string, body *UsageCreate) (*Usage, error) {
-	path := c.InterpolatePath("/usage/{usage_id}", usageId)
+	path, err := c.InterpolatePath("/usage/{usage_id}", usageId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Usage{}
-	err := c.Call(http.MethodPut, path, body, result)
+	err = c.Call(http.MethodPut, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4727,22 +4572,21 @@ func (c *Client) UpdateUsage(usageId string, body *UsageCreate) (*Usage, error) 
 }
 
 // RemoveUsage Delete a usage record.
+//
+// API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_usage
+//
 // Returns: Usage was successfully deleted.
 func (c *Client) RemoveUsage(usageId string) (*Empty, error) {
-	path := c.InterpolatePath("/usage/{usage_id}", usageId)
+	path, err := c.InterpolatePath("/usage/{usage_id}", usageId)
+	if err != nil {
+		return nil, err
+	}
 	result := &Empty{}
-	err := c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(http.MethodDelete, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
-=======
-	return &CouponRedemptionList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
 }
 
 type ListTransactionsParams struct {
@@ -4843,15 +4687,7 @@ func (c *Client) ListTransactions(params *ListTransactionsParams) (*TransactionL
 		return nil, err
 	}
 	path = BuildUrl(path, params)
-<<<<<<< HEAD
-	return NewTransactionList(c, path)
-=======
-	return &TransactionList{
-		client:       c,
-		nextPagePath: path,
-		HasMore:      true,
-	}, nil
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+	return NewTransactionList(c, path), nil
 }
 
 // GetTransaction Fetch a transaction

--- a/client_operations_test.go
+++ b/client_operations_test.go
@@ -64,7 +64,8 @@ func TestListAccounts(test *testing.T) {
 		Order: String("desc"),
 		Limit: Int(1),
 	}
-	accounts := client.ListAccounts(params)
+	accounts, err := client.ListAccounts(params)
+	t.Assert(err, nil, "Error not expected")
 	accounts.Fetch()
 
 	t.Assert(accounts.Data[0].Id, "abcd1234", "list.Data[0].Id")

--- a/client_test.go
+++ b/client_test.go
@@ -17,7 +17,7 @@ func TestEncodePathParameters(test *testing.T) {
 		},
 		MakeResponse: func(req *http.Request) *http.Response {
 			// default headers set, we may want to customize though
-			return mockResponse(req, 200, `{"id": "abcd1234"}`)
+			return mockResponse(req, 200, String(`{"id": "abcd1234"}`))
 		},
 	}
 	client := scenario.MockHTTPClient()
@@ -39,7 +39,7 @@ func TestValidatePathParameters(test *testing.T) {
 		},
 		MakeResponse: func(req *http.Request) *http.Response {
 			// default headers set, we may want to customize though
-			return mockResponse(req, 200, `{"id": "abcd1234"}`)
+			return mockResponse(req, 200, String(`{"id": "abcd1234"}`))
 		},
 	}
 	client := scenario.MockHTTPClient()

--- a/client_test.go
+++ b/client_test.go
@@ -5,6 +5,49 @@ import (
 	"testing"
 )
 
+func TestEncodePathParameters(test *testing.T) {
+	t := &T{test}
+
+	scenario := &Scenario{
+		T: t,
+		AssertRequest: func(req *http.Request) {
+			t.Assert(req.Method, http.MethodGet, "HTTP Method")
+			t.Assert(req.URL.String(), "https://v3.recurly.com/resources/%2F", "Request URL")
+			// assert headers and other request properties
+		},
+		MakeResponse: func(req *http.Request) *http.Response {
+			// default headers set, we may want to customize though
+			return mockResponse(req, 200, `{"id": "abcd1234"}`)
+		},
+	}
+	client := scenario.MockHTTPClient()
+
+	resource, err := client.GetResource("/")
+	t.Assert(err, nil, "Error not expected")
+	t.Assert(resource.Id, "abcd1234", "resource.Id")
+}
+
+func TestValidatePathParameters(test *testing.T) {
+	t := &T{test}
+
+	scenario := &Scenario{
+		T: t,
+		AssertRequest: func(req *http.Request) {
+			t.Assert(req.Method, http.MethodGet, "HTTP Method")
+			t.Assert(req.URL.String(), "https://v3.recurly.com/resources/abcd1234", "Request URL")
+			// assert headers and other request properties
+		},
+		MakeResponse: func(req *http.Request) *http.Response {
+			// default headers set, we may want to customize though
+			return mockResponse(req, 200, `{"id": "abcd1234"}`)
+		},
+	}
+	client := scenario.MockHTTPClient()
+
+	_, err := client.GetResource("")
+	t.Assert(err.Error(), "Parameters cannot be empty strings", "err.Error()")
+}
+
 func TestGetResource200(test *testing.T) {
 	t := &T{test}
 

--- a/client_test.go
+++ b/client_test.go
@@ -45,7 +45,7 @@ func TestValidatePathParameters(test *testing.T) {
 	client := scenario.MockHTTPClient()
 
 	_, err := client.GetResource("")
-	t.Assert(err.Error(), "Parameters cannot be empty strings", "err.Error()")
+	t.Assert(err.Error(), "Operation parameters cannot be empty strings", "err.Error()")
 }
 
 func TestGetResource200(test *testing.T) {

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -353,11 +353,7 @@ paths:
           for (Site site : sites) {
               System.out.println(site.getSubdomain());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $sites = $client->listSites($params);
@@ -566,11 +562,7 @@ paths:
           for (Account acct : accounts) {
               System.out.println(acct.getCode());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = [
               'limit' => 200,
@@ -762,37 +754,6 @@ paths:
             puts "ValidationError: #{e.recurly_error.params}"
           end
       - lang: Java
-<<<<<<< HEAD
-=======
-        source: |
-          try {
-              AccountCreate accountReq = new AccountCreate();
-              Address address = new Address();
-
-              accountReq.setCode(accountCode);
-              accountReq.setFirstName("Aaron");
-              accountReq.setLastName("Du Monde");
-
-              address.setStreet1("900 Camp St.");
-              address.setCity("New Orleans");
-              address.setRegion("LA");
-              address.setCountry("US");
-              address.setPostalCode("70115");
-
-              accountReq.setAddress(address);
-
-              Account account = client.createAccount(accountReq);
-              System.out.println("Created account " + account.getCode());
-          } catch (ValidationException e) {
-              // If the request was not valid, you may want to tell your user
-              // why. You can find the invalid params and reasons in e.getError().getParams()
-              System.out.println("Failed validation: " + e.getError().getMessage());
-          } catch (ApiException e) {
-              // Use ApiException to catch a generic error from the API
-              System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
-          }
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               AccountCreate accountReq = new AccountCreate();
@@ -958,11 +919,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $account = $client->getAccount($account_id);
@@ -1118,11 +1075,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $account_update = [
@@ -1244,11 +1197,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $account = $client->deactivateAccount($account_id);
@@ -1361,11 +1310,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $acquisition = $client->getAccountAcquisition($account_id);
@@ -1637,11 +1582,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |-
           try {
               $client->removeAccountAcquisition($account_id);
@@ -1763,11 +1704,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $account = $client->reactivateAccount($account_id);
@@ -1884,11 +1821,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $balance = $client->getAccountBalance($account_id);
@@ -1985,19 +1918,6 @@ paths:
               Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
           }
       - lang: Ruby
-<<<<<<< HEAD
-=======
-        source: |
-          begin
-            billing = @client.get_billing_info(account_id: account_id)
-            puts "Got BillingInfo #{billing}"
-          rescue Recurly::Errors::NotFoundError
-            # If the resource was not found, you may want to alert the user or
-            # just return nil
-            puts "Resource Not Found"
-          end
-      - lang: Java
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           begin
             billing = @client.get_billing_info(account_id: account_id)
@@ -2020,11 +1940,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $binfo = $client->getBillingInfo($account_id);
@@ -2194,11 +2110,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $binfo_update = [
@@ -2314,11 +2226,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |-
           try {
               $client->removeBillingInfo($account_id);
@@ -2374,7 +2282,6 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
-<<<<<<< HEAD
       - lang: Node.js
         source: |
           const redemptions = client.listAccountCouponRedemptions(accountId, { limit: 200 })
@@ -2382,14 +2289,11 @@ paths:
           for await (const redemption of redemptions.each()) {
             console.log(redemption.id)
           }
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Python
         source: |
           redemptions = client.list_account_coupon_redemptions(account_id, limit=200).items()
           for redemption in redemptions:
               print(redemption.id)
-<<<<<<< HEAD
       - lang: ".NET"
         source: |
           var redemptions = client.ListAccountCouponRedemptions(accountId);
@@ -2397,8 +2301,6 @@ paths:
           {
               Console.WriteLine(redemption.Id);
           }
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           redemptions = @client.list_account_coupon_redemptions(
@@ -2417,11 +2319,7 @@ paths:
           for (CouponRedemption redemption : redemptions) {
               System.out.println(redemption.getId());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $account_coupon_redemptions = $client->listAccountCouponRedemptions($account->getId(), $params);
@@ -2468,34 +2366,6 @@ paths:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
       - lang: Node.js
-<<<<<<< HEAD
-=======
-        source: |
-          try {
-            const redemption = await client.getActiveCouponRedemption(accountId)
-            console.log('Fetched coupon redemption: ', redemption.id)
-          } catch (err) {
-            if (err instanceof recurly.errors.NotFoundError) {
-              // If the request was not found, you may want to alert the user or
-              // just return null
-              console.log('Resource Not Found')
-            } else {
-              // If we don't know what to do with the err, we should
-              // probably re-raise and let our web framework and logger handle it
-              console.log('Unknown Error: ', err)
-            }
-          }
-      - lang: Python
-        source: |
-          try:
-              redemption = client.get_active_coupon_redemption(account_id)
-              print("Got Redemption %s" % redemption)
-          except recurly.errors.NotFoundError:
-              # If the resource was not found, you may want to alert the user or
-              # just return nil
-              print("Resource Not Found")
-      - lang: ".NET"
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
             const redemption = await client.getActiveCouponRedemption(accountId)
@@ -2561,11 +2431,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $redemption = $client->getActiveCouponRedemption($account_id);
@@ -2639,7 +2505,6 @@ paths:
               # why. You can find the invalid params and reasons in e.error.params
               print("ValidationError: %s" % e.error.message)
               print(e.error.params)
-<<<<<<< HEAD
       - lang: ".NET"
         source: |-
           try {
@@ -2661,8 +2526,6 @@ paths:
               // Use ApiError to catch a generic error from the API
               Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
           }
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           begin
@@ -2696,11 +2559,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |-
           try {
               $redemption_create = [
@@ -2755,30 +2614,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
-<<<<<<< HEAD
       - lang: Node.js
-=======
-      - lang: Python
-        source: |
-          try:
-              client.remove_coupon_redemption(account_id)
-              print("Removed Redemption from Account id=%s" % account_id)
-          except recurly.errors.NotFoundError:
-              # If the resource was not found, you may want to alert the user or
-              # just return nil
-              print("Resource Not Found")
-      - lang: Ruby
-        source: |
-          begin
-            @client.remove_coupon_redemption(account_id: account_id)
-            puts "Removed CouponRedemption #{account_id}"
-          rescue Recurly::Errors::NotFoundError
-            # If the resource was not found, you may want to alert the user or
-            # just return nil
-            puts "Resource Not Found"
-          end
-      - lang: Java
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
             const redemption = await client.removeCouponRedemption(accountId)
@@ -2820,7 +2656,6 @@ paths:
               // Use ApiError to catch a generic error from the API
               Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
           }
-<<<<<<< HEAD
       - lang: Ruby
         source: |
           begin
@@ -2845,9 +2680,6 @@ paths:
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |-
           try {
               $redemption = $client->removeCouponRedemption($account_id);
@@ -2948,11 +2780,7 @@ paths:
           for (CreditPayment payment : payments) {
               System.out.println(payment.getUuid());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $credit_payments = $client->listAccountCreditPayments($account->getId(), $params);
@@ -3013,7 +2841,6 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
-<<<<<<< HEAD
       - lang: Node.js
         source: |
           const invoices = client.listAccountInvoices(accountId, { limit: 200 })
@@ -3033,13 +2860,6 @@ paths:
           {
               Console.WriteLine(invoice.Id);
           }
-=======
-      - lang: Python
-        source: |
-          invoices = client.list_account_invoices(account_id, limit=200).items()
-          for invoice in invoices:
-              print(invoice.number)
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           invoices = @client.list_account_invoices(
@@ -3058,11 +2878,7 @@ paths:
           for (Invoice invoice : invoices) {
               System.out.println(invoice.getNumber());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 10];
           $invoices = $client->listAccountInvoices($account->getId(), $params);
@@ -3219,11 +3035,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |-
           try {
               $invoice_create = [
@@ -3394,11 +3206,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |-
           try {
               $invoice_preview = [
@@ -3474,7 +3282,6 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
-<<<<<<< HEAD
       - lang: Node.js
         source: |
           const lineItems = client.listAccountLineItems(accountId, { limit: 200 })
@@ -3494,13 +3301,6 @@ paths:
           {
               Console.WriteLine(lineItem.Id);
           }
-=======
-      - lang: Python
-        source: |
-          line_items = client.list_account_line_items(account_id, limit=200).items()
-          for line_item in line_items:
-              print(line_item.id)
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           line_items = @client.list_account_line_items(
@@ -3519,11 +3319,7 @@ paths:
           for (LineItem lineItem : lineItems) {
               System.out.println(lineItem.getId());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $account_line_items = $client->listAccountLineItems($account_id, $params);
@@ -3677,11 +3473,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |-
           try {
               $line_item_create = [
@@ -3779,11 +3571,7 @@ paths:
           for (AccountNote note : notes) {
               System.out.println(note.getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $account_notes = $client->listAccountNotes($account_id, $params);
@@ -3904,11 +3692,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $note = $client->getAccountNote($account_id, $account_node_id);
@@ -4005,7 +3789,6 @@ paths:
           for (ShippingAddress address : addresses) {
               System.out.println(address.getStreet1());
           }
-<<<<<<< HEAD
       - lang: PHP
         source: |
           $params = ['limit' => 200];
@@ -4014,8 +3797,6 @@ paths:
           foreach($shippingAddresses as $address) {
             echo 'Shipping Address: ' . $address->getId() . PHP_EOL;
           }
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Go
         source: "listParams := &recurly.ListShippingAddressesParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
           recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\nshippingAddresses
@@ -4264,13 +4045,8 @@ paths:
       - lang: Python
         source: |
           try:
-<<<<<<< HEAD
               client.get_shipping_address(account_id, shipping_address_id)
               print("Got ShippingAddress %s" % shipping_address_id)
-=======
-              subscription = client.get_subscription(subscription_id)
-              print("Got Subscription %s" % subscription)
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
           except recurly.errors.NotFoundError:
               # If the resource was not found, you may want to alert the user or
               # just return nil
@@ -4319,11 +4095,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $shipping_address = $client->getShippingAddress($account_id, $shipping_address_id);
@@ -4473,8 +4245,6 @@ paths:
             puts "ValidationError: #{e.recurly_error.params}"
           end
       - lang: Java
-<<<<<<< HEAD
-=======
         source: |
           try {
               final ShippingAddressUpdate shadUpdate = new ShippingAddressUpdate();
@@ -4491,25 +4261,6 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
-        source: |
-          try {
-              final ShippingAddressUpdate shadUpdate = new ShippingAddressUpdate();
-              shadUpdate.setFirstName("Aaron");
-              shadUpdate.setLastName("Du Monde");
-
-              final ShippingAddress address = client.updateShippingAddress(accountId, shippingAddressId, shadUpdate);
-              System.out.println("Updated shipping address " + address.getStreet1());
-          } catch (ValidationException e) {
-              // If the request was not valid, you may want to tell your user
-              // why. You can find the invalid params and reasons in e.getError().getParams()
-              System.out.println("Failed validation: " + e.getError().getMessage());
-          } catch (ApiException e) {
-              // Use ApiException to catch a generic error from the API
-              System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
-          }
-<<<<<<< HEAD
       - lang: PHP
         source: |
           try {
@@ -4530,8 +4281,6 @@ paths:
               // probably re-raise and let our web framework and logger handle it
               var_dump($e);
           }
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Go
         source: "updateReq := &recurly.ShippingAddressUpdate{\n\tFirstName: recurly.String(\"Joanna\"),\n\tLastName:
           \ recurly.String(\"DuMonde\"),\n}\nshippingAddress, err := client.UpdateShippingAddress(accountID,
@@ -4629,11 +4378,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |-
           try {
               $client->removeShippingAddress($account_id, $shipping_address_id);
@@ -4698,7 +4443,6 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
-<<<<<<< HEAD
       - lang: Node.js
         source: |
           const subscriptions = client.listAccountSubscriptions(accountId, { limit: 200 })
@@ -4717,13 +4461,6 @@ paths:
           foreach(Subscription subscription in subscriptions) {
             Console.WriteLine(subscription.Id);
           }
-=======
-      - lang: Python
-        source: |
-          subscriptions = client.list_account_subscriptions(account.id, limit=200).items()
-          for subscription in subscriptions:
-              print(subscription.uuid)
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           subscriptions = @client.list_account_subscriptions(
@@ -4742,11 +4479,7 @@ paths:
           for (Subscription subscription : subscriptions) {
               System.out.println(subscription.getUuid());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $account_subscriptions = $client->listAccountSubscriptions($account_id, $params);
@@ -4808,7 +4541,6 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
-<<<<<<< HEAD
       - lang: Node.js
         source: |
           const transactions = client.listAccountTransactions(accountId, { limit: 200 })
@@ -4828,8 +4560,6 @@ paths:
           {
               Console.WriteLine(transaction.Id);
           }
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           transactions = @client.list_account_transactions(
@@ -4848,11 +4578,7 @@ paths:
           for (Transaction transaction : transactions) {
               System.out.println(transaction.getUuid());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $account_transactions = $client->listAccountTransactions($account_id, $params);
@@ -4985,7 +4711,6 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
-<<<<<<< HEAD
       - lang: Node.js
         source: |
           const acquisitions = client.listAccountAcquisition({ limit: 200 })
@@ -4993,14 +4718,11 @@ paths:
           for await (const acquisition of acquisitions.each()) {
             console.log(acquisition.id)
           }
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Python
         source: |
           acquisitions = client.list_account_acquisition(limit=200).items()
           for acquisition in acquisitions:
               print(acquisition.id)
-<<<<<<< HEAD
       - lang: ".NET"
         source: |
           var acquisitions = client.ListAccountAcquisition();
@@ -5008,8 +4730,6 @@ paths:
           {
               Console.WriteLine(acquisition.Id);
           }
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           acquisitions = @client.list_account_acquisition(limit: 200)
@@ -5117,11 +4837,7 @@ paths:
           for (Coupon coupon : coupons) {
               System.out.println(coupon.getCode());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $coupons = $client->listCoupons($params);
@@ -5180,50 +4896,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
-<<<<<<< HEAD
       - lang: Node.js
-=======
-      - lang: Python
-        source: |
-          try:
-              coupon_create = {
-                  "name": "Promotional Coupon",
-                  "code": coupon_code,
-                  "discount_type": "fixed",
-                  "currencies": [{"currency": "USD", "discount": 10000}],
-              }
-              coupon = client.create_coupon(coupon_create)
-              print("Created Coupon %s" % coupon)
-          except recurly.errors.ValidationError as e:
-              # If the request was invalid, you may want to tell your user
-              # why. You can find the invalid params and reasons in e.error.params
-              print("ValidationError: %s" % e.error.message)
-              print(e.error.params)
-      - lang: Ruby
-        source: |
-          begin
-            coupon_create = {
-              name: "Promotional Coupon",
-              code: coupon_code,
-              discount_type: 'fixed',
-              currencies: [
-                {
-                  currency: 'USD',
-                  discount: 10_000
-                }
-              ]
-            }
-            coupon = @client.create_coupon(
-              body: coupon_create
-            )
-            puts "Created Coupon #{coupon}"
-          rescue Recurly::Errors::ValidationError => e
-            # If the request was invalid, you may want to tell your user
-            # why. You can find the invalid params and reasons in e.recurly_error.params
-            puts "ValidationError: #{e.recurly_error.params}"
-          end
-      - lang: Java
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
             const couponCreate = {
@@ -5291,7 +4964,6 @@ paths:
               // Use ApiError to catch a generic error from the API
               Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
           }
-<<<<<<< HEAD
       - lang: Ruby
         source: |
           begin
@@ -5342,9 +5014,6 @@ paths:
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $coupon_create = [
@@ -5475,11 +5144,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $coupon = $client->getCoupon($coupon_id);
@@ -5750,11 +5415,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $coupon = $client->deactivateCoupon($coupon_id);
@@ -5900,14 +5561,11 @@ paths:
           for await (const payment of payments.each()) {
             console.log(payment.uuid)
           }
-<<<<<<< HEAD
       - lang: Python
         source: |
           payments = client.list_credit_payments(limit=200).items()
           for payment in payments:
               print("Credit Payment %s" % payment.id)
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: ".NET"
         source: |
           var payments = client.ListCreditPayments(limit: 200);
@@ -5930,11 +5588,7 @@ paths:
           for (CreditPayment payment : payments) {
               System.out.println(payment.getUuid());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $credit_payments = $client->listCreditPayments($params);
@@ -6063,11 +5717,7 @@ paths:
           for (CustomFieldDefinition field : fields) {
               System.out.println(field.getDisplayName());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $custom_field_definitions = $client->listCustomFieldDefinitions($params);
@@ -6128,7 +5778,6 @@ paths:
               console.log('Unknown Error: ', err)
             }
           }
-<<<<<<< HEAD
       - lang: Python
         source: |
           try:
@@ -6136,8 +5785,6 @@ paths:
               print("Custom Field Definition %s" % custom_field_definition)
           except recurly.errors.NotFoundError as e:
               print("Invoice not found")
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: ".NET"
         source: |
           try
@@ -6280,11 +5927,7 @@ paths:
           for (Item item : items) {
               System.out.println(item.getCode());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $items = $client->listItems($params);
@@ -6344,59 +5987,6 @@ paths:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
       - lang: Node.js
-<<<<<<< HEAD
-=======
-        source: |
-          try {
-            const itemCreate = {
-              code: itemCode,
-              name: "Item Name",
-              description: "Item Description",
-              external_sku: "a35JE-44",
-              accounting_code: "item-code-127",
-              revenue_schedule_type: "at_range_end",
-              custom_fields: [{
-                name: "custom-field-1",
-                value: "Custom Field 1 value"
-              }]
-            }
-            const item = await client.createItem(itemCreate)
-            console.log('Created Item: ', item.code)
-          } catch (err) {
-            if (err instanceof recurly.errors.ValidationError) {
-              // If the request was not valid, you may want to tell your user
-              // why. You can find the invalid params and reasons in err.params
-              console.log('Failed validation', err.params)
-            } else {
-              // If we don't know what to do with the err, we should
-              // probably re-raise and let our web framework and logger handle it
-              console.log('Unknown Error: ', err)
-            }
-          }
-      - lang: Python
-        source: |
-          try:
-              item_create = {
-                  "code": item_code,
-                  "name": "Item Name",
-                  "description": "Item Description",
-                  "external_sku": "a35JE-44",
-                  "accounting_code": "item-code-127",
-                  "revenue_schedule_type": "at_range_end",
-                  "custom_fields": [{
-                      "name": "custom-field-1",
-                      "value": "Custom Field 1 value"
-                  }]
-              }
-              item = client.create_item(item_create)
-              print("Created Item %s" % item)
-          except recurly.errors.ValidationError as e:
-              # If the request was invalid, you may want to tell your user
-              # why. You can find the invalid params and reasons in e.error.params
-              print("ValidationError: %s" % e.error.message)
-              print(e.error.params)
-      - lang: ".NET"
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
             const itemCreate = {
@@ -6532,11 +6122,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $item_create = [
@@ -6662,11 +6248,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $item = $client->getItem($item_id);
@@ -6735,43 +6317,6 @@ paths:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
       - lang: Node.js
-<<<<<<< HEAD
-=======
-        source: |
-          try {
-            const itemUpdate = {
-              name: 'New Item Name',
-              description: 'New Item Description'
-            }
-            const item = await client.updateItem(itemId, itemUpdate)
-            console.log('Updated item: ', item)
-          } catch (err) {
-            if (err instanceof recurly.errors.ValidationError) {
-              // If the request was not valid, you may want to tell your user
-              // why. You can find the invalid params and reasons in err.params
-              console.log('Failed validation', err.params)
-            } else {
-              // If we don't know what to do with the err, we should
-              // probably re-raise and let our web framework and logger handle it
-              console.log('Unknown Error: ', err)
-            }
-          }
-      - lang: Python
-        source: |
-          try:
-              item_update = {
-                  "name": "New Item Name",
-                  "description": "New Item Description",
-              }
-              item = client.update_item(item_id, item_update)
-              print("Updated Item %s" % item)
-          except recurly.errors.ValidationError as e:
-              # If the request was invalid, you may want to tell your user
-              # why. You can find the invalid params and reasons in e.error.params
-              print("ValidationError: %s" % e.error.message)
-              print(e.error.params)
-      - lang: ".NET"
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
             const itemUpdate = {
@@ -6864,11 +6409,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $item_update = [
@@ -6991,11 +6532,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $item = $client->deactivateItem($item_id);
@@ -7119,11 +6656,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $item = $client->reactivateItem($item_id);
@@ -7145,11 +6678,7 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Reactivated
           Item: %s\", item.Id)"
-<<<<<<< HEAD
   "/sites/{site_id}/measured_units":
-=======
-  "/sites/{site_id}/invoices":
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
     get:
       tags:
       - measured_unit
@@ -7412,11 +6941,7 @@ paths:
           for (Invoice invoice : invoices) {
               System.out.println(invoice.getNumber());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => '200'];
           $invoices = $client->listInvoices($params);
@@ -7525,11 +7050,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $invoice = $client->getInvoice($invoice_id);
@@ -7607,7 +7128,6 @@ paths:
               console.log('Unknown Error: ', err)
             }
           }
-<<<<<<< HEAD
       - lang: Python
         source: |
           try:
@@ -7621,8 +7141,6 @@ paths:
               # If the resource was not found, you may want to alert the user or
               # just return nil
               print("Resource Not Found")
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: ".NET"
         source: |
           try
@@ -7677,7 +7195,6 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
         source: |
           try {
@@ -7698,8 +7215,6 @@ paths:
               // probably re-raise and let our web framework and logger handle it
               var_dump($e);
           }
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Go
         source: "updateReq := &recurly.InvoiceUpdatable{\n\tCustomerNotes:      recurly.String(\"New
           Notes\"),\n\tTermsAndConditions: recurly.String(\"New Terms and Conditions\"),\n}\ninvoice,
@@ -7828,11 +7343,7 @@ paths:
           } catch (java.io.IOException e) {
               System.out.println("Unexpected File Writing Error: " + e.toString());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $invoice = $client->getInvoicePdf($invoice_id);
@@ -7958,11 +7469,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $invoice = $client->collectInvoice($invoice_id);
@@ -8025,53 +7532,6 @@ paths:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
       - lang: Node.js
-<<<<<<< HEAD
-=======
-        source: |
-          try {
-            const invoice = await client.failInvoice(invoiceId)
-            console.log('Failed invoice: ', invoice.number)
-          } catch (err) {
-            if (err instanceof recurly.errors.ValidationError) {
-              // If the request was not valid, you may want to tell your user
-              // why. You can find the invalid params and reasons in err.params
-              console.log('Failed validation', err.params)
-            } else {
-              // If we don't know what to do with the err, we should
-              // probably re-raise and let our web framework and logger handle it
-              console.log('Unknown Error: ', err)
-            }
-          }
-      - lang: ".NET"
-        source: |
-          try
-          {
-              Invoice invoice = client.FailInvoice(invoiceId);
-              Console.WriteLine($"Failed invoice #{invoice.Number}");
-          }
-          catch (Recurly.Errors.Validation ex)
-          {
-              // If the request was not valid, you may want to tell your user
-              // why. You can find the invalid params and reasons in ex.Error.Params
-              Console.WriteLine($"Failed validation: {ex.Error.Message}");
-          }
-          catch (Recurly.Errors.ApiError ex)
-          {
-              // Use ApiError to catch a generic error from the API
-              Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
-          }
-      - lang: Ruby
-        source: |
-          begin
-            invoice = @client.fail_invoice(invoice_id: invoice_id)
-            puts "Failed invoice #{invoice}"
-          rescue Recurly::Errors::NotFoundError
-            # If the resource was not found, you may want to alert the user or
-            # just return nil
-            puts "Resource Not Found"
-          end
-      - lang: Java
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
             const invoice = await client.failInvoice(invoiceId)
@@ -8114,7 +7574,6 @@ paths:
               // Use ApiError to catch a generic error from the API
               Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
           }
-<<<<<<< HEAD
       - lang: Ruby
         source: |
           begin
@@ -8139,9 +7598,6 @@ paths:
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $invoice = $client->failInvoice($invoice_id);
@@ -8270,11 +7726,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $invoice = $client->markInvoiceSuccessful($invoice_id);
@@ -8348,7 +7800,6 @@ paths:
               console.log('Unknown Error: ', err)
             }
           }
-<<<<<<< HEAD
       - lang: Python
         source: |
           try:
@@ -8358,8 +7809,6 @@ paths:
               # If the resource was not found, you may want to alert the user or
               # just return nil
               print("Resource Not Found")
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: ".NET"
         source: |
           try
@@ -8401,11 +7850,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $invoice = $client->reopenInvoice($invoice_id);
@@ -8534,13 +7979,8 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Voided Invoice:
           %v\", invoice)"
-<<<<<<< HEAD
   "/sites/{site_id}/invoices/{invoice_id}/transactions":
     post:
-=======
-  "/sites/{site_id}/invoices/{invoice_id}/line_items":
-    get:
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       tags:
       - invoice
       operationId: record_external_transaction
@@ -8743,7 +8183,6 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
-<<<<<<< HEAD
       - lang: Node.js
         source: |
           const redemptions = client.listInvoiceCouponRedemptions(invoiceId, { limit: 200 })
@@ -8768,8 +8207,6 @@ paths:
           {
               Console.WriteLine(redemption.Id);
           }
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           coupon_redemptions = @client.list_invoice_coupon_redemptions(
@@ -8788,11 +8225,7 @@ paths:
           for (CouponRedemption redemption : redemptions) {
               System.out.println(redemption.getId());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $invoice_coupon_redemptions = $client->listInvoiceCouponRedemptions($invoice_id, $params);
@@ -8850,7 +8283,6 @@ paths:
           for await (const invoice of invoices.each()) {
             console.log(invoice.number)
           }
-<<<<<<< HEAD
       - lang: Python
         source: |
           try:
@@ -8861,8 +8293,6 @@ paths:
               # If the resource was not found, you may want to alert the user or
               # just return nil
               print("Resource Not Found")
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: ".NET"
         source: |
           var invoices = client.ListRelatedInvoices(invoiceId);
@@ -9037,11 +8467,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $refund = [
@@ -9259,11 +8685,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $line_item = $client->getLineItem($line_item_id);
@@ -9383,11 +8805,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $client->removeLineItem($line_item_id);
@@ -9484,11 +8902,7 @@ paths:
           for (Plan plan : plans) {
               System.out.println(plan.getCode());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $plans = $client->listPlans($params);
@@ -9664,11 +9078,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $plan_create = [
@@ -9799,11 +9209,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $plan = $client->getPlan($plan_id);
@@ -9884,7 +9290,6 @@ paths:
               console.log('Unknown Error: ', err)
             }
           }
-<<<<<<< HEAD
       - lang: Python
         source: |
           try:
@@ -9897,8 +9302,6 @@ paths:
               # If the resource was not found, you may want to alert the user or
               # just return nil
               print("Resource Not Found")
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: ".NET"
         source: |
           try
@@ -10013,7 +9416,6 @@ paths:
               console.log('Unknown Error: ', err)
             }
           }
-<<<<<<< HEAD
       - lang: Python
         source: |
           try:
@@ -10023,8 +9425,6 @@ paths:
               # If the resource was not found, you may want to alert the user or
               # just return nil
               print("Resource Not Found")
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: ".NET"
         source: |
           try
@@ -10131,7 +9531,6 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
-<<<<<<< HEAD
       - lang: Node.js
         source: |
           const addOns = client.listPlanAddOns(planId, { limit: 200 })
@@ -10151,13 +9550,6 @@ paths:
           {
               Console.WriteLine(addOn.Code);
           }
-=======
-      - lang: Python
-        source: |
-          add_ons = client.list_plan_add_ons(plan_id).items()
-          for add_on in add_ons:
-              print(add_on.code)
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           add_ons = @client.list_plan_add_ons(
@@ -10176,11 +9568,7 @@ paths:
           for (AddOn addOn : addOns) {
               System.out.println(addOn.getCode());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $plan_add_ons = $client->listPlanAddOns($plan_id, $params);
@@ -10236,7 +9624,6 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
-<<<<<<< HEAD
       - lang: Node.js
         source: |
           try {
@@ -10265,8 +9652,6 @@ paths:
               console.log('Unknown Error: ', err)
             }
           }
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Python
         source: |
           try:
@@ -10427,7 +9812,6 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
-<<<<<<< HEAD
       - lang: Node.js
         source: |
           try {
@@ -10449,13 +9833,6 @@ paths:
           try:
               add_on = client.get_plan_add_on(plan_id, add_on_id)
               print("Got Plan Add-On %s" % add_on)
-=======
-      - lang: Python
-        source: |
-          try:
-              shipping_addr = client.get_shipping_address(account_id, shipping_address_id)
-              print("Got ShippingAddress %s" % shipping_addr)
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
           except recurly.errors.NotFoundError:
               # If the resource was not found, you may want to alert the user or
               # just return nil
@@ -10503,11 +9880,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $add_on = $client->getPlanAddOn($plan_id, $add_on_id);
@@ -10700,7 +10073,6 @@ paths:
       - lang: Node.js
         source: |
           try {
-<<<<<<< HEAD
             const addOn = await client.removePlanAddOn(planId, addOnId)
             console.log('Removed plan add-on: ', addOn)
           } catch (err) {
@@ -10762,8 +10134,6 @@ paths:
       - lang: PHP
         source: |
           try {
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
               $add_on = $client->removePlanAddOn($plan_id, $add_on_id);
 
               echo 'Removed Plan AddOn:' . PHP_EOL;
@@ -11087,7 +10457,6 @@ paths:
           ok {\n\t\tfmt.Printf(\"Failed to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor
           i, method := range shippingMethods.Data {\n\t\tfmt.Printf(\"Shipping Method
           %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\tmethod.Id,\n\t\t\tmethod.Code,\n\t\t)\n\t}\n}"
-<<<<<<< HEAD
     post:
       tags:
       - shipping_method
@@ -11133,8 +10502,6 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
   "/sites/{site_id}/shipping_methods/{id}":
     get:
       tags:
@@ -11216,7 +10583,6 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Error"
-<<<<<<< HEAD
       x-code-samples: []
     delete:
       tags:
@@ -11290,8 +10656,6 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Error"
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       x-code-samples:
       - lang: Node.js
         source: |
@@ -11327,11 +10691,7 @@ paths:
           for (Subscription subscription : subscriptions) {
               System.out.println(subscription.getUuid());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $subscriptions = $client->listSubscriptions($params);
@@ -11473,30 +10833,6 @@ paths:
             puts "ValidationError: #{e.recurly_error.params}"
           end
       - lang: Java
-<<<<<<< HEAD
-=======
-        source: |
-          try {
-              SubscriptionCreate subscriptionCreate = new SubscriptionCreate();
-              AccountCreate accountCreate = new AccountCreate();
-
-              accountCreate.setCode(accountCode);
-              subscriptionCreate.setCurrency("USD");
-              subscriptionCreate.setAccount(accountCreate);
-              subscriptionCreate.setPlanCode(planCode);
-
-              Subscription subscription = client.createSubscription(subscriptionCreate);
-              System.out.println("Created Subscription with Id: " + subscription.getUuid());
-          } catch (ValidationException e) {
-              // If the request was not valid, you may want to tell your user
-              // why. You can find the invalid params and reasons in e.getError().getParams()
-              System.out.println("Failed validation: " + e.getError().getMessage());
-          } catch (ApiException e) {
-              // Use ApiException to catch a generic error from the API
-              System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
-          }
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               SubscriptionCreate subscriptionCreate = new SubscriptionCreate();
@@ -11646,11 +10982,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $subscription = $client->getSubscription($subscription_id);
@@ -11791,11 +11123,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $changes = [
@@ -11952,11 +11280,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $subscription = $client->terminateSubscription($subscription_id);
@@ -12094,11 +11418,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $subscription = $client->cancelSubscription($subscription_id);
@@ -12178,7 +11498,6 @@ paths:
               console.log('Unknown Error: ', err)
             }
           }
-<<<<<<< HEAD
       - lang: Python
         source: |
           try:
@@ -12188,8 +11507,6 @@ paths:
               # If the resource was not found, you may want to alert the user or
               # just return nil
               print("Resource Not Found")
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: ".NET"
         source: |
           try
@@ -12233,11 +11550,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $subscription = $client->reactivateSubscription($subscription_id);
@@ -12307,7 +11620,6 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
-<<<<<<< HEAD
       - lang: Node.js
         source: |
           try {
@@ -12329,10 +11641,6 @@ paths:
           }
       - lang: Python
         source: |
-=======
-      - lang: Python
-        source: |
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
           try:
               sub_pause = {"remaining_pause_cycles": 10}
               subscription = client.pause_subscription(subscription_id, sub_pause)
@@ -12342,7 +11650,6 @@ paths:
               # why. You can find the invalid params and reasons in e.error.params
               print("ValidationError: %s" % e.error.message)
               print(e.error.params)
-<<<<<<< HEAD
       - lang: ".NET"
         source: |
           try
@@ -12364,8 +11671,6 @@ paths:
               // Use ApiError to catch a generic error from the API
               Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
           }
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           begin
@@ -12398,11 +11703,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $sub_pause = [ "remaining_pause_cycles" => 10 ];
@@ -12467,7 +11768,6 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
-<<<<<<< HEAD
       - lang: Node.js
         source: |
           try {
@@ -12484,8 +11784,6 @@ paths:
               console.log('Unknown Error: ', err)
             }
           }
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Python
         source: |
           try:
@@ -12496,7 +11794,6 @@ paths:
               # why. You can find the invalid params and reasons in e.error.params
               print("ValidationError: %s" % e.error.message)
               print(e.error.params)
-<<<<<<< HEAD
       - lang: ".NET"
         source: |
           try
@@ -12515,8 +11812,6 @@ paths:
               // Use ApiError to catch a generic error from the API
               Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
           }
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           begin
@@ -12649,34 +11944,6 @@ paths:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
       - lang: Node.js
-<<<<<<< HEAD
-=======
-        source: |
-          try {
-            const change = await client.getSubscriptionChange(subscriptionId)
-            console.log('Fetched subscription change: ', change.id)
-          } catch (err) {
-            if (err instanceof recurly.errors.NotFoundError) {
-              // If the request was not found, you may want to alert the user or
-              // just return null
-              console.log('Resource Not Found')
-            } else {
-              // If we don't know what to do with the err, we should
-              // probably re-raise and let our web framework and logger handle it
-              console.log('Unknown Error: ', err)
-            }
-          }
-      - lang: Python
-        source: |
-          try:
-              change = client.get_subscription_change(subscription_id)
-              print("Got SubscriptionChange %s" % change)
-          except recurly.errors.NotFoundError:
-              # If the resource was not found, you may want to alert the user or
-              # just return nil
-              print("Resource Not Found")
-      - lang: ".NET"
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
             const change = await client.getSubscriptionChange(subscriptionId)
@@ -12744,11 +12011,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $change = $client->getSubscriptionChange($subscription_id);
@@ -12903,11 +12166,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $change_create = [
@@ -13029,11 +12288,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $client->removeSubscriptionChange($subscription_id);
@@ -13053,7 +12308,6 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Removed Subscription
           Change: %v\", subscriptionChange)"
-<<<<<<< HEAD
   "/sites/{site_id}/subscriptions/{subscription_id}/change/preview":
     post:
       tags:
@@ -13099,8 +12353,6 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
   "/sites/{site_id}/subscriptions/{subscription_id}/invoices":
     get:
       tags:
@@ -13146,7 +12398,6 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
-<<<<<<< HEAD
       - lang: Node.js
         source: |
           const invoices = client.listSubscriptionInvoices(subscriptionId, { limit: 200 })
@@ -13166,13 +12417,6 @@ paths:
           {
               Console.WriteLine(invoice.Number);
           }
-=======
-      - lang: Python
-        source: |
-          invoices = client.list_subscription_invoices(subscription_id).items()
-          for invoice in invoices:
-              print(invoice.number)
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           invoices = @client.list_subscription_invoices(
@@ -13191,11 +12435,7 @@ paths:
           for (Invoice invoice : invoices) {
               System.out.println(invoice.getNumber());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $subscription_invoices = $client->listSubscriptionInvoices($subscription_id, $params);
@@ -13212,7 +12452,6 @@ paths:
           i, invoice := range subInvoices.Data {\n\t\tfmt.Printf(\"Subscription Invoice
           %3d: %s\\n\",\n\t\t\ti,\n\t\t\tinvoice.Id,\n\t\t)\n\t}\n}"
   "/sites/{site_id}/subscriptions/{subscription_id}/line_items":
-<<<<<<< HEAD
     get:
       tags:
       - subscription
@@ -13400,8 +12639,6 @@ paths:
           next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, redemption := range subCouponRedemptions.Data
           {\n\t\tfmt.Printf(\"Subscription Coupon Redemption %3d: %s\\n\",\n\t\t\ti,\n\t\t\tredemption.Id,\n\t\t)\n\t}\n}"
   "/sites/{site_id}/subscriptions/{subscription_id}/add_ons/{add_on_id}/usage":
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
     get:
       tags:
       - invoice
@@ -13579,53 +12816,8 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Error"
-<<<<<<< HEAD
       x-code-samples: []
     delete:
-=======
-      x-code-samples:
-      - lang: Python
-        source: |
-          line_items = client.list_subscription_line_items(subscription_id).items()
-          for line_item in line_items:
-              print(line_item.id)
-      - lang: Ruby
-        source: |
-          line_items = @client.list_subscription_line_items(
-            subscription_id: subscription_id,
-            limit: 200
-          )
-          line_items.each do |line_item|
-            puts "LineItem: #{line_item.id}"
-          end
-      - lang: Java
-        source: |
-          QueryParams params = new QueryParams();
-          params.setLimit(200); // Pull 200 records at a time
-          final Pager<LineItem> lineItems = client.listSubscriptionLineItems(subscriptionId, params);
-
-          for (LineItem lineItem : lineItems) {
-              System.out.println(lineItem.getId());
-          }
-      - lang: Php
-        source: |
-          $params = ['limit' => 200];
-          $subscription_line_items = $client->listSubscriptionLineItems($subscription_id, $params);
-
-          foreach($subscription_line_items as $line_item) {
-            echo 'Subscription Invoice: ' . $line_item->getId() . PHP_EOL;
-          }
-      - lang: Go
-        source: "listParams := &recurly.ListSubscriptionLineItemsParams{\n\tSort:
-          \ recurly.String(\"created_at\"),\n\tOrder: recurly.String(\"desc\"),\n\tLimit:
-          recurly.Int(200),\n}\nsubLineItems := client.ListSubscriptionLineItems(subID,
-          listParams)\n\nfor subLineItems.HasMore {\n\terr := subLineItems.Fetch()\n\tif
-          e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
-          next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, lineItem := range subLineItems.Data
-          {\n\t\tfmt.Printf(\"Subscription Line Item %3d: %s\\n\",\n\t\t\ti,\n\t\t\tlineItem.Id,\n\t\t)\n\t}\n}"
-  "/sites/{site_id}/subscriptions/{subscription_id}/coupon_redemptions":
-    get:
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       tags:
       - invoice
       - subscription
@@ -13662,49 +12854,7 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Error"
-<<<<<<< HEAD
       x-code-samples: []
-=======
-      x-code-samples:
-      - lang: Python
-        source: |
-          redemptions = client.list_subscription_coupon_redemptions(subscription_id).items()
-          for redemption in redemptions:
-              print(redemption.uuid)
-      - lang: Ruby
-        source: |
-          coupon_redemptions = @client.list_subscription_coupon_redemptions(
-            subscription_id: subscription_id,
-            limit: 200
-          )
-          coupon_redemptions.each do |redemption|
-            puts "CouponRedemption: #{redemption.id}"
-          end
-      - lang: Java
-        source: |
-          QueryParams params = new QueryParams();
-          params.setLimit(200); // Pull 200 records at a time
-          final Pager<CouponRedemption> redemptions = client.listSubscriptionCouponRedemptions(subscriptionId, params);
-
-          for (CouponRedemption redemption : redemptions) {
-              System.out.println(redemption.getId());
-          }
-      - lang: Php
-        source: |
-          $params = ['limit' => 200];
-          $subscription_coupon_redemptions = $client->listSubscriptionCouponRedemptions($subscription_id, $params);
-
-          foreach($subscription_coupon_redemptions as $redemption) {
-            echo 'Subscription Coupon Redemption: ' . $redemption->getId() . PHP_EOL;
-          }
-      - lang: Go
-        source: "listParams := &recurly.ListSubscriptionCouponRedemptionsParams{\n\tSort:
-          recurly.String(\"created_at\"),\n}\nsubCouponRedemptions := client.ListSubscriptionCouponRedemptions(subID,
-          listParams)\n\nfor subCouponRedemptions.HasMore {\n\terr := subCouponRedemptions.Fetch()\n\tif
-          e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
-          next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, redemption := range subCouponRedemptions.Data
-          {\n\t\tfmt.Printf(\"Subscription Coupon Redemption %3d: %s\\n\",\n\t\t\ti,\n\t\t\tredemption.Id,\n\t\t)\n\t}\n}"
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
   "/sites/{site_id}/transactions":
     get:
       tags:
@@ -13783,11 +12933,7 @@ paths:
           for (Transaction transaction : transactions) {
               System.out.println(transaction.getUuid());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $transactions = $client->listTransactions($params);
@@ -13847,7 +12993,6 @@ paths:
               console.log('Unknown Error: ', err)
             }
           }
-<<<<<<< HEAD
       - lang: Python
         source: |
           try:
@@ -13857,8 +13002,6 @@ paths:
               # If the resource was not found, you may want to alert the user or
               # just return nil
               print("Resource Not Found")
-=======
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: ".NET"
         source: |
           try
@@ -13900,11 +13043,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $transaction = $client->getTransaction($transaction_id);
@@ -14215,11 +13354,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
-<<<<<<< HEAD
       - lang: PHP
-=======
-      - lang: Php
->>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $purchase_create = [

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -353,7 +353,11 @@ paths:
           for (Site site : sites) {
               System.out.println(site.getSubdomain());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $sites = $client->listSites($params);
@@ -562,7 +566,11 @@ paths:
           for (Account acct : accounts) {
               System.out.println(acct.getCode());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = [
               'limit' => 200,
@@ -754,6 +762,37 @@ paths:
             puts "ValidationError: #{e.recurly_error.params}"
           end
       - lang: Java
+<<<<<<< HEAD
+=======
+        source: |
+          try {
+              AccountCreate accountReq = new AccountCreate();
+              Address address = new Address();
+
+              accountReq.setCode(accountCode);
+              accountReq.setFirstName("Aaron");
+              accountReq.setLastName("Du Monde");
+
+              address.setStreet1("900 Camp St.");
+              address.setCity("New Orleans");
+              address.setRegion("LA");
+              address.setCountry("US");
+              address.setPostalCode("70115");
+
+              accountReq.setAddress(address);
+
+              Account account = client.createAccount(accountReq);
+              System.out.println("Created account " + account.getCode());
+          } catch (ValidationException e) {
+              // If the request was not valid, you may want to tell your user
+              // why. You can find the invalid params and reasons in e.getError().getParams()
+              System.out.println("Failed validation: " + e.getError().getMessage());
+          } catch (ApiException e) {
+              // Use ApiException to catch a generic error from the API
+              System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+          }
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               AccountCreate accountReq = new AccountCreate();
@@ -919,7 +958,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $account = $client->getAccount($account_id);
@@ -1075,7 +1118,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $account_update = [
@@ -1197,7 +1244,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $account = $client->deactivateAccount($account_id);
@@ -1310,7 +1361,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $acquisition = $client->getAccountAcquisition($account_id);
@@ -1582,7 +1637,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |-
           try {
               $client->removeAccountAcquisition($account_id);
@@ -1704,7 +1763,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $account = $client->reactivateAccount($account_id);
@@ -1821,7 +1884,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $balance = $client->getAccountBalance($account_id);
@@ -1918,6 +1985,19 @@ paths:
               Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
           }
       - lang: Ruby
+<<<<<<< HEAD
+=======
+        source: |
+          begin
+            billing = @client.get_billing_info(account_id: account_id)
+            puts "Got BillingInfo #{billing}"
+          rescue Recurly::Errors::NotFoundError
+            # If the resource was not found, you may want to alert the user or
+            # just return nil
+            puts "Resource Not Found"
+          end
+      - lang: Java
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           begin
             billing = @client.get_billing_info(account_id: account_id)
@@ -1940,7 +2020,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $binfo = $client->getBillingInfo($account_id);
@@ -2110,7 +2194,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $binfo_update = [
@@ -2226,7 +2314,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |-
           try {
               $client->removeBillingInfo($account_id);
@@ -2282,6 +2374,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
+<<<<<<< HEAD
       - lang: Node.js
         source: |
           const redemptions = client.listAccountCouponRedemptions(accountId, { limit: 200 })
@@ -2289,11 +2382,14 @@ paths:
           for await (const redemption of redemptions.each()) {
             console.log(redemption.id)
           }
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Python
         source: |
           redemptions = client.list_account_coupon_redemptions(account_id, limit=200).items()
           for redemption in redemptions:
               print(redemption.id)
+<<<<<<< HEAD
       - lang: ".NET"
         source: |
           var redemptions = client.ListAccountCouponRedemptions(accountId);
@@ -2301,6 +2397,8 @@ paths:
           {
               Console.WriteLine(redemption.Id);
           }
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           redemptions = @client.list_account_coupon_redemptions(
@@ -2319,7 +2417,11 @@ paths:
           for (CouponRedemption redemption : redemptions) {
               System.out.println(redemption.getId());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $account_coupon_redemptions = $client->listAccountCouponRedemptions($account->getId(), $params);
@@ -2366,6 +2468,34 @@ paths:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
       - lang: Node.js
+<<<<<<< HEAD
+=======
+        source: |
+          try {
+            const redemption = await client.getActiveCouponRedemption(accountId)
+            console.log('Fetched coupon redemption: ', redemption.id)
+          } catch (err) {
+            if (err instanceof recurly.errors.NotFoundError) {
+              // If the request was not found, you may want to alert the user or
+              // just return null
+              console.log('Resource Not Found')
+            } else {
+              // If we don't know what to do with the err, we should
+              // probably re-raise and let our web framework and logger handle it
+              console.log('Unknown Error: ', err)
+            }
+          }
+      - lang: Python
+        source: |
+          try:
+              redemption = client.get_active_coupon_redemption(account_id)
+              print("Got Redemption %s" % redemption)
+          except recurly.errors.NotFoundError:
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              print("Resource Not Found")
+      - lang: ".NET"
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
             const redemption = await client.getActiveCouponRedemption(accountId)
@@ -2431,7 +2561,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $redemption = $client->getActiveCouponRedemption($account_id);
@@ -2505,6 +2639,7 @@ paths:
               # why. You can find the invalid params and reasons in e.error.params
               print("ValidationError: %s" % e.error.message)
               print(e.error.params)
+<<<<<<< HEAD
       - lang: ".NET"
         source: |-
           try {
@@ -2526,6 +2661,8 @@ paths:
               // Use ApiError to catch a generic error from the API
               Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
           }
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           begin
@@ -2559,7 +2696,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |-
           try {
               $redemption_create = [
@@ -2614,7 +2755,30 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
+<<<<<<< HEAD
       - lang: Node.js
+=======
+      - lang: Python
+        source: |
+          try:
+              client.remove_coupon_redemption(account_id)
+              print("Removed Redemption from Account id=%s" % account_id)
+          except recurly.errors.NotFoundError:
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              print("Resource Not Found")
+      - lang: Ruby
+        source: |
+          begin
+            @client.remove_coupon_redemption(account_id: account_id)
+            puts "Removed CouponRedemption #{account_id}"
+          rescue Recurly::Errors::NotFoundError
+            # If the resource was not found, you may want to alert the user or
+            # just return nil
+            puts "Resource Not Found"
+          end
+      - lang: Java
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
             const redemption = await client.removeCouponRedemption(accountId)
@@ -2656,6 +2820,7 @@ paths:
               // Use ApiError to catch a generic error from the API
               Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
           }
+<<<<<<< HEAD
       - lang: Ruby
         source: |
           begin
@@ -2680,6 +2845,9 @@ paths:
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |-
           try {
               $redemption = $client->removeCouponRedemption($account_id);
@@ -2780,7 +2948,11 @@ paths:
           for (CreditPayment payment : payments) {
               System.out.println(payment.getUuid());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $credit_payments = $client->listAccountCreditPayments($account->getId(), $params);
@@ -2841,6 +3013,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
+<<<<<<< HEAD
       - lang: Node.js
         source: |
           const invoices = client.listAccountInvoices(accountId, { limit: 200 })
@@ -2860,6 +3033,13 @@ paths:
           {
               Console.WriteLine(invoice.Id);
           }
+=======
+      - lang: Python
+        source: |
+          invoices = client.list_account_invoices(account_id, limit=200).items()
+          for invoice in invoices:
+              print(invoice.number)
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           invoices = @client.list_account_invoices(
@@ -2878,7 +3058,11 @@ paths:
           for (Invoice invoice : invoices) {
               System.out.println(invoice.getNumber());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 10];
           $invoices = $client->listAccountInvoices($account->getId(), $params);
@@ -3035,7 +3219,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |-
           try {
               $invoice_create = [
@@ -3206,7 +3394,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |-
           try {
               $invoice_preview = [
@@ -3282,6 +3474,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
+<<<<<<< HEAD
       - lang: Node.js
         source: |
           const lineItems = client.listAccountLineItems(accountId, { limit: 200 })
@@ -3301,6 +3494,13 @@ paths:
           {
               Console.WriteLine(lineItem.Id);
           }
+=======
+      - lang: Python
+        source: |
+          line_items = client.list_account_line_items(account_id, limit=200).items()
+          for line_item in line_items:
+              print(line_item.id)
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           line_items = @client.list_account_line_items(
@@ -3319,7 +3519,11 @@ paths:
           for (LineItem lineItem : lineItems) {
               System.out.println(lineItem.getId());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $account_line_items = $client->listAccountLineItems($account_id, $params);
@@ -3473,7 +3677,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |-
           try {
               $line_item_create = [
@@ -3571,7 +3779,11 @@ paths:
           for (AccountNote note : notes) {
               System.out.println(note.getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $account_notes = $client->listAccountNotes($account_id, $params);
@@ -3692,7 +3904,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $note = $client->getAccountNote($account_id, $account_node_id);
@@ -3789,6 +4005,7 @@ paths:
           for (ShippingAddress address : addresses) {
               System.out.println(address.getStreet1());
           }
+<<<<<<< HEAD
       - lang: PHP
         source: |
           $params = ['limit' => 200];
@@ -3797,6 +4014,8 @@ paths:
           foreach($shippingAddresses as $address) {
             echo 'Shipping Address: ' . $address->getId() . PHP_EOL;
           }
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Go
         source: "listParams := &recurly.ListShippingAddressesParams{\n\tSort:  recurly.String(\"created_at\"),\n\tOrder:
           recurly.String(\"desc\"),\n\tLimit: recurly.Int(200),\n}\nshippingAddresses
@@ -4045,8 +4264,13 @@ paths:
       - lang: Python
         source: |
           try:
+<<<<<<< HEAD
               client.get_shipping_address(account_id, shipping_address_id)
               print("Got ShippingAddress %s" % shipping_address_id)
+=======
+              subscription = client.get_subscription(subscription_id)
+              print("Got Subscription %s" % subscription)
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
           except recurly.errors.NotFoundError:
               # If the resource was not found, you may want to alert the user or
               # just return nil
@@ -4095,7 +4319,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $shipping_address = $client->getShippingAddress($account_id, $shipping_address_id);
@@ -4245,6 +4473,8 @@ paths:
             puts "ValidationError: #{e.recurly_error.params}"
           end
       - lang: Java
+<<<<<<< HEAD
+=======
         source: |
           try {
               final ShippingAddressUpdate shadUpdate = new ShippingAddressUpdate();
@@ -4261,6 +4491,25 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
+        source: |
+          try {
+              final ShippingAddressUpdate shadUpdate = new ShippingAddressUpdate();
+              shadUpdate.setFirstName("Aaron");
+              shadUpdate.setLastName("Du Monde");
+
+              final ShippingAddress address = client.updateShippingAddress(accountId, shippingAddressId, shadUpdate);
+              System.out.println("Updated shipping address " + address.getStreet1());
+          } catch (ValidationException e) {
+              // If the request was not valid, you may want to tell your user
+              // why. You can find the invalid params and reasons in e.getError().getParams()
+              System.out.println("Failed validation: " + e.getError().getMessage());
+          } catch (ApiException e) {
+              // Use ApiException to catch a generic error from the API
+              System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+          }
+<<<<<<< HEAD
       - lang: PHP
         source: |
           try {
@@ -4281,6 +4530,8 @@ paths:
               // probably re-raise and let our web framework and logger handle it
               var_dump($e);
           }
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Go
         source: "updateReq := &recurly.ShippingAddressUpdate{\n\tFirstName: recurly.String(\"Joanna\"),\n\tLastName:
           \ recurly.String(\"DuMonde\"),\n}\nshippingAddress, err := client.UpdateShippingAddress(accountID,
@@ -4378,7 +4629,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |-
           try {
               $client->removeShippingAddress($account_id, $shipping_address_id);
@@ -4443,6 +4698,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
+<<<<<<< HEAD
       - lang: Node.js
         source: |
           const subscriptions = client.listAccountSubscriptions(accountId, { limit: 200 })
@@ -4461,6 +4717,13 @@ paths:
           foreach(Subscription subscription in subscriptions) {
             Console.WriteLine(subscription.Id);
           }
+=======
+      - lang: Python
+        source: |
+          subscriptions = client.list_account_subscriptions(account.id, limit=200).items()
+          for subscription in subscriptions:
+              print(subscription.uuid)
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           subscriptions = @client.list_account_subscriptions(
@@ -4479,7 +4742,11 @@ paths:
           for (Subscription subscription : subscriptions) {
               System.out.println(subscription.getUuid());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $account_subscriptions = $client->listAccountSubscriptions($account_id, $params);
@@ -4541,6 +4808,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
+<<<<<<< HEAD
       - lang: Node.js
         source: |
           const transactions = client.listAccountTransactions(accountId, { limit: 200 })
@@ -4560,6 +4828,8 @@ paths:
           {
               Console.WriteLine(transaction.Id);
           }
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           transactions = @client.list_account_transactions(
@@ -4578,7 +4848,11 @@ paths:
           for (Transaction transaction : transactions) {
               System.out.println(transaction.getUuid());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $account_transactions = $client->listAccountTransactions($account_id, $params);
@@ -4711,6 +4985,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
+<<<<<<< HEAD
       - lang: Node.js
         source: |
           const acquisitions = client.listAccountAcquisition({ limit: 200 })
@@ -4718,11 +4993,14 @@ paths:
           for await (const acquisition of acquisitions.each()) {
             console.log(acquisition.id)
           }
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Python
         source: |
           acquisitions = client.list_account_acquisition(limit=200).items()
           for acquisition in acquisitions:
               print(acquisition.id)
+<<<<<<< HEAD
       - lang: ".NET"
         source: |
           var acquisitions = client.ListAccountAcquisition();
@@ -4730,6 +5008,8 @@ paths:
           {
               Console.WriteLine(acquisition.Id);
           }
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           acquisitions = @client.list_account_acquisition(limit: 200)
@@ -4837,7 +5117,11 @@ paths:
           for (Coupon coupon : coupons) {
               System.out.println(coupon.getCode());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $coupons = $client->listCoupons($params);
@@ -4896,7 +5180,50 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
+<<<<<<< HEAD
       - lang: Node.js
+=======
+      - lang: Python
+        source: |
+          try:
+              coupon_create = {
+                  "name": "Promotional Coupon",
+                  "code": coupon_code,
+                  "discount_type": "fixed",
+                  "currencies": [{"currency": "USD", "discount": 10000}],
+              }
+              coupon = client.create_coupon(coupon_create)
+              print("Created Coupon %s" % coupon)
+          except recurly.errors.ValidationError as e:
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.error.params
+              print("ValidationError: %s" % e.error.message)
+              print(e.error.params)
+      - lang: Ruby
+        source: |
+          begin
+            coupon_create = {
+              name: "Promotional Coupon",
+              code: coupon_code,
+              discount_type: 'fixed',
+              currencies: [
+                {
+                  currency: 'USD',
+                  discount: 10_000
+                }
+              ]
+            }
+            coupon = @client.create_coupon(
+              body: coupon_create
+            )
+            puts "Created Coupon #{coupon}"
+          rescue Recurly::Errors::ValidationError => e
+            # If the request was invalid, you may want to tell your user
+            # why. You can find the invalid params and reasons in e.recurly_error.params
+            puts "ValidationError: #{e.recurly_error.params}"
+          end
+      - lang: Java
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
             const couponCreate = {
@@ -4964,6 +5291,7 @@ paths:
               // Use ApiError to catch a generic error from the API
               Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
           }
+<<<<<<< HEAD
       - lang: Ruby
         source: |
           begin
@@ -5014,6 +5342,9 @@ paths:
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $coupon_create = [
@@ -5144,7 +5475,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $coupon = $client->getCoupon($coupon_id);
@@ -5415,7 +5750,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $coupon = $client->deactivateCoupon($coupon_id);
@@ -5561,11 +5900,14 @@ paths:
           for await (const payment of payments.each()) {
             console.log(payment.uuid)
           }
+<<<<<<< HEAD
       - lang: Python
         source: |
           payments = client.list_credit_payments(limit=200).items()
           for payment in payments:
               print("Credit Payment %s" % payment.id)
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: ".NET"
         source: |
           var payments = client.ListCreditPayments(limit: 200);
@@ -5588,7 +5930,11 @@ paths:
           for (CreditPayment payment : payments) {
               System.out.println(payment.getUuid());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $credit_payments = $client->listCreditPayments($params);
@@ -5717,7 +6063,11 @@ paths:
           for (CustomFieldDefinition field : fields) {
               System.out.println(field.getDisplayName());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $custom_field_definitions = $client->listCustomFieldDefinitions($params);
@@ -5778,6 +6128,7 @@ paths:
               console.log('Unknown Error: ', err)
             }
           }
+<<<<<<< HEAD
       - lang: Python
         source: |
           try:
@@ -5785,6 +6136,8 @@ paths:
               print("Custom Field Definition %s" % custom_field_definition)
           except recurly.errors.NotFoundError as e:
               print("Invoice not found")
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: ".NET"
         source: |
           try
@@ -5927,7 +6280,11 @@ paths:
           for (Item item : items) {
               System.out.println(item.getCode());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $items = $client->listItems($params);
@@ -5987,6 +6344,59 @@ paths:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
       - lang: Node.js
+<<<<<<< HEAD
+=======
+        source: |
+          try {
+            const itemCreate = {
+              code: itemCode,
+              name: "Item Name",
+              description: "Item Description",
+              external_sku: "a35JE-44",
+              accounting_code: "item-code-127",
+              revenue_schedule_type: "at_range_end",
+              custom_fields: [{
+                name: "custom-field-1",
+                value: "Custom Field 1 value"
+              }]
+            }
+            const item = await client.createItem(itemCreate)
+            console.log('Created Item: ', item.code)
+          } catch (err) {
+            if (err instanceof recurly.errors.ValidationError) {
+              // If the request was not valid, you may want to tell your user
+              // why. You can find the invalid params and reasons in err.params
+              console.log('Failed validation', err.params)
+            } else {
+              // If we don't know what to do with the err, we should
+              // probably re-raise and let our web framework and logger handle it
+              console.log('Unknown Error: ', err)
+            }
+          }
+      - lang: Python
+        source: |
+          try:
+              item_create = {
+                  "code": item_code,
+                  "name": "Item Name",
+                  "description": "Item Description",
+                  "external_sku": "a35JE-44",
+                  "accounting_code": "item-code-127",
+                  "revenue_schedule_type": "at_range_end",
+                  "custom_fields": [{
+                      "name": "custom-field-1",
+                      "value": "Custom Field 1 value"
+                  }]
+              }
+              item = client.create_item(item_create)
+              print("Created Item %s" % item)
+          except recurly.errors.ValidationError as e:
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.error.params
+              print("ValidationError: %s" % e.error.message)
+              print(e.error.params)
+      - lang: ".NET"
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
             const itemCreate = {
@@ -6122,7 +6532,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $item_create = [
@@ -6248,7 +6662,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $item = $client->getItem($item_id);
@@ -6317,6 +6735,43 @@ paths:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
       - lang: Node.js
+<<<<<<< HEAD
+=======
+        source: |
+          try {
+            const itemUpdate = {
+              name: 'New Item Name',
+              description: 'New Item Description'
+            }
+            const item = await client.updateItem(itemId, itemUpdate)
+            console.log('Updated item: ', item)
+          } catch (err) {
+            if (err instanceof recurly.errors.ValidationError) {
+              // If the request was not valid, you may want to tell your user
+              // why. You can find the invalid params and reasons in err.params
+              console.log('Failed validation', err.params)
+            } else {
+              // If we don't know what to do with the err, we should
+              // probably re-raise and let our web framework and logger handle it
+              console.log('Unknown Error: ', err)
+            }
+          }
+      - lang: Python
+        source: |
+          try:
+              item_update = {
+                  "name": "New Item Name",
+                  "description": "New Item Description",
+              }
+              item = client.update_item(item_id, item_update)
+              print("Updated Item %s" % item)
+          except recurly.errors.ValidationError as e:
+              # If the request was invalid, you may want to tell your user
+              # why. You can find the invalid params and reasons in e.error.params
+              print("ValidationError: %s" % e.error.message)
+              print(e.error.params)
+      - lang: ".NET"
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
             const itemUpdate = {
@@ -6409,7 +6864,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $item_update = [
@@ -6532,7 +6991,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $item = $client->deactivateItem($item_id);
@@ -6656,7 +7119,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $item = $client->reactivateItem($item_id);
@@ -6678,7 +7145,11 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Reactivated
           Item: %s\", item.Id)"
+<<<<<<< HEAD
   "/sites/{site_id}/measured_units":
+=======
+  "/sites/{site_id}/invoices":
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
     get:
       tags:
       - measured_unit
@@ -6941,7 +7412,11 @@ paths:
           for (Invoice invoice : invoices) {
               System.out.println(invoice.getNumber());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => '200'];
           $invoices = $client->listInvoices($params);
@@ -7050,7 +7525,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $invoice = $client->getInvoice($invoice_id);
@@ -7128,6 +7607,7 @@ paths:
               console.log('Unknown Error: ', err)
             }
           }
+<<<<<<< HEAD
       - lang: Python
         source: |
           try:
@@ -7141,6 +7621,8 @@ paths:
               # If the resource was not found, you may want to alert the user or
               # just return nil
               print("Resource Not Found")
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: ".NET"
         source: |
           try
@@ -7195,6 +7677,7 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
         source: |
           try {
@@ -7215,6 +7698,8 @@ paths:
               // probably re-raise and let our web framework and logger handle it
               var_dump($e);
           }
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Go
         source: "updateReq := &recurly.InvoiceUpdatable{\n\tCustomerNotes:      recurly.String(\"New
           Notes\"),\n\tTermsAndConditions: recurly.String(\"New Terms and Conditions\"),\n}\ninvoice,
@@ -7343,7 +7828,11 @@ paths:
           } catch (java.io.IOException e) {
               System.out.println("Unexpected File Writing Error: " + e.toString());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $invoice = $client->getInvoicePdf($invoice_id);
@@ -7469,7 +7958,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $invoice = $client->collectInvoice($invoice_id);
@@ -7532,6 +8025,53 @@ paths:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
       - lang: Node.js
+<<<<<<< HEAD
+=======
+        source: |
+          try {
+            const invoice = await client.failInvoice(invoiceId)
+            console.log('Failed invoice: ', invoice.number)
+          } catch (err) {
+            if (err instanceof recurly.errors.ValidationError) {
+              // If the request was not valid, you may want to tell your user
+              // why. You can find the invalid params and reasons in err.params
+              console.log('Failed validation', err.params)
+            } else {
+              // If we don't know what to do with the err, we should
+              // probably re-raise and let our web framework and logger handle it
+              console.log('Unknown Error: ', err)
+            }
+          }
+      - lang: ".NET"
+        source: |
+          try
+          {
+              Invoice invoice = client.FailInvoice(invoiceId);
+              Console.WriteLine($"Failed invoice #{invoice.Number}");
+          }
+          catch (Recurly.Errors.Validation ex)
+          {
+              // If the request was not valid, you may want to tell your user
+              // why. You can find the invalid params and reasons in ex.Error.Params
+              Console.WriteLine($"Failed validation: {ex.Error.Message}");
+          }
+          catch (Recurly.Errors.ApiError ex)
+          {
+              // Use ApiError to catch a generic error from the API
+              Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+          }
+      - lang: Ruby
+        source: |
+          begin
+            invoice = @client.fail_invoice(invoice_id: invoice_id)
+            puts "Failed invoice #{invoice}"
+          rescue Recurly::Errors::NotFoundError
+            # If the resource was not found, you may want to alert the user or
+            # just return nil
+            puts "Resource Not Found"
+          end
+      - lang: Java
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
             const invoice = await client.failInvoice(invoiceId)
@@ -7574,6 +8114,7 @@ paths:
               // Use ApiError to catch a generic error from the API
               Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
           }
+<<<<<<< HEAD
       - lang: Ruby
         source: |
           begin
@@ -7598,6 +8139,9 @@ paths:
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $invoice = $client->failInvoice($invoice_id);
@@ -7726,7 +8270,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $invoice = $client->markInvoiceSuccessful($invoice_id);
@@ -7800,6 +8348,7 @@ paths:
               console.log('Unknown Error: ', err)
             }
           }
+<<<<<<< HEAD
       - lang: Python
         source: |
           try:
@@ -7809,6 +8358,8 @@ paths:
               # If the resource was not found, you may want to alert the user or
               # just return nil
               print("Resource Not Found")
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: ".NET"
         source: |
           try
@@ -7850,7 +8401,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $invoice = $client->reopenInvoice($invoice_id);
@@ -7979,8 +8534,13 @@ paths:
           validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Voided Invoice:
           %v\", invoice)"
+<<<<<<< HEAD
   "/sites/{site_id}/invoices/{invoice_id}/transactions":
     post:
+=======
+  "/sites/{site_id}/invoices/{invoice_id}/line_items":
+    get:
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       tags:
       - invoice
       operationId: record_external_transaction
@@ -8183,6 +8743,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
+<<<<<<< HEAD
       - lang: Node.js
         source: |
           const redemptions = client.listInvoiceCouponRedemptions(invoiceId, { limit: 200 })
@@ -8207,6 +8768,8 @@ paths:
           {
               Console.WriteLine(redemption.Id);
           }
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           coupon_redemptions = @client.list_invoice_coupon_redemptions(
@@ -8225,7 +8788,11 @@ paths:
           for (CouponRedemption redemption : redemptions) {
               System.out.println(redemption.getId());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $invoice_coupon_redemptions = $client->listInvoiceCouponRedemptions($invoice_id, $params);
@@ -8283,6 +8850,7 @@ paths:
           for await (const invoice of invoices.each()) {
             console.log(invoice.number)
           }
+<<<<<<< HEAD
       - lang: Python
         source: |
           try:
@@ -8293,6 +8861,8 @@ paths:
               # If the resource was not found, you may want to alert the user or
               # just return nil
               print("Resource Not Found")
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: ".NET"
         source: |
           var invoices = client.ListRelatedInvoices(invoiceId);
@@ -8467,7 +9037,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $refund = [
@@ -8685,7 +9259,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $line_item = $client->getLineItem($line_item_id);
@@ -8805,7 +9383,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $client->removeLineItem($line_item_id);
@@ -8902,7 +9484,11 @@ paths:
           for (Plan plan : plans) {
               System.out.println(plan.getCode());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $plans = $client->listPlans($params);
@@ -9078,7 +9664,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $plan_create = [
@@ -9209,7 +9799,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $plan = $client->getPlan($plan_id);
@@ -9290,6 +9884,7 @@ paths:
               console.log('Unknown Error: ', err)
             }
           }
+<<<<<<< HEAD
       - lang: Python
         source: |
           try:
@@ -9302,6 +9897,8 @@ paths:
               # If the resource was not found, you may want to alert the user or
               # just return nil
               print("Resource Not Found")
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: ".NET"
         source: |
           try
@@ -9416,6 +10013,7 @@ paths:
               console.log('Unknown Error: ', err)
             }
           }
+<<<<<<< HEAD
       - lang: Python
         source: |
           try:
@@ -9425,6 +10023,8 @@ paths:
               # If the resource was not found, you may want to alert the user or
               # just return nil
               print("Resource Not Found")
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: ".NET"
         source: |
           try
@@ -9531,6 +10131,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
+<<<<<<< HEAD
       - lang: Node.js
         source: |
           const addOns = client.listPlanAddOns(planId, { limit: 200 })
@@ -9550,6 +10151,13 @@ paths:
           {
               Console.WriteLine(addOn.Code);
           }
+=======
+      - lang: Python
+        source: |
+          add_ons = client.list_plan_add_ons(plan_id).items()
+          for add_on in add_ons:
+              print(add_on.code)
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           add_ons = @client.list_plan_add_ons(
@@ -9568,7 +10176,11 @@ paths:
           for (AddOn addOn : addOns) {
               System.out.println(addOn.getCode());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $plan_add_ons = $client->listPlanAddOns($plan_id, $params);
@@ -9624,6 +10236,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
+<<<<<<< HEAD
       - lang: Node.js
         source: |
           try {
@@ -9652,6 +10265,8 @@ paths:
               console.log('Unknown Error: ', err)
             }
           }
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Python
         source: |
           try:
@@ -9812,6 +10427,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
+<<<<<<< HEAD
       - lang: Node.js
         source: |
           try {
@@ -9833,6 +10449,13 @@ paths:
           try:
               add_on = client.get_plan_add_on(plan_id, add_on_id)
               print("Got Plan Add-On %s" % add_on)
+=======
+      - lang: Python
+        source: |
+          try:
+              shipping_addr = client.get_shipping_address(account_id, shipping_address_id)
+              print("Got ShippingAddress %s" % shipping_addr)
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
           except recurly.errors.NotFoundError:
               # If the resource was not found, you may want to alert the user or
               # just return nil
@@ -9880,7 +10503,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $add_on = $client->getPlanAddOn($plan_id, $add_on_id);
@@ -10073,6 +10700,7 @@ paths:
       - lang: Node.js
         source: |
           try {
+<<<<<<< HEAD
             const addOn = await client.removePlanAddOn(planId, addOnId)
             console.log('Removed plan add-on: ', addOn)
           } catch (err) {
@@ -10134,6 +10762,8 @@ paths:
       - lang: PHP
         source: |
           try {
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
               $add_on = $client->removePlanAddOn($plan_id, $add_on_id);
 
               echo 'Removed Plan AddOn:' . PHP_EOL;
@@ -10457,6 +11087,7 @@ paths:
           ok {\n\t\tfmt.Printf(\"Failed to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor
           i, method := range shippingMethods.Data {\n\t\tfmt.Printf(\"Shipping Method
           %3d: %s, %s\\n\",\n\t\t\ti,\n\t\t\tmethod.Id,\n\t\t\tmethod.Code,\n\t\t)\n\t}\n}"
+<<<<<<< HEAD
     post:
       tags:
       - shipping_method
@@ -10502,6 +11133,8 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
   "/sites/{site_id}/shipping_methods/{id}":
     get:
       tags:
@@ -10583,6 +11216,7 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Error"
+<<<<<<< HEAD
       x-code-samples: []
     delete:
       tags:
@@ -10656,6 +11290,8 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Error"
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       x-code-samples:
       - lang: Node.js
         source: |
@@ -10691,7 +11327,11 @@ paths:
           for (Subscription subscription : subscriptions) {
               System.out.println(subscription.getUuid());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $subscriptions = $client->listSubscriptions($params);
@@ -10833,6 +11473,30 @@ paths:
             puts "ValidationError: #{e.recurly_error.params}"
           end
       - lang: Java
+<<<<<<< HEAD
+=======
+        source: |
+          try {
+              SubscriptionCreate subscriptionCreate = new SubscriptionCreate();
+              AccountCreate accountCreate = new AccountCreate();
+
+              accountCreate.setCode(accountCode);
+              subscriptionCreate.setCurrency("USD");
+              subscriptionCreate.setAccount(accountCreate);
+              subscriptionCreate.setPlanCode(planCode);
+
+              Subscription subscription = client.createSubscription(subscriptionCreate);
+              System.out.println("Created Subscription with Id: " + subscription.getUuid());
+          } catch (ValidationException e) {
+              // If the request was not valid, you may want to tell your user
+              // why. You can find the invalid params and reasons in e.getError().getParams()
+              System.out.println("Failed validation: " + e.getError().getMessage());
+          } catch (ApiException e) {
+              // Use ApiException to catch a generic error from the API
+              System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+          }
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               SubscriptionCreate subscriptionCreate = new SubscriptionCreate();
@@ -10982,7 +11646,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $subscription = $client->getSubscription($subscription_id);
@@ -11123,7 +11791,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $changes = [
@@ -11280,7 +11952,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $subscription = $client->terminateSubscription($subscription_id);
@@ -11418,7 +12094,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $subscription = $client->cancelSubscription($subscription_id);
@@ -11498,6 +12178,7 @@ paths:
               console.log('Unknown Error: ', err)
             }
           }
+<<<<<<< HEAD
       - lang: Python
         source: |
           try:
@@ -11507,6 +12188,8 @@ paths:
               # If the resource was not found, you may want to alert the user or
               # just return nil
               print("Resource Not Found")
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: ".NET"
         source: |
           try
@@ -11550,7 +12233,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $subscription = $client->reactivateSubscription($subscription_id);
@@ -11620,6 +12307,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
+<<<<<<< HEAD
       - lang: Node.js
         source: |
           try {
@@ -11641,6 +12329,10 @@ paths:
           }
       - lang: Python
         source: |
+=======
+      - lang: Python
+        source: |
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
           try:
               sub_pause = {"remaining_pause_cycles": 10}
               subscription = client.pause_subscription(subscription_id, sub_pause)
@@ -11650,6 +12342,7 @@ paths:
               # why. You can find the invalid params and reasons in e.error.params
               print("ValidationError: %s" % e.error.message)
               print(e.error.params)
+<<<<<<< HEAD
       - lang: ".NET"
         source: |
           try
@@ -11671,6 +12364,8 @@ paths:
               // Use ApiError to catch a generic error from the API
               Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
           }
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           begin
@@ -11703,7 +12398,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $sub_pause = [ "remaining_pause_cycles" => 10 ];
@@ -11768,6 +12467,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
+<<<<<<< HEAD
       - lang: Node.js
         source: |
           try {
@@ -11784,6 +12484,8 @@ paths:
               console.log('Unknown Error: ', err)
             }
           }
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Python
         source: |
           try:
@@ -11794,6 +12496,7 @@ paths:
               # why. You can find the invalid params and reasons in e.error.params
               print("ValidationError: %s" % e.error.message)
               print(e.error.params)
+<<<<<<< HEAD
       - lang: ".NET"
         source: |
           try
@@ -11812,6 +12515,8 @@ paths:
               // Use ApiError to catch a generic error from the API
               Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
           }
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           begin
@@ -11944,6 +12649,34 @@ paths:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
       - lang: Node.js
+<<<<<<< HEAD
+=======
+        source: |
+          try {
+            const change = await client.getSubscriptionChange(subscriptionId)
+            console.log('Fetched subscription change: ', change.id)
+          } catch (err) {
+            if (err instanceof recurly.errors.NotFoundError) {
+              // If the request was not found, you may want to alert the user or
+              // just return null
+              console.log('Resource Not Found')
+            } else {
+              // If we don't know what to do with the err, we should
+              // probably re-raise and let our web framework and logger handle it
+              console.log('Unknown Error: ', err)
+            }
+          }
+      - lang: Python
+        source: |
+          try:
+              change = client.get_subscription_change(subscription_id)
+              print("Got SubscriptionChange %s" % change)
+          except recurly.errors.NotFoundError:
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              print("Resource Not Found")
+      - lang: ".NET"
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
             const change = await client.getSubscriptionChange(subscriptionId)
@@ -12011,7 +12744,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $change = $client->getSubscriptionChange($subscription_id);
@@ -12166,7 +12903,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $change_create = [
@@ -12288,7 +13029,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $client->removeSubscriptionChange($subscription_id);
@@ -12308,6 +13053,7 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Removed Subscription
           Change: %v\", subscriptionChange)"
+<<<<<<< HEAD
   "/sites/{site_id}/subscriptions/{subscription_id}/change/preview":
     post:
       tags:
@@ -12353,6 +13099,8 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
   "/sites/{site_id}/subscriptions/{subscription_id}/invoices":
     get:
       tags:
@@ -12398,6 +13146,7 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples:
+<<<<<<< HEAD
       - lang: Node.js
         source: |
           const invoices = client.listSubscriptionInvoices(subscriptionId, { limit: 200 })
@@ -12417,6 +13166,13 @@ paths:
           {
               Console.WriteLine(invoice.Number);
           }
+=======
+      - lang: Python
+        source: |
+          invoices = client.list_subscription_invoices(subscription_id).items()
+          for invoice in invoices:
+              print(invoice.number)
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: Ruby
         source: |
           invoices = @client.list_subscription_invoices(
@@ -12435,7 +13191,11 @@ paths:
           for (Invoice invoice : invoices) {
               System.out.println(invoice.getNumber());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $subscription_invoices = $client->listSubscriptionInvoices($subscription_id, $params);
@@ -12452,6 +13212,7 @@ paths:
           i, invoice := range subInvoices.Data {\n\t\tfmt.Printf(\"Subscription Invoice
           %3d: %s\\n\",\n\t\t\ti,\n\t\t\tinvoice.Id,\n\t\t)\n\t}\n}"
   "/sites/{site_id}/subscriptions/{subscription_id}/line_items":
+<<<<<<< HEAD
     get:
       tags:
       - subscription
@@ -12639,6 +13400,8 @@ paths:
           next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, redemption := range subCouponRedemptions.Data
           {\n\t\tfmt.Printf(\"Subscription Coupon Redemption %3d: %s\\n\",\n\t\t\ti,\n\t\t\tredemption.Id,\n\t\t)\n\t}\n}"
   "/sites/{site_id}/subscriptions/{subscription_id}/add_ons/{add_on_id}/usage":
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
     get:
       tags:
       - invoice
@@ -12816,8 +13579,53 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Error"
+<<<<<<< HEAD
       x-code-samples: []
     delete:
+=======
+      x-code-samples:
+      - lang: Python
+        source: |
+          line_items = client.list_subscription_line_items(subscription_id).items()
+          for line_item in line_items:
+              print(line_item.id)
+      - lang: Ruby
+        source: |
+          line_items = @client.list_subscription_line_items(
+            subscription_id: subscription_id,
+            limit: 200
+          )
+          line_items.each do |line_item|
+            puts "LineItem: #{line_item.id}"
+          end
+      - lang: Java
+        source: |
+          QueryParams params = new QueryParams();
+          params.setLimit(200); // Pull 200 records at a time
+          final Pager<LineItem> lineItems = client.listSubscriptionLineItems(subscriptionId, params);
+
+          for (LineItem lineItem : lineItems) {
+              System.out.println(lineItem.getId());
+          }
+      - lang: Php
+        source: |
+          $params = ['limit' => 200];
+          $subscription_line_items = $client->listSubscriptionLineItems($subscription_id, $params);
+
+          foreach($subscription_line_items as $line_item) {
+            echo 'Subscription Invoice: ' . $line_item->getId() . PHP_EOL;
+          }
+      - lang: Go
+        source: "listParams := &recurly.ListSubscriptionLineItemsParams{\n\tSort:
+          \ recurly.String(\"created_at\"),\n\tOrder: recurly.String(\"desc\"),\n\tLimit:
+          recurly.Int(200),\n}\nsubLineItems := client.ListSubscriptionLineItems(subID,
+          listParams)\n\nfor subLineItems.HasMore {\n\terr := subLineItems.Fetch()\n\tif
+          e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
+          next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, lineItem := range subLineItems.Data
+          {\n\t\tfmt.Printf(\"Subscription Line Item %3d: %s\\n\",\n\t\t\ti,\n\t\t\tlineItem.Id,\n\t\t)\n\t}\n}"
+  "/sites/{site_id}/subscriptions/{subscription_id}/coupon_redemptions":
+    get:
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       tags:
       - invoice
       - subscription
@@ -12854,7 +13662,49 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Error"
+<<<<<<< HEAD
       x-code-samples: []
+=======
+      x-code-samples:
+      - lang: Python
+        source: |
+          redemptions = client.list_subscription_coupon_redemptions(subscription_id).items()
+          for redemption in redemptions:
+              print(redemption.uuid)
+      - lang: Ruby
+        source: |
+          coupon_redemptions = @client.list_subscription_coupon_redemptions(
+            subscription_id: subscription_id,
+            limit: 200
+          )
+          coupon_redemptions.each do |redemption|
+            puts "CouponRedemption: #{redemption.id}"
+          end
+      - lang: Java
+        source: |
+          QueryParams params = new QueryParams();
+          params.setLimit(200); // Pull 200 records at a time
+          final Pager<CouponRedemption> redemptions = client.listSubscriptionCouponRedemptions(subscriptionId, params);
+
+          for (CouponRedemption redemption : redemptions) {
+              System.out.println(redemption.getId());
+          }
+      - lang: Php
+        source: |
+          $params = ['limit' => 200];
+          $subscription_coupon_redemptions = $client->listSubscriptionCouponRedemptions($subscription_id, $params);
+
+          foreach($subscription_coupon_redemptions as $redemption) {
+            echo 'Subscription Coupon Redemption: ' . $redemption->getId() . PHP_EOL;
+          }
+      - lang: Go
+        source: "listParams := &recurly.ListSubscriptionCouponRedemptionsParams{\n\tSort:
+          recurly.String(\"created_at\"),\n}\nsubCouponRedemptions := client.ListSubscriptionCouponRedemptions(subID,
+          listParams)\n\nfor subCouponRedemptions.HasMore {\n\terr := subCouponRedemptions.Fetch()\n\tif
+          e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed to retrieve
+          next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, redemption := range subCouponRedemptions.Data
+          {\n\t\tfmt.Printf(\"Subscription Coupon Redemption %3d: %s\\n\",\n\t\t\ti,\n\t\t\tredemption.Id,\n\t\t)\n\t}\n}"
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
   "/sites/{site_id}/transactions":
     get:
       tags:
@@ -12933,7 +13783,11 @@ paths:
           for (Transaction transaction : transactions) {
               System.out.println(transaction.getUuid());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           $params = ['limit' => 200];
           $transactions = $client->listTransactions($params);
@@ -12993,6 +13847,7 @@ paths:
               console.log('Unknown Error: ', err)
             }
           }
+<<<<<<< HEAD
       - lang: Python
         source: |
           try:
@@ -13002,6 +13857,8 @@ paths:
               # If the resource was not found, you may want to alert the user or
               # just return nil
               print("Resource Not Found")
+=======
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
       - lang: ".NET"
         source: |
           try
@@ -13043,7 +13900,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $transaction = $client->getTransaction($transaction_id);
@@ -13354,7 +14215,11 @@ paths:
               // Use ApiException to catch a generic error from the API
               System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
           }
+<<<<<<< HEAD
       - lang: PHP
+=======
+      - lang: Php
+>>>>>>> 52b9f7f... Ensure that path parameters are not empty strings
         source: |
           try {
               $purchase_create = [

--- a/recurly_test.go
+++ b/recurly_test.go
@@ -153,9 +153,12 @@ func (attr *ResourceCreate) toParams() *Params {
 // We also implement fake CRUD operations for these fake resources
 // We want to use the Client from the consuming code's perspective
 func (c *Client) GetResource(resourceId string) (*RecurlyResource, error) {
-	path := c.InterpolatePath("/resources/{resource_id}", resourceId)
+	path, err := c.InterpolatePath("/resources/{resource_id}", resourceId)
+	if err != nil {
+		return nil, err
+	}
 	result := &RecurlyResource{}
-	err := c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, result)
 	if err != nil {
 		return nil, err
 	}
@@ -163,9 +166,12 @@ func (c *Client) GetResource(resourceId string) (*RecurlyResource, error) {
 }
 
 func (c *Client) CreateResource(body *ResourceCreate) (*RecurlyResource, error) {
-	path := c.InterpolatePath("/resources")
+	path, err := c.InterpolatePath("/resources")
+	if err != nil {
+		return nil, err
+	}
 	result := &RecurlyResource{}
-	err := c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, result)
 	if err != nil {
 		return nil, err
 	}
@@ -173,9 +179,12 @@ func (c *Client) CreateResource(body *ResourceCreate) (*RecurlyResource, error) 
 }
 
 func (c *Client) DeleteResource(resourceId string) (*Empty, error) {
-	path := c.InterpolatePath("/resources")
+	path, err := c.InterpolatePath("/resources")
+	if err != nil {
+		return nil, err
+	}
 	result := &Empty{}
-	err := c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(http.MethodDelete, path, nil, result)
 	if err != nil {
 		return nil, err
 	}

--- a/recurly_test.go
+++ b/recurly_test.go
@@ -193,9 +193,12 @@ func (c *Client) DeleteResource(resourceId string) (*Empty, error) {
 
 // ResourceMetada calls the HEAD endpoint and returns the response metadata
 func (c *Client) GetResourceMetadata(resourceId string) (*ResponseMetadata, error) {
-	path := c.InterpolatePath("/resources")
+	path, err := c.InterpolatePath("/resources")
+	if err != nil {
+		return nil, err
+	}
 	result := &Empty{}
-	err := c.Call(http.MethodHead, path, nil, result)
+	err = c.Call(http.MethodHead, path, nil, result)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adding a validation function to `InterpolatePath` to ensure that path parameters are not empty strings.

Adds a test to ensure that the path parameters are properly encoded.