### PR TITLE
Only log warnings and errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -74,7 +74,7 @@ func DefaultClient() *Client {
 	return &Client{
 		apiKey:     APIKey,
 		baseURL:    APIHost,
-		Log:        NewLogger(LevelDebug),
+		Log:        NewLogger(LevelWarn),
 		HTTPClient: defaultClient,
 	}
 }


### PR DESCRIPTION
We don't want Debug logging by default since it prints PII and stuff that is not needed or dangerous in production.

Only log warnings and errors for the time being. Next step is to make this more configurable and document that.