### PR TITLE
Cleaner implementation of --this-version

### DIFF
--- a/scripts/bump
+++ b/scripts/bump
@@ -5,7 +5,7 @@ if [ "$1" == "--next-version" ]; then
   shift
   bump2version --dry-run --list "$@" | grep new_version | cut -d "=" -f 2
 elif [ "$1" == "--this-version" ]; then
-  grep current_version .bumpversion.cfg | awk -F"current_version = " '{print $2}' | tr -d '\n'
+  grep "current_version =" .bumpversion.cfg | awk -F"current_version = " '{print $2}'
 else
   bump2version "$@"
 fi


### PR DESCRIPTION
I ran into a problem when releasing today and hacked this script to get it to work. This library's `.bumpversion.cfg` file has multiple instances of `current_version` so the `grep` call picks up too much text. This is a slightly cleaner way of handling it, although I think we could make this more robust across the clients in the future.