### PR TITLE
Loosen restrictions on what is successful resp

### DIFF
--- a/client.go
+++ b/client.go
@@ -277,5 +277,5 @@ func (c *Client) Do(req *http.Request, v interface{}) error {
 }
 
 func successfulStatus(statusCode int) bool {
-	return statusCode == http.StatusOK || statusCode == http.StatusCreated || statusCode == http.StatusNoContent
+	return statusCode >= http.StatusOK && statusCode < http.StatusBadRequest
 }


### PR DESCRIPTION
Loosens the restrictions on what is a successful response. We'll make this more specific if the client needs to handle these differently, for now we don't want to be too specific.