### PR TITLE
Adds `NewClient` and removes `DefaultClient`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ import (
 A client represents a connection to the Recurly API. Every call to the server exists as a method on this struct. To initialize, you only need the private API key which can be obtained on the [API Credentials Page](https://app.recurly.com/go/integrations/api_keys).
 
 ```go
-recurly.APIKey = "<apikey>"
-client := recurly.DefaultClient()
+client := recurly.NewClient("<apikey>")
 ```
 
 ### Operations

--- a/client.go
+++ b/client.go
@@ -69,7 +69,7 @@ type Client struct {
 	HTTPClient *http.Client
 }
 
-// NwqClient returns the default API Client using the given APIKey
+// NewClient returns a new API Client using the given APIKey
 func NewClient(apiKey string) *Client {
 	return &Client{
 		apiKey:     apiKey,

--- a/client.go
+++ b/client.go
@@ -69,16 +69,7 @@ type Client struct {
 	HTTPClient *http.Client
 }
 
-// DefaultClient returns the default API Client using the globally set Site and APIKey
-func DefaultClient() *Client {
-	return &Client{
-		apiKey:     APIKey,
-		baseURL:    APIHost,
-		Log:        NewLogger(LevelWarn),
-		HTTPClient: defaultClient,
-	}
-}
-
+// NwqClient returns the default API Client using the given APIKey
 func NewClient(apiKey string) *Client {
 	return &Client{
 		apiKey:     apiKey,

--- a/client.go
+++ b/client.go
@@ -79,6 +79,15 @@ func DefaultClient() *Client {
 	}
 }
 
+func NewClient(apiKey string) *Client {
+	return &Client{
+		apiKey:     apiKey,
+		baseURL:    APIHost,
+		Log:        NewLogger(LevelWarn),
+		HTTPClient: defaultClient,
+	}
+}
+
 // newClient creates a new Recurly API Client
 func newClient(apiKey string, httpClient *http.Client) *Client {
 	if apiKey == "" {


### PR DESCRIPTION
I prefer this interface for client creation because it can be safely used whether you are managing multiple sites (multiple api keys) or just one. It's better to support just one way of doing things for this initial launch. We can always add support back if there is a need for it.