### PR TITLE
Adding Context and RequestOptions support

### DIFF
--- a/account.go
+++ b/account.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -126,25 +127,27 @@ func (resource *accountList) setResponse(res *ResponseMetadata) {
 
 // AccountList allows you to paginate Account objects
 type AccountList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []Account
 }
 
-func NewAccountList(client HttpCaller, nextPagePath string) *AccountList {
+func NewAccountList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *AccountList {
 	return &AccountList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *AccountList) Fetch() error {
+func (list *AccountList) FetchWithContext(ctx context.Context) error {
 	resources := &accountList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -155,13 +158,23 @@ func (list *AccountList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *AccountList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *AccountList) Count() (*int64, error) {
+func (list *AccountList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &accountList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *AccountList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/account_acquisition.go
+++ b/account_acquisition.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -68,25 +69,27 @@ func (resource *accountAcquisitionList) setResponse(res *ResponseMetadata) {
 
 // AccountAcquisitionList allows you to paginate AccountAcquisition objects
 type AccountAcquisitionList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []AccountAcquisition
 }
 
-func NewAccountAcquisitionList(client HttpCaller, nextPagePath string) *AccountAcquisitionList {
+func NewAccountAcquisitionList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *AccountAcquisitionList {
 	return &AccountAcquisitionList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *AccountAcquisitionList) Fetch() error {
+func (list *AccountAcquisitionList) FetchWithContext(ctx context.Context) error {
 	resources := &accountAcquisitionList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -97,13 +100,23 @@ func (list *AccountAcquisitionList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *AccountAcquisitionList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *AccountAcquisitionList) Count() (*int64, error) {
+func (list *AccountAcquisitionList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &accountAcquisitionList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *AccountAcquisitionList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/account_acquisition_cost.go
+++ b/account_acquisition_cost.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -47,25 +48,27 @@ func (resource *accountAcquisitionCostList) setResponse(res *ResponseMetadata) {
 
 // AccountAcquisitionCostList allows you to paginate AccountAcquisitionCost objects
 type AccountAcquisitionCostList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []AccountAcquisitionCost
 }
 
-func NewAccountAcquisitionCostList(client HttpCaller, nextPagePath string) *AccountAcquisitionCostList {
+func NewAccountAcquisitionCostList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *AccountAcquisitionCostList {
 	return &AccountAcquisitionCostList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *AccountAcquisitionCostList) Fetch() error {
+func (list *AccountAcquisitionCostList) FetchWithContext(ctx context.Context) error {
 	resources := &accountAcquisitionCostList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -76,13 +79,23 @@ func (list *AccountAcquisitionCostList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *AccountAcquisitionCostList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *AccountAcquisitionCostList) Count() (*int64, error) {
+func (list *AccountAcquisitionCostList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &accountAcquisitionCostList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *AccountAcquisitionCostList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/account_balance.go
+++ b/account_balance.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -51,25 +52,27 @@ func (resource *accountBalanceList) setResponse(res *ResponseMetadata) {
 
 // AccountBalanceList allows you to paginate AccountBalance objects
 type AccountBalanceList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []AccountBalance
 }
 
-func NewAccountBalanceList(client HttpCaller, nextPagePath string) *AccountBalanceList {
+func NewAccountBalanceList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *AccountBalanceList {
 	return &AccountBalanceList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *AccountBalanceList) Fetch() error {
+func (list *AccountBalanceList) FetchWithContext(ctx context.Context) error {
 	resources := &accountBalanceList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -80,13 +83,23 @@ func (list *AccountBalanceList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *AccountBalanceList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *AccountBalanceList) Count() (*int64, error) {
+func (list *AccountBalanceList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &accountBalanceList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *AccountBalanceList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/account_balance_amount.go
+++ b/account_balance_amount.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -47,25 +48,27 @@ func (resource *accountBalanceAmountList) setResponse(res *ResponseMetadata) {
 
 // AccountBalanceAmountList allows you to paginate AccountBalanceAmount objects
 type AccountBalanceAmountList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []AccountBalanceAmount
 }
 
-func NewAccountBalanceAmountList(client HttpCaller, nextPagePath string) *AccountBalanceAmountList {
+func NewAccountBalanceAmountList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *AccountBalanceAmountList {
 	return &AccountBalanceAmountList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *AccountBalanceAmountList) Fetch() error {
+func (list *AccountBalanceAmountList) FetchWithContext(ctx context.Context) error {
 	resources := &accountBalanceAmountList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -76,13 +79,23 @@ func (list *AccountBalanceAmountList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *AccountBalanceAmountList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *AccountBalanceAmountList) Count() (*int64, error) {
+func (list *AccountBalanceAmountList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &accountBalanceAmountList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *AccountBalanceAmountList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/account_note.go
+++ b/account_note.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -55,25 +56,27 @@ func (resource *accountNoteList) setResponse(res *ResponseMetadata) {
 
 // AccountNoteList allows you to paginate AccountNote objects
 type AccountNoteList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []AccountNote
 }
 
-func NewAccountNoteList(client HttpCaller, nextPagePath string) *AccountNoteList {
+func NewAccountNoteList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *AccountNoteList {
 	return &AccountNoteList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *AccountNoteList) Fetch() error {
+func (list *AccountNoteList) FetchWithContext(ctx context.Context) error {
 	resources := &accountNoteList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -84,13 +87,23 @@ func (list *AccountNoteList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *AccountNoteList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *AccountNoteList) Count() (*int64, error) {
+func (list *AccountNoteList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &accountNoteList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *AccountNoteList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/add_on.go
+++ b/add_on.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -120,25 +121,27 @@ func (resource *addOnList) setResponse(res *ResponseMetadata) {
 
 // AddOnList allows you to paginate AddOn objects
 type AddOnList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []AddOn
 }
 
-func NewAddOnList(client HttpCaller, nextPagePath string) *AddOnList {
+func NewAddOnList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *AddOnList {
 	return &AddOnList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *AddOnList) Fetch() error {
+func (list *AddOnList) FetchWithContext(ctx context.Context) error {
 	resources := &addOnList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -149,13 +152,23 @@ func (list *AddOnList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *AddOnList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *AddOnList) Count() (*int64, error) {
+func (list *AddOnList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &addOnList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *AddOnList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/add_on_mini.go
+++ b/add_on_mini.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -74,25 +75,27 @@ func (resource *addOnMiniList) setResponse(res *ResponseMetadata) {
 
 // AddOnMiniList allows you to paginate AddOnMini objects
 type AddOnMiniList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []AddOnMini
 }
 
-func NewAddOnMiniList(client HttpCaller, nextPagePath string) *AddOnMiniList {
+func NewAddOnMiniList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *AddOnMiniList {
 	return &AddOnMiniList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *AddOnMiniList) Fetch() error {
+func (list *AddOnMiniList) FetchWithContext(ctx context.Context) error {
 	resources := &addOnMiniList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -103,13 +106,23 @@ func (list *AddOnMiniList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *AddOnMiniList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *AddOnMiniList) Count() (*int64, error) {
+func (list *AddOnMiniList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &addOnMiniList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *AddOnMiniList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/add_on_pricing.go
+++ b/add_on_pricing.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -47,25 +48,27 @@ func (resource *addOnPricingList) setResponse(res *ResponseMetadata) {
 
 // AddOnPricingList allows you to paginate AddOnPricing objects
 type AddOnPricingList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []AddOnPricing
 }
 
-func NewAddOnPricingList(client HttpCaller, nextPagePath string) *AddOnPricingList {
+func NewAddOnPricingList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *AddOnPricingList {
 	return &AddOnPricingList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *AddOnPricingList) Fetch() error {
+func (list *AddOnPricingList) FetchWithContext(ctx context.Context) error {
 	resources := &addOnPricingList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -76,13 +79,23 @@ func (list *AddOnPricingList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *AddOnPricingList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *AddOnPricingList) Count() (*int64, error) {
+func (list *AddOnPricingList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &addOnPricingList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *AddOnPricingList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/billing_info.go
+++ b/billing_info.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -78,25 +79,27 @@ func (resource *billingInfoList) setResponse(res *ResponseMetadata) {
 
 // BillingInfoList allows you to paginate BillingInfo objects
 type BillingInfoList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []BillingInfo
 }
 
-func NewBillingInfoList(client HttpCaller, nextPagePath string) *BillingInfoList {
+func NewBillingInfoList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *BillingInfoList {
 	return &BillingInfoList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *BillingInfoList) Fetch() error {
+func (list *BillingInfoList) FetchWithContext(ctx context.Context) error {
 	resources := &billingInfoList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -107,13 +110,23 @@ func (list *BillingInfoList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *BillingInfoList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *BillingInfoList) Count() (*int64, error) {
+func (list *BillingInfoList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &billingInfoList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *BillingInfoList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/billing_info_updated_by.go
+++ b/billing_info_updated_by.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -47,25 +48,27 @@ func (resource *billingInfoUpdatedByList) setResponse(res *ResponseMetadata) {
 
 // BillingInfoUpdatedByList allows you to paginate BillingInfoUpdatedBy objects
 type BillingInfoUpdatedByList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []BillingInfoUpdatedBy
 }
 
-func NewBillingInfoUpdatedByList(client HttpCaller, nextPagePath string) *BillingInfoUpdatedByList {
+func NewBillingInfoUpdatedByList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *BillingInfoUpdatedByList {
 	return &BillingInfoUpdatedByList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *BillingInfoUpdatedByList) Fetch() error {
+func (list *BillingInfoUpdatedByList) FetchWithContext(ctx context.Context) error {
 	resources := &billingInfoUpdatedByList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -76,13 +79,23 @@ func (list *BillingInfoUpdatedByList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *BillingInfoUpdatedByList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *BillingInfoUpdatedByList) Count() (*int64, error) {
+func (list *BillingInfoUpdatedByList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &billingInfoUpdatedByList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *BillingInfoUpdatedByList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/binary_file.go
+++ b/binary_file.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -43,25 +44,27 @@ func (resource *binaryFileList) setResponse(res *ResponseMetadata) {
 
 // BinaryFileList allows you to paginate BinaryFile objects
 type BinaryFileList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []BinaryFile
 }
 
-func NewBinaryFileList(client HttpCaller, nextPagePath string) *BinaryFileList {
+func NewBinaryFileList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *BinaryFileList {
 	return &BinaryFileList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *BinaryFileList) Fetch() error {
+func (list *BinaryFileList) FetchWithContext(ctx context.Context) error {
 	resources := &binaryFileList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -72,13 +75,23 @@ func (list *BinaryFileList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *BinaryFileList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *BinaryFileList) Count() (*int64, error) {
+func (list *BinaryFileList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &binaryFileList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *BinaryFileList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/client.go
+++ b/client.go
@@ -119,6 +119,9 @@ type HTTPCaller interface {
 // (which is returned by genericParams.toParams()) to seperate concerns with payload/URL params
 // from configurations of the HTTP request (RequestOptions).
 func (c *Client) Call(ctx context.Context, method string, path string, body GenericParams, queryParams GenericParams, requestOptions optionsApplier, v interface{}) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if !strings.HasPrefix(path, "/") {
 		path = fmt.Sprintf("%s/%s", c.baseURL, path)
 	} else {

--- a/client_operations.go
+++ b/client_operations.go
@@ -447,7 +447,8 @@ func (c *Client) ListSites(params *ListSitesParams, opts ...Option) *SiteList {
 
 // GetSite wraps GetSiteWithContext using the background context
 func (c *Client) GetSite(siteId string, opts ...Option) (*Site, error) {
-	return c.getSite(context.Background(), siteId, opts...)
+	ctx := context.Background()
+	return c.getSite(ctx, siteId, opts...)
 }
 
 // GetSiteWithContext Fetch a site
@@ -466,7 +467,7 @@ func (c *Client) getSite(ctx context.Context, siteId string, opts ...Option) (*S
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Site{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -585,7 +586,11 @@ func (c *Client) ListAccounts(params *ListAccountsParams, opts ...Option) *Accou
 
 // CreateAccount wraps CreateAccountWithContext using the background context
 func (c *Client) CreateAccount(body *AccountCreate, opts ...Option) (*Account, error) {
-	return c.createAccount(context.Background(), body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.createAccount(ctx, body, opts...)
 }
 
 // CreateAccountWithContext Create an account
@@ -604,7 +609,7 @@ func (c *Client) createAccount(ctx context.Context, body *AccountCreate, opts ..
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Account{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -613,7 +618,8 @@ func (c *Client) createAccount(ctx context.Context, body *AccountCreate, opts ..
 
 // GetAccount wraps GetAccountWithContext using the background context
 func (c *Client) GetAccount(accountId string, opts ...Option) (*Account, error) {
-	return c.getAccount(context.Background(), accountId, opts...)
+	ctx := context.Background()
+	return c.getAccount(ctx, accountId, opts...)
 }
 
 // GetAccountWithContext Fetch an account
@@ -632,7 +638,7 @@ func (c *Client) getAccount(ctx context.Context, accountId string, opts ...Optio
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Account{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -641,7 +647,11 @@ func (c *Client) getAccount(ctx context.Context, accountId string, opts ...Optio
 
 // UpdateAccount wraps UpdateAccountWithContext using the background context
 func (c *Client) UpdateAccount(accountId string, body *AccountUpdate, opts ...Option) (*Account, error) {
-	return c.updateAccount(context.Background(), accountId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.updateAccount(ctx, accountId, body, opts...)
 }
 
 // UpdateAccountWithContext Modify an account
@@ -660,7 +670,7 @@ func (c *Client) updateAccount(ctx context.Context, accountId string, body *Acco
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Account{}
-	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -669,7 +679,8 @@ func (c *Client) updateAccount(ctx context.Context, accountId string, body *Acco
 
 // DeactivateAccount wraps DeactivateAccountWithContext using the background context
 func (c *Client) DeactivateAccount(accountId string, opts ...Option) (*Account, error) {
-	return c.deactivateAccount(context.Background(), accountId, opts...)
+	ctx := context.Background()
+	return c.deactivateAccount(ctx, accountId, opts...)
 }
 
 // DeactivateAccountWithContext Deactivate an account
@@ -688,7 +699,7 @@ func (c *Client) deactivateAccount(ctx context.Context, accountId string, opts .
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Account{}
-	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -697,7 +708,8 @@ func (c *Client) deactivateAccount(ctx context.Context, accountId string, opts .
 
 // GetAccountAcquisition wraps GetAccountAcquisitionWithContext using the background context
 func (c *Client) GetAccountAcquisition(accountId string, opts ...Option) (*AccountAcquisition, error) {
-	return c.getAccountAcquisition(context.Background(), accountId, opts...)
+	ctx := context.Background()
+	return c.getAccountAcquisition(ctx, accountId, opts...)
 }
 
 // GetAccountAcquisitionWithContext Fetch an account's acquisition data
@@ -716,7 +728,7 @@ func (c *Client) getAccountAcquisition(ctx context.Context, accountId string, op
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &AccountAcquisition{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -725,7 +737,11 @@ func (c *Client) getAccountAcquisition(ctx context.Context, accountId string, op
 
 // UpdateAccountAcquisition wraps UpdateAccountAcquisitionWithContext using the background context
 func (c *Client) UpdateAccountAcquisition(accountId string, body *AccountAcquisitionUpdatable, opts ...Option) (*AccountAcquisition, error) {
-	return c.updateAccountAcquisition(context.Background(), accountId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.updateAccountAcquisition(ctx, accountId, body, opts...)
 }
 
 // UpdateAccountAcquisitionWithContext Update an account's acquisition data
@@ -744,7 +760,7 @@ func (c *Client) updateAccountAcquisition(ctx context.Context, accountId string,
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &AccountAcquisition{}
-	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -753,7 +769,8 @@ func (c *Client) updateAccountAcquisition(ctx context.Context, accountId string,
 
 // RemoveAccountAcquisition wraps RemoveAccountAcquisitionWithContext using the background context
 func (c *Client) RemoveAccountAcquisition(accountId string, opts ...Option) (*Empty, error) {
-	return c.removeAccountAcquisition(context.Background(), accountId, opts...)
+	ctx := context.Background()
+	return c.removeAccountAcquisition(ctx, accountId, opts...)
 }
 
 // RemoveAccountAcquisitionWithContext Remove an account's acquisition data
@@ -772,7 +789,7 @@ func (c *Client) removeAccountAcquisition(ctx context.Context, accountId string,
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Empty{}
-	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -781,7 +798,8 @@ func (c *Client) removeAccountAcquisition(ctx context.Context, accountId string,
 
 // ReactivateAccount wraps ReactivateAccountWithContext using the background context
 func (c *Client) ReactivateAccount(accountId string, opts ...Option) (*Account, error) {
-	return c.reactivateAccount(context.Background(), accountId, opts...)
+	ctx := context.Background()
+	return c.reactivateAccount(ctx, accountId, opts...)
 }
 
 // ReactivateAccountWithContext Reactivate an inactive account
@@ -800,7 +818,7 @@ func (c *Client) reactivateAccount(ctx context.Context, accountId string, opts .
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Account{}
-	err = c.Call(context.Background(), http.MethodPut, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -809,7 +827,8 @@ func (c *Client) reactivateAccount(ctx context.Context, accountId string, opts .
 
 // GetAccountBalance wraps GetAccountBalanceWithContext using the background context
 func (c *Client) GetAccountBalance(accountId string, opts ...Option) (*AccountBalance, error) {
-	return c.getAccountBalance(context.Background(), accountId, opts...)
+	ctx := context.Background()
+	return c.getAccountBalance(ctx, accountId, opts...)
 }
 
 // GetAccountBalanceWithContext Fetch an account's balance and past due status
@@ -828,7 +847,7 @@ func (c *Client) getAccountBalance(ctx context.Context, accountId string, opts .
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &AccountBalance{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -837,7 +856,8 @@ func (c *Client) getAccountBalance(ctx context.Context, accountId string, opts .
 
 // GetBillingInfo wraps GetBillingInfoWithContext using the background context
 func (c *Client) GetBillingInfo(accountId string, opts ...Option) (*BillingInfo, error) {
-	return c.getBillingInfo(context.Background(), accountId, opts...)
+	ctx := context.Background()
+	return c.getBillingInfo(ctx, accountId, opts...)
 }
 
 // GetBillingInfoWithContext Fetch an account's billing information
@@ -856,7 +876,7 @@ func (c *Client) getBillingInfo(ctx context.Context, accountId string, opts ...O
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &BillingInfo{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -865,7 +885,11 @@ func (c *Client) getBillingInfo(ctx context.Context, accountId string, opts ...O
 
 // UpdateBillingInfo wraps UpdateBillingInfoWithContext using the background context
 func (c *Client) UpdateBillingInfo(accountId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error) {
-	return c.updateBillingInfo(context.Background(), accountId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.updateBillingInfo(ctx, accountId, body, opts...)
 }
 
 // UpdateBillingInfoWithContext Set an account's billing information
@@ -884,7 +908,7 @@ func (c *Client) updateBillingInfo(ctx context.Context, accountId string, body *
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &BillingInfo{}
-	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -893,7 +917,8 @@ func (c *Client) updateBillingInfo(ctx context.Context, accountId string, body *
 
 // RemoveBillingInfo wraps RemoveBillingInfoWithContext using the background context
 func (c *Client) RemoveBillingInfo(accountId string, opts ...Option) (*Empty, error) {
-	return c.removeBillingInfo(context.Background(), accountId, opts...)
+	ctx := context.Background()
+	return c.removeBillingInfo(ctx, accountId, opts...)
 }
 
 // RemoveBillingInfoWithContext Remove an account's billing information
@@ -912,7 +937,7 @@ func (c *Client) removeBillingInfo(ctx context.Context, accountId string, opts .
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Empty{}
-	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -995,7 +1020,11 @@ func (c *Client) ListBillingInfos(accountId string, params *ListBillingInfosPara
 
 // CreateBillingInfo wraps CreateBillingInfoWithContext using the background context
 func (c *Client) CreateBillingInfo(accountId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error) {
-	return c.createBillingInfo(context.Background(), accountId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.createBillingInfo(ctx, accountId, body, opts...)
 }
 
 // CreateBillingInfoWithContext Set an account's billing information when the wallet feature is enabled
@@ -1014,7 +1043,7 @@ func (c *Client) createBillingInfo(ctx context.Context, accountId string, body *
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &BillingInfo{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1023,7 +1052,8 @@ func (c *Client) createBillingInfo(ctx context.Context, accountId string, body *
 
 // GetABillingInfo wraps GetABillingInfoWithContext using the background context
 func (c *Client) GetABillingInfo(accountId string, billingInfoId string, opts ...Option) (*BillingInfo, error) {
-	return c.getABillingInfo(context.Background(), accountId, billingInfoId, opts...)
+	ctx := context.Background()
+	return c.getABillingInfo(ctx, accountId, billingInfoId, opts...)
 }
 
 // GetABillingInfoWithContext Fetch a billing info
@@ -1042,7 +1072,7 @@ func (c *Client) getABillingInfo(ctx context.Context, accountId string, billingI
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &BillingInfo{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1051,7 +1081,11 @@ func (c *Client) getABillingInfo(ctx context.Context, accountId string, billingI
 
 // UpdateABillingInfo wraps UpdateABillingInfoWithContext using the background context
 func (c *Client) UpdateABillingInfo(accountId string, billingInfoId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error) {
-	return c.updateABillingInfo(context.Background(), accountId, billingInfoId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.updateABillingInfo(ctx, accountId, billingInfoId, body, opts...)
 }
 
 // UpdateABillingInfoWithContext Update an account's billing information
@@ -1070,7 +1104,7 @@ func (c *Client) updateABillingInfo(ctx context.Context, accountId string, billi
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &BillingInfo{}
-	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1079,7 +1113,8 @@ func (c *Client) updateABillingInfo(ctx context.Context, accountId string, billi
 
 // RemoveABillingInfo wraps RemoveABillingInfoWithContext using the background context
 func (c *Client) RemoveABillingInfo(accountId string, billingInfoId string, opts ...Option) (*Empty, error) {
-	return c.removeABillingInfo(context.Background(), accountId, billingInfoId, opts...)
+	ctx := context.Background()
+	return c.removeABillingInfo(ctx, accountId, billingInfoId, opts...)
 }
 
 // RemoveABillingInfoWithContext Remove an account's billing information
@@ -1098,7 +1133,7 @@ func (c *Client) removeABillingInfo(ctx context.Context, accountId string, billi
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Empty{}
-	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1188,7 +1223,8 @@ func (c *Client) ListAccountCouponRedemptions(accountId string, params *ListAcco
 
 // GetActiveCouponRedemption wraps GetActiveCouponRedemptionWithContext using the background context
 func (c *Client) GetActiveCouponRedemption(accountId string, opts ...Option) (*CouponRedemption, error) {
-	return c.getActiveCouponRedemption(context.Background(), accountId, opts...)
+	ctx := context.Background()
+	return c.getActiveCouponRedemption(ctx, accountId, opts...)
 }
 
 // GetActiveCouponRedemptionWithContext Show the coupon redemption that is active on an account
@@ -1207,7 +1243,7 @@ func (c *Client) getActiveCouponRedemption(ctx context.Context, accountId string
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &CouponRedemption{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1216,7 +1252,11 @@ func (c *Client) getActiveCouponRedemption(ctx context.Context, accountId string
 
 // CreateCouponRedemption wraps CreateCouponRedemptionWithContext using the background context
 func (c *Client) CreateCouponRedemption(accountId string, body *CouponRedemptionCreate, opts ...Option) (*CouponRedemption, error) {
-	return c.createCouponRedemption(context.Background(), accountId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.createCouponRedemption(ctx, accountId, body, opts...)
 }
 
 // CreateCouponRedemptionWithContext Generate an active coupon redemption on an account
@@ -1235,7 +1275,7 @@ func (c *Client) createCouponRedemption(ctx context.Context, accountId string, b
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &CouponRedemption{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1244,7 +1284,8 @@ func (c *Client) createCouponRedemption(ctx context.Context, accountId string, b
 
 // RemoveCouponRedemption wraps RemoveCouponRedemptionWithContext using the background context
 func (c *Client) RemoveCouponRedemption(accountId string, opts ...Option) (*CouponRedemption, error) {
-	return c.removeCouponRedemption(context.Background(), accountId, opts...)
+	ctx := context.Background()
+	return c.removeCouponRedemption(ctx, accountId, opts...)
 }
 
 // RemoveCouponRedemptionWithContext Delete the active coupon redemption from an account
@@ -1263,7 +1304,7 @@ func (c *Client) removeCouponRedemption(ctx context.Context, accountId string, o
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &CouponRedemption{}
-	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1444,7 +1485,11 @@ func (c *Client) ListAccountInvoices(accountId string, params *ListAccountInvoic
 
 // CreateInvoice wraps CreateInvoiceWithContext using the background context
 func (c *Client) CreateInvoice(accountId string, body *InvoiceCreate, opts ...Option) (*InvoiceCollection, error) {
-	return c.createInvoice(context.Background(), accountId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.createInvoice(ctx, accountId, body, opts...)
 }
 
 // CreateInvoiceWithContext Create an invoice for pending line items
@@ -1463,7 +1508,7 @@ func (c *Client) createInvoice(ctx context.Context, accountId string, body *Invo
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &InvoiceCollection{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1472,7 +1517,11 @@ func (c *Client) createInvoice(ctx context.Context, accountId string, body *Invo
 
 // PreviewInvoice wraps PreviewInvoiceWithContext using the background context
 func (c *Client) PreviewInvoice(accountId string, body *InvoiceCreate, opts ...Option) (*InvoiceCollection, error) {
-	return c.previewInvoice(context.Background(), accountId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.previewInvoice(ctx, accountId, body, opts...)
 }
 
 // PreviewInvoiceWithContext Preview new invoice for pending line items
@@ -1491,7 +1540,7 @@ func (c *Client) previewInvoice(ctx context.Context, accountId string, body *Inv
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &InvoiceCollection{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1609,7 +1658,11 @@ func (c *Client) ListAccountLineItems(accountId string, params *ListAccountLineI
 
 // CreateLineItem wraps CreateLineItemWithContext using the background context
 func (c *Client) CreateLineItem(accountId string, body *LineItemCreate, opts ...Option) (*LineItem, error) {
-	return c.createLineItem(context.Background(), accountId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.createLineItem(ctx, accountId, body, opts...)
 }
 
 // CreateLineItemWithContext Create a new line item for the account
@@ -1628,7 +1681,7 @@ func (c *Client) createLineItem(ctx context.Context, accountId string, body *Lin
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &LineItem{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1686,7 +1739,8 @@ func (c *Client) ListAccountNotes(accountId string, params *ListAccountNotesPara
 
 // GetAccountNote wraps GetAccountNoteWithContext using the background context
 func (c *Client) GetAccountNote(accountId string, accountNoteId string, opts ...Option) (*AccountNote, error) {
-	return c.getAccountNote(context.Background(), accountId, accountNoteId, opts...)
+	ctx := context.Background()
+	return c.getAccountNote(ctx, accountId, accountNoteId, opts...)
 }
 
 // GetAccountNoteWithContext Fetch an account note
@@ -1705,7 +1759,7 @@ func (c *Client) getAccountNote(ctx context.Context, accountId string, accountNo
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &AccountNote{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1802,7 +1856,11 @@ func (c *Client) ListShippingAddresses(accountId string, params *ListShippingAdd
 
 // CreateShippingAddress wraps CreateShippingAddressWithContext using the background context
 func (c *Client) CreateShippingAddress(accountId string, body *ShippingAddressCreate, opts ...Option) (*ShippingAddress, error) {
-	return c.createShippingAddress(context.Background(), accountId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.createShippingAddress(ctx, accountId, body, opts...)
 }
 
 // CreateShippingAddressWithContext Create a new shipping address for the account
@@ -1821,7 +1879,7 @@ func (c *Client) createShippingAddress(ctx context.Context, accountId string, bo
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &ShippingAddress{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1830,7 +1888,8 @@ func (c *Client) createShippingAddress(ctx context.Context, accountId string, bo
 
 // GetShippingAddress wraps GetShippingAddressWithContext using the background context
 func (c *Client) GetShippingAddress(accountId string, shippingAddressId string, opts ...Option) (*ShippingAddress, error) {
-	return c.getShippingAddress(context.Background(), accountId, shippingAddressId, opts...)
+	ctx := context.Background()
+	return c.getShippingAddress(ctx, accountId, shippingAddressId, opts...)
 }
 
 // GetShippingAddressWithContext Fetch an account's shipping address
@@ -1849,7 +1908,7 @@ func (c *Client) getShippingAddress(ctx context.Context, accountId string, shipp
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &ShippingAddress{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1858,7 +1917,11 @@ func (c *Client) getShippingAddress(ctx context.Context, accountId string, shipp
 
 // UpdateShippingAddress wraps UpdateShippingAddressWithContext using the background context
 func (c *Client) UpdateShippingAddress(accountId string, shippingAddressId string, body *ShippingAddressUpdate, opts ...Option) (*ShippingAddress, error) {
-	return c.updateShippingAddress(context.Background(), accountId, shippingAddressId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.updateShippingAddress(ctx, accountId, shippingAddressId, body, opts...)
 }
 
 // UpdateShippingAddressWithContext Update an account's shipping address
@@ -1877,7 +1940,7 @@ func (c *Client) updateShippingAddress(ctx context.Context, accountId string, sh
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &ShippingAddress{}
-	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1886,7 +1949,8 @@ func (c *Client) updateShippingAddress(ctx context.Context, accountId string, sh
 
 // RemoveShippingAddress wraps RemoveShippingAddressWithContext using the background context
 func (c *Client) RemoveShippingAddress(accountId string, shippingAddressId string, opts ...Option) (*Empty, error) {
-	return c.removeShippingAddress(context.Background(), accountId, shippingAddressId, opts...)
+	ctx := context.Background()
+	return c.removeShippingAddress(ctx, accountId, shippingAddressId, opts...)
 }
 
 // RemoveShippingAddressWithContext Remove an account's shipping address
@@ -1905,7 +1969,7 @@ func (c *Client) removeShippingAddress(ctx context.Context, accountId string, sh
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Empty{}
-	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2400,7 +2464,11 @@ func (c *Client) ListCoupons(params *ListCouponsParams, opts ...Option) *CouponL
 
 // CreateCoupon wraps CreateCouponWithContext using the background context
 func (c *Client) CreateCoupon(body *CouponCreate, opts ...Option) (*Coupon, error) {
-	return c.createCoupon(context.Background(), body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.createCoupon(ctx, body, opts...)
 }
 
 // CreateCouponWithContext Create a new coupon
@@ -2419,7 +2487,7 @@ func (c *Client) createCoupon(ctx context.Context, body *CouponCreate, opts ...O
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Coupon{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2428,7 +2496,8 @@ func (c *Client) createCoupon(ctx context.Context, body *CouponCreate, opts ...O
 
 // GetCoupon wraps GetCouponWithContext using the background context
 func (c *Client) GetCoupon(couponId string, opts ...Option) (*Coupon, error) {
-	return c.getCoupon(context.Background(), couponId, opts...)
+	ctx := context.Background()
+	return c.getCoupon(ctx, couponId, opts...)
 }
 
 // GetCouponWithContext Fetch a coupon
@@ -2447,7 +2516,7 @@ func (c *Client) getCoupon(ctx context.Context, couponId string, opts ...Option)
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Coupon{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2456,7 +2525,11 @@ func (c *Client) getCoupon(ctx context.Context, couponId string, opts ...Option)
 
 // UpdateCoupon wraps UpdateCouponWithContext using the background context
 func (c *Client) UpdateCoupon(couponId string, body *CouponUpdate, opts ...Option) (*Coupon, error) {
-	return c.updateCoupon(context.Background(), couponId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.updateCoupon(ctx, couponId, body, opts...)
 }
 
 // UpdateCouponWithContext Update an active coupon
@@ -2475,7 +2548,7 @@ func (c *Client) updateCoupon(ctx context.Context, couponId string, body *Coupon
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Coupon{}
-	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2484,7 +2557,8 @@ func (c *Client) updateCoupon(ctx context.Context, couponId string, body *Coupon
 
 // DeactivateCoupon wraps DeactivateCouponWithContext using the background context
 func (c *Client) DeactivateCoupon(couponId string, opts ...Option) (*Coupon, error) {
-	return c.deactivateCoupon(context.Background(), couponId, opts...)
+	ctx := context.Background()
+	return c.deactivateCoupon(ctx, couponId, opts...)
 }
 
 // DeactivateCouponWithContext Expire a coupon
@@ -2503,7 +2577,7 @@ func (c *Client) deactivateCoupon(ctx context.Context, couponId string, opts ...
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Coupon{}
-	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2512,7 +2586,11 @@ func (c *Client) deactivateCoupon(ctx context.Context, couponId string, opts ...
 
 // RestoreCoupon wraps RestoreCouponWithContext using the background context
 func (c *Client) RestoreCoupon(couponId string, body *CouponUpdate, opts ...Option) (*Coupon, error) {
-	return c.restoreCoupon(context.Background(), couponId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.restoreCoupon(ctx, couponId, body, opts...)
 }
 
 // RestoreCouponWithContext Restore an inactive coupon
@@ -2531,7 +2609,7 @@ func (c *Client) restoreCoupon(ctx context.Context, couponId string, body *Coupo
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Coupon{}
-	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2701,7 +2779,8 @@ func (c *Client) ListCreditPayments(params *ListCreditPaymentsParams, opts ...Op
 
 // GetCreditPayment wraps GetCreditPaymentWithContext using the background context
 func (c *Client) GetCreditPayment(creditPaymentId string, opts ...Option) (*CreditPayment, error) {
-	return c.getCreditPayment(context.Background(), creditPaymentId, opts...)
+	ctx := context.Background()
+	return c.getCreditPayment(ctx, creditPaymentId, opts...)
 }
 
 // GetCreditPaymentWithContext Fetch a credit payment
@@ -2720,7 +2799,7 @@ func (c *Client) getCreditPayment(ctx context.Context, creditPaymentId string, o
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &CreditPayment{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2824,7 +2903,8 @@ func (c *Client) ListCustomFieldDefinitions(params *ListCustomFieldDefinitionsPa
 
 // GetCustomFieldDefinition wraps GetCustomFieldDefinitionWithContext using the background context
 func (c *Client) GetCustomFieldDefinition(customFieldDefinitionId string, opts ...Option) (*CustomFieldDefinition, error) {
-	return c.getCustomFieldDefinition(context.Background(), customFieldDefinitionId, opts...)
+	ctx := context.Background()
+	return c.getCustomFieldDefinition(ctx, customFieldDefinitionId, opts...)
 }
 
 // GetCustomFieldDefinitionWithContext Fetch an custom field definition
@@ -2843,7 +2923,7 @@ func (c *Client) getCustomFieldDefinition(ctx context.Context, customFieldDefini
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &CustomFieldDefinition{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2947,7 +3027,11 @@ func (c *Client) ListItems(params *ListItemsParams, opts ...Option) *ItemList {
 
 // CreateItem wraps CreateItemWithContext using the background context
 func (c *Client) CreateItem(body *ItemCreate, opts ...Option) (*Item, error) {
-	return c.createItem(context.Background(), body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.createItem(ctx, body, opts...)
 }
 
 // CreateItemWithContext Create a new item
@@ -2966,7 +3050,7 @@ func (c *Client) createItem(ctx context.Context, body *ItemCreate, opts ...Optio
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Item{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2975,7 +3059,8 @@ func (c *Client) createItem(ctx context.Context, body *ItemCreate, opts ...Optio
 
 // GetItem wraps GetItemWithContext using the background context
 func (c *Client) GetItem(itemId string, opts ...Option) (*Item, error) {
-	return c.getItem(context.Background(), itemId, opts...)
+	ctx := context.Background()
+	return c.getItem(ctx, itemId, opts...)
 }
 
 // GetItemWithContext Fetch an item
@@ -2994,7 +3079,7 @@ func (c *Client) getItem(ctx context.Context, itemId string, opts ...Option) (*I
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Item{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3003,7 +3088,11 @@ func (c *Client) getItem(ctx context.Context, itemId string, opts ...Option) (*I
 
 // UpdateItem wraps UpdateItemWithContext using the background context
 func (c *Client) UpdateItem(itemId string, body *ItemUpdate, opts ...Option) (*Item, error) {
-	return c.updateItem(context.Background(), itemId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.updateItem(ctx, itemId, body, opts...)
 }
 
 // UpdateItemWithContext Update an active item
@@ -3022,7 +3111,7 @@ func (c *Client) updateItem(ctx context.Context, itemId string, body *ItemUpdate
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Item{}
-	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3031,7 +3120,8 @@ func (c *Client) updateItem(ctx context.Context, itemId string, body *ItemUpdate
 
 // DeactivateItem wraps DeactivateItemWithContext using the background context
 func (c *Client) DeactivateItem(itemId string, opts ...Option) (*Item, error) {
-	return c.deactivateItem(context.Background(), itemId, opts...)
+	ctx := context.Background()
+	return c.deactivateItem(ctx, itemId, opts...)
 }
 
 // DeactivateItemWithContext Deactivate an item
@@ -3050,7 +3140,7 @@ func (c *Client) deactivateItem(ctx context.Context, itemId string, opts ...Opti
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Item{}
-	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3059,7 +3149,8 @@ func (c *Client) deactivateItem(ctx context.Context, itemId string, opts ...Opti
 
 // ReactivateItem wraps ReactivateItemWithContext using the background context
 func (c *Client) ReactivateItem(itemId string, opts ...Option) (*Item, error) {
-	return c.reactivateItem(context.Background(), itemId, opts...)
+	ctx := context.Background()
+	return c.reactivateItem(ctx, itemId, opts...)
 }
 
 // ReactivateItemWithContext Reactivate an inactive item
@@ -3078,7 +3169,7 @@ func (c *Client) reactivateItem(ctx context.Context, itemId string, opts ...Opti
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Item{}
-	err = c.Call(context.Background(), http.MethodPut, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3182,7 +3273,11 @@ func (c *Client) ListMeasuredUnit(params *ListMeasuredUnitParams, opts ...Option
 
 // CreateMeasuredUnit wraps CreateMeasuredUnitWithContext using the background context
 func (c *Client) CreateMeasuredUnit(body *MeasuredUnitCreate, opts ...Option) (*MeasuredUnit, error) {
-	return c.createMeasuredUnit(context.Background(), body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.createMeasuredUnit(ctx, body, opts...)
 }
 
 // CreateMeasuredUnitWithContext Create a new measured unit
@@ -3201,7 +3296,7 @@ func (c *Client) createMeasuredUnit(ctx context.Context, body *MeasuredUnitCreat
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &MeasuredUnit{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3210,7 +3305,8 @@ func (c *Client) createMeasuredUnit(ctx context.Context, body *MeasuredUnitCreat
 
 // GetMeasuredUnit wraps GetMeasuredUnitWithContext using the background context
 func (c *Client) GetMeasuredUnit(measuredUnitId string, opts ...Option) (*MeasuredUnit, error) {
-	return c.getMeasuredUnit(context.Background(), measuredUnitId, opts...)
+	ctx := context.Background()
+	return c.getMeasuredUnit(ctx, measuredUnitId, opts...)
 }
 
 // GetMeasuredUnitWithContext Fetch a measured unit
@@ -3229,7 +3325,7 @@ func (c *Client) getMeasuredUnit(ctx context.Context, measuredUnitId string, opt
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &MeasuredUnit{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3238,7 +3334,11 @@ func (c *Client) getMeasuredUnit(ctx context.Context, measuredUnitId string, opt
 
 // UpdateMeasuredUnit wraps UpdateMeasuredUnitWithContext using the background context
 func (c *Client) UpdateMeasuredUnit(measuredUnitId string, body *MeasuredUnitUpdate, opts ...Option) (*MeasuredUnit, error) {
-	return c.updateMeasuredUnit(context.Background(), measuredUnitId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.updateMeasuredUnit(ctx, measuredUnitId, body, opts...)
 }
 
 // UpdateMeasuredUnitWithContext Update a measured unit
@@ -3257,7 +3357,7 @@ func (c *Client) updateMeasuredUnit(ctx context.Context, measuredUnitId string, 
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &MeasuredUnit{}
-	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3266,7 +3366,8 @@ func (c *Client) updateMeasuredUnit(ctx context.Context, measuredUnitId string, 
 
 // RemoveMeasuredUnit wraps RemoveMeasuredUnitWithContext using the background context
 func (c *Client) RemoveMeasuredUnit(measuredUnitId string, opts ...Option) (*MeasuredUnit, error) {
-	return c.removeMeasuredUnit(context.Background(), measuredUnitId, opts...)
+	ctx := context.Background()
+	return c.removeMeasuredUnit(ctx, measuredUnitId, opts...)
 }
 
 // RemoveMeasuredUnitWithContext Remove a measured unit
@@ -3285,7 +3386,7 @@ func (c *Client) removeMeasuredUnit(ctx context.Context, measuredUnitId string, 
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &MeasuredUnit{}
-	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3393,7 +3494,8 @@ func (c *Client) ListInvoices(params *ListInvoicesParams, opts ...Option) *Invoi
 
 // GetInvoice wraps GetInvoiceWithContext using the background context
 func (c *Client) GetInvoice(invoiceId string, opts ...Option) (*Invoice, error) {
-	return c.getInvoice(context.Background(), invoiceId, opts...)
+	ctx := context.Background()
+	return c.getInvoice(ctx, invoiceId, opts...)
 }
 
 // GetInvoiceWithContext Fetch an invoice
@@ -3412,7 +3514,7 @@ func (c *Client) getInvoice(ctx context.Context, invoiceId string, opts ...Optio
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Invoice{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3421,7 +3523,11 @@ func (c *Client) getInvoice(ctx context.Context, invoiceId string, opts ...Optio
 
 // PutInvoice wraps PutInvoiceWithContext using the background context
 func (c *Client) PutInvoice(invoiceId string, body *InvoiceUpdatable, opts ...Option) (*Invoice, error) {
-	return c.putInvoice(context.Background(), invoiceId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.putInvoice(ctx, invoiceId, body, opts...)
 }
 
 // PutInvoiceWithContext Update an invoice
@@ -3440,7 +3546,7 @@ func (c *Client) putInvoice(ctx context.Context, invoiceId string, body *Invoice
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Invoice{}
-	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3471,7 +3577,8 @@ func (list *CollectInvoiceParams) URLParams() []KeyValue {
 
 // CollectInvoice wraps CollectInvoiceWithContext using the background context
 func (c *Client) CollectInvoice(invoiceId string, params *CollectInvoiceParams, opts ...Option) (*Invoice, error) {
-	return c.collectInvoice(context.Background(), invoiceId, params, opts...)
+	ctx := context.Background()
+	return c.collectInvoice(ctx, invoiceId, params, opts...)
 }
 
 // CollectInvoiceWithContext Collect a pending or past due, automatic invoice
@@ -3490,7 +3597,7 @@ func (c *Client) collectInvoice(ctx context.Context, invoiceId string, params *C
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Invoice{}
-	err = c.Call(context.Background(), http.MethodPut, path, nil, params, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, nil, params, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3499,7 +3606,8 @@ func (c *Client) collectInvoice(ctx context.Context, invoiceId string, params *C
 
 // FailInvoice wraps FailInvoiceWithContext using the background context
 func (c *Client) FailInvoice(invoiceId string, opts ...Option) (*Invoice, error) {
-	return c.failInvoice(context.Background(), invoiceId, opts...)
+	ctx := context.Background()
+	return c.failInvoice(ctx, invoiceId, opts...)
 }
 
 // FailInvoiceWithContext Mark an open invoice as failed
@@ -3518,7 +3626,7 @@ func (c *Client) failInvoice(ctx context.Context, invoiceId string, opts ...Opti
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Invoice{}
-	err = c.Call(context.Background(), http.MethodPut, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3527,7 +3635,8 @@ func (c *Client) failInvoice(ctx context.Context, invoiceId string, opts ...Opti
 
 // MarkInvoiceSuccessful wraps MarkInvoiceSuccessfulWithContext using the background context
 func (c *Client) MarkInvoiceSuccessful(invoiceId string, opts ...Option) (*Invoice, error) {
-	return c.markInvoiceSuccessful(context.Background(), invoiceId, opts...)
+	ctx := context.Background()
+	return c.markInvoiceSuccessful(ctx, invoiceId, opts...)
 }
 
 // MarkInvoiceSuccessfulWithContext Mark an open invoice as successful
@@ -3546,7 +3655,7 @@ func (c *Client) markInvoiceSuccessful(ctx context.Context, invoiceId string, op
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Invoice{}
-	err = c.Call(context.Background(), http.MethodPut, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3555,7 +3664,8 @@ func (c *Client) markInvoiceSuccessful(ctx context.Context, invoiceId string, op
 
 // ReopenInvoice wraps ReopenInvoiceWithContext using the background context
 func (c *Client) ReopenInvoice(invoiceId string, opts ...Option) (*Invoice, error) {
-	return c.reopenInvoice(context.Background(), invoiceId, opts...)
+	ctx := context.Background()
+	return c.reopenInvoice(ctx, invoiceId, opts...)
 }
 
 // ReopenInvoiceWithContext Reopen a closed, manual invoice
@@ -3574,7 +3684,7 @@ func (c *Client) reopenInvoice(ctx context.Context, invoiceId string, opts ...Op
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Invoice{}
-	err = c.Call(context.Background(), http.MethodPut, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3583,7 +3693,8 @@ func (c *Client) reopenInvoice(ctx context.Context, invoiceId string, opts ...Op
 
 // VoidInvoice wraps VoidInvoiceWithContext using the background context
 func (c *Client) VoidInvoice(invoiceId string, opts ...Option) (*Invoice, error) {
-	return c.voidInvoice(context.Background(), invoiceId, opts...)
+	ctx := context.Background()
+	return c.voidInvoice(ctx, invoiceId, opts...)
 }
 
 // VoidInvoiceWithContext Void a credit invoice.
@@ -3602,7 +3713,7 @@ func (c *Client) voidInvoice(ctx context.Context, invoiceId string, opts ...Opti
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Invoice{}
-	err = c.Call(context.Background(), http.MethodPut, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3611,7 +3722,11 @@ func (c *Client) voidInvoice(ctx context.Context, invoiceId string, opts ...Opti
 
 // RecordExternalTransaction wraps RecordExternalTransactionWithContext using the background context
 func (c *Client) RecordExternalTransaction(invoiceId string, body *ExternalTransaction, opts ...Option) (*Transaction, error) {
-	return c.recordExternalTransaction(context.Background(), invoiceId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.recordExternalTransaction(ctx, invoiceId, body, opts...)
 }
 
 // RecordExternalTransactionWithContext Record an external payment for a manual invoices.
@@ -3630,7 +3745,7 @@ func (c *Client) recordExternalTransaction(ctx context.Context, invoiceId string
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Transaction{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3836,7 +3951,11 @@ func (c *Client) ListRelatedInvoices(invoiceId string, opts ...Option) *InvoiceL
 
 // RefundInvoice wraps RefundInvoiceWithContext using the background context
 func (c *Client) RefundInvoice(invoiceId string, body *InvoiceRefund, opts ...Option) (*Invoice, error) {
-	return c.refundInvoice(context.Background(), invoiceId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.refundInvoice(ctx, invoiceId, body, opts...)
 }
 
 // RefundInvoiceWithContext Refund an invoice
@@ -3855,7 +3974,7 @@ func (c *Client) refundInvoice(ctx context.Context, invoiceId string, body *Invo
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Invoice{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3973,7 +4092,8 @@ func (c *Client) ListLineItems(params *ListLineItemsParams, opts ...Option) *Lin
 
 // GetLineItem wraps GetLineItemWithContext using the background context
 func (c *Client) GetLineItem(lineItemId string, opts ...Option) (*LineItem, error) {
-	return c.getLineItem(context.Background(), lineItemId, opts...)
+	ctx := context.Background()
+	return c.getLineItem(ctx, lineItemId, opts...)
 }
 
 // GetLineItemWithContext Fetch a line item
@@ -3992,7 +4112,7 @@ func (c *Client) getLineItem(ctx context.Context, lineItemId string, opts ...Opt
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &LineItem{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4001,7 +4121,8 @@ func (c *Client) getLineItem(ctx context.Context, lineItemId string, opts ...Opt
 
 // RemoveLineItem wraps RemoveLineItemWithContext using the background context
 func (c *Client) RemoveLineItem(lineItemId string, opts ...Option) (*Empty, error) {
-	return c.removeLineItem(context.Background(), lineItemId, opts...)
+	ctx := context.Background()
+	return c.removeLineItem(ctx, lineItemId, opts...)
 }
 
 // RemoveLineItemWithContext Delete an uninvoiced line item
@@ -4020,7 +4141,7 @@ func (c *Client) removeLineItem(ctx context.Context, lineItemId string, opts ...
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Empty{}
-	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4124,7 +4245,11 @@ func (c *Client) ListPlans(params *ListPlansParams, opts ...Option) *PlanList {
 
 // CreatePlan wraps CreatePlanWithContext using the background context
 func (c *Client) CreatePlan(body *PlanCreate, opts ...Option) (*Plan, error) {
-	return c.createPlan(context.Background(), body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.createPlan(ctx, body, opts...)
 }
 
 // CreatePlanWithContext Create a plan
@@ -4143,7 +4268,7 @@ func (c *Client) createPlan(ctx context.Context, body *PlanCreate, opts ...Optio
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Plan{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4152,7 +4277,8 @@ func (c *Client) createPlan(ctx context.Context, body *PlanCreate, opts ...Optio
 
 // GetPlan wraps GetPlanWithContext using the background context
 func (c *Client) GetPlan(planId string, opts ...Option) (*Plan, error) {
-	return c.getPlan(context.Background(), planId, opts...)
+	ctx := context.Background()
+	return c.getPlan(ctx, planId, opts...)
 }
 
 // GetPlanWithContext Fetch a plan
@@ -4171,7 +4297,7 @@ func (c *Client) getPlan(ctx context.Context, planId string, opts ...Option) (*P
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Plan{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4180,7 +4306,11 @@ func (c *Client) getPlan(ctx context.Context, planId string, opts ...Option) (*P
 
 // UpdatePlan wraps UpdatePlanWithContext using the background context
 func (c *Client) UpdatePlan(planId string, body *PlanUpdate, opts ...Option) (*Plan, error) {
-	return c.updatePlan(context.Background(), planId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.updatePlan(ctx, planId, body, opts...)
 }
 
 // UpdatePlanWithContext Update a plan
@@ -4199,7 +4329,7 @@ func (c *Client) updatePlan(ctx context.Context, planId string, body *PlanUpdate
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Plan{}
-	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4208,7 +4338,8 @@ func (c *Client) updatePlan(ctx context.Context, planId string, body *PlanUpdate
 
 // RemovePlan wraps RemovePlanWithContext using the background context
 func (c *Client) RemovePlan(planId string, opts ...Option) (*Plan, error) {
-	return c.removePlan(context.Background(), planId, opts...)
+	ctx := context.Background()
+	return c.removePlan(ctx, planId, opts...)
 }
 
 // RemovePlanWithContext Remove a plan
@@ -4227,7 +4358,7 @@ func (c *Client) removePlan(ctx context.Context, planId string, opts ...Option) 
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Plan{}
-	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4331,7 +4462,11 @@ func (c *Client) ListPlanAddOns(planId string, params *ListPlanAddOnsParams, opt
 
 // CreatePlanAddOn wraps CreatePlanAddOnWithContext using the background context
 func (c *Client) CreatePlanAddOn(planId string, body *AddOnCreate, opts ...Option) (*AddOn, error) {
-	return c.createPlanAddOn(context.Background(), planId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.createPlanAddOn(ctx, planId, body, opts...)
 }
 
 // CreatePlanAddOnWithContext Create an add-on
@@ -4350,7 +4485,7 @@ func (c *Client) createPlanAddOn(ctx context.Context, planId string, body *AddOn
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &AddOn{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4359,7 +4494,8 @@ func (c *Client) createPlanAddOn(ctx context.Context, planId string, body *AddOn
 
 // GetPlanAddOn wraps GetPlanAddOnWithContext using the background context
 func (c *Client) GetPlanAddOn(planId string, addOnId string, opts ...Option) (*AddOn, error) {
-	return c.getPlanAddOn(context.Background(), planId, addOnId, opts...)
+	ctx := context.Background()
+	return c.getPlanAddOn(ctx, planId, addOnId, opts...)
 }
 
 // GetPlanAddOnWithContext Fetch a plan's add-on
@@ -4378,7 +4514,7 @@ func (c *Client) getPlanAddOn(ctx context.Context, planId string, addOnId string
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &AddOn{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4387,7 +4523,11 @@ func (c *Client) getPlanAddOn(ctx context.Context, planId string, addOnId string
 
 // UpdatePlanAddOn wraps UpdatePlanAddOnWithContext using the background context
 func (c *Client) UpdatePlanAddOn(planId string, addOnId string, body *AddOnUpdate, opts ...Option) (*AddOn, error) {
-	return c.updatePlanAddOn(context.Background(), planId, addOnId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.updatePlanAddOn(ctx, planId, addOnId, body, opts...)
 }
 
 // UpdatePlanAddOnWithContext Update an add-on
@@ -4406,7 +4546,7 @@ func (c *Client) updatePlanAddOn(ctx context.Context, planId string, addOnId str
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &AddOn{}
-	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4415,7 +4555,8 @@ func (c *Client) updatePlanAddOn(ctx context.Context, planId string, addOnId str
 
 // RemovePlanAddOn wraps RemovePlanAddOnWithContext using the background context
 func (c *Client) RemovePlanAddOn(planId string, addOnId string, opts ...Option) (*AddOn, error) {
-	return c.removePlanAddOn(context.Background(), planId, addOnId, opts...)
+	ctx := context.Background()
+	return c.removePlanAddOn(ctx, planId, addOnId, opts...)
 }
 
 // RemovePlanAddOnWithContext Remove an add-on
@@ -4434,7 +4575,7 @@ func (c *Client) removePlanAddOn(ctx context.Context, planId string, addOnId str
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &AddOn{}
-	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4538,7 +4679,8 @@ func (c *Client) ListAddOns(params *ListAddOnsParams, opts ...Option) *AddOnList
 
 // GetAddOn wraps GetAddOnWithContext using the background context
 func (c *Client) GetAddOn(addOnId string, opts ...Option) (*AddOn, error) {
-	return c.getAddOn(context.Background(), addOnId, opts...)
+	ctx := context.Background()
+	return c.getAddOn(ctx, addOnId, opts...)
 }
 
 // GetAddOnWithContext Fetch an add-on
@@ -4557,7 +4699,7 @@ func (c *Client) getAddOn(ctx context.Context, addOnId string, opts ...Option) (
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &AddOn{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4654,7 +4796,11 @@ func (c *Client) ListShippingMethods(params *ListShippingMethodsParams, opts ...
 
 // CreateShippingMethod wraps CreateShippingMethodWithContext using the background context
 func (c *Client) CreateShippingMethod(body *ShippingMethodCreate, opts ...Option) (*ShippingMethod, error) {
-	return c.createShippingMethod(context.Background(), body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.createShippingMethod(ctx, body, opts...)
 }
 
 // CreateShippingMethodWithContext Create a new shipping method
@@ -4673,7 +4819,7 @@ func (c *Client) createShippingMethod(ctx context.Context, body *ShippingMethodC
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &ShippingMethod{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4682,7 +4828,8 @@ func (c *Client) createShippingMethod(ctx context.Context, body *ShippingMethodC
 
 // GetShippingMethod wraps GetShippingMethodWithContext using the background context
 func (c *Client) GetShippingMethod(id string, opts ...Option) (*ShippingMethod, error) {
-	return c.getShippingMethod(context.Background(), id, opts...)
+	ctx := context.Background()
+	return c.getShippingMethod(ctx, id, opts...)
 }
 
 // GetShippingMethodWithContext Fetch a shipping method
@@ -4701,7 +4848,7 @@ func (c *Client) getShippingMethod(ctx context.Context, id string, opts ...Optio
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &ShippingMethod{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4710,7 +4857,11 @@ func (c *Client) getShippingMethod(ctx context.Context, id string, opts ...Optio
 
 // UpdateShippingMethod wraps UpdateShippingMethodWithContext using the background context
 func (c *Client) UpdateShippingMethod(shippingMethodId string, body *ShippingMethodUpdate, opts ...Option) (*ShippingMethod, error) {
-	return c.updateShippingMethod(context.Background(), shippingMethodId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.updateShippingMethod(ctx, shippingMethodId, body, opts...)
 }
 
 // UpdateShippingMethodWithContext Update an active Shipping Method
@@ -4729,7 +4880,7 @@ func (c *Client) updateShippingMethod(ctx context.Context, shippingMethodId stri
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &ShippingMethod{}
-	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4738,7 +4889,8 @@ func (c *Client) updateShippingMethod(ctx context.Context, shippingMethodId stri
 
 // DeactivateShippingMethod wraps DeactivateShippingMethodWithContext using the background context
 func (c *Client) DeactivateShippingMethod(shippingMethodId string, opts ...Option) (*ShippingMethod, error) {
-	return c.deactivateShippingMethod(context.Background(), shippingMethodId, opts...)
+	ctx := context.Background()
+	return c.deactivateShippingMethod(ctx, shippingMethodId, opts...)
 }
 
 // DeactivateShippingMethodWithContext Deactivate a shipping method
@@ -4757,7 +4909,7 @@ func (c *Client) deactivateShippingMethod(ctx context.Context, shippingMethodId 
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &ShippingMethod{}
-	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4864,7 +5016,11 @@ func (c *Client) ListSubscriptions(params *ListSubscriptionsParams, opts ...Opti
 
 // CreateSubscription wraps CreateSubscriptionWithContext using the background context
 func (c *Client) CreateSubscription(body *SubscriptionCreate, opts ...Option) (*Subscription, error) {
-	return c.createSubscription(context.Background(), body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.createSubscription(ctx, body, opts...)
 }
 
 // CreateSubscriptionWithContext Create a new subscription
@@ -4883,7 +5039,7 @@ func (c *Client) createSubscription(ctx context.Context, body *SubscriptionCreat
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Subscription{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4892,7 +5048,8 @@ func (c *Client) createSubscription(ctx context.Context, body *SubscriptionCreat
 
 // GetSubscription wraps GetSubscriptionWithContext using the background context
 func (c *Client) GetSubscription(subscriptionId string, opts ...Option) (*Subscription, error) {
-	return c.getSubscription(context.Background(), subscriptionId, opts...)
+	ctx := context.Background()
+	return c.getSubscription(ctx, subscriptionId, opts...)
 }
 
 // GetSubscriptionWithContext Fetch a subscription
@@ -4911,7 +5068,7 @@ func (c *Client) getSubscription(ctx context.Context, subscriptionId string, opt
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Subscription{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4920,7 +5077,11 @@ func (c *Client) getSubscription(ctx context.Context, subscriptionId string, opt
 
 // ModifySubscription wraps ModifySubscriptionWithContext using the background context
 func (c *Client) ModifySubscription(subscriptionId string, body *SubscriptionUpdate, opts ...Option) (*Subscription, error) {
-	return c.modifySubscription(context.Background(), subscriptionId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.modifySubscription(ctx, subscriptionId, body, opts...)
 }
 
 // ModifySubscriptionWithContext Modify a subscription
@@ -4939,7 +5100,7 @@ func (c *Client) modifySubscription(ctx context.Context, subscriptionId string, 
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Subscription{}
-	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4986,7 +5147,8 @@ func (list *TerminateSubscriptionParams) URLParams() []KeyValue {
 
 // TerminateSubscription wraps TerminateSubscriptionWithContext using the background context
 func (c *Client) TerminateSubscription(subscriptionId string, params *TerminateSubscriptionParams, opts ...Option) (*Subscription, error) {
-	return c.terminateSubscription(context.Background(), subscriptionId, params, opts...)
+	ctx := context.Background()
+	return c.terminateSubscription(ctx, subscriptionId, params, opts...)
 }
 
 // TerminateSubscriptionWithContext Terminate a subscription
@@ -5005,7 +5167,7 @@ func (c *Client) terminateSubscription(ctx context.Context, subscriptionId strin
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Subscription{}
-	err = c.Call(context.Background(), http.MethodDelete, path, nil, params, requestOptions, result)
+	err = c.Call(ctx, http.MethodDelete, path, nil, params, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -5036,7 +5198,8 @@ func (list *CancelSubscriptionParams) URLParams() []KeyValue {
 
 // CancelSubscription wraps CancelSubscriptionWithContext using the background context
 func (c *Client) CancelSubscription(subscriptionId string, params *CancelSubscriptionParams, opts ...Option) (*Subscription, error) {
-	return c.cancelSubscription(context.Background(), subscriptionId, params, opts...)
+	ctx := context.Background()
+	return c.cancelSubscription(ctx, subscriptionId, params, opts...)
 }
 
 // CancelSubscriptionWithContext Cancel a subscription
@@ -5055,7 +5218,7 @@ func (c *Client) cancelSubscription(ctx context.Context, subscriptionId string, 
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Subscription{}
-	err = c.Call(context.Background(), http.MethodPut, path, nil, params, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, nil, params, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -5064,7 +5227,8 @@ func (c *Client) cancelSubscription(ctx context.Context, subscriptionId string, 
 
 // ReactivateSubscription wraps ReactivateSubscriptionWithContext using the background context
 func (c *Client) ReactivateSubscription(subscriptionId string, opts ...Option) (*Subscription, error) {
-	return c.reactivateSubscription(context.Background(), subscriptionId, opts...)
+	ctx := context.Background()
+	return c.reactivateSubscription(ctx, subscriptionId, opts...)
 }
 
 // ReactivateSubscriptionWithContext Reactivate a canceled subscription
@@ -5083,7 +5247,7 @@ func (c *Client) reactivateSubscription(ctx context.Context, subscriptionId stri
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Subscription{}
-	err = c.Call(context.Background(), http.MethodPut, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -5092,7 +5256,11 @@ func (c *Client) reactivateSubscription(ctx context.Context, subscriptionId stri
 
 // PauseSubscription wraps PauseSubscriptionWithContext using the background context
 func (c *Client) PauseSubscription(subscriptionId string, body *SubscriptionPause, opts ...Option) (*Subscription, error) {
-	return c.pauseSubscription(context.Background(), subscriptionId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.pauseSubscription(ctx, subscriptionId, body, opts...)
 }
 
 // PauseSubscriptionWithContext Pause subscription
@@ -5111,7 +5279,7 @@ func (c *Client) pauseSubscription(ctx context.Context, subscriptionId string, b
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Subscription{}
-	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -5120,7 +5288,8 @@ func (c *Client) pauseSubscription(ctx context.Context, subscriptionId string, b
 
 // ResumeSubscription wraps ResumeSubscriptionWithContext using the background context
 func (c *Client) ResumeSubscription(subscriptionId string, opts ...Option) (*Subscription, error) {
-	return c.resumeSubscription(context.Background(), subscriptionId, opts...)
+	ctx := context.Background()
+	return c.resumeSubscription(ctx, subscriptionId, opts...)
 }
 
 // ResumeSubscriptionWithContext Resume subscription
@@ -5139,7 +5308,7 @@ func (c *Client) resumeSubscription(ctx context.Context, subscriptionId string, 
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Subscription{}
-	err = c.Call(context.Background(), http.MethodPut, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -5148,7 +5317,8 @@ func (c *Client) resumeSubscription(ctx context.Context, subscriptionId string, 
 
 // ConvertTrial wraps ConvertTrialWithContext using the background context
 func (c *Client) ConvertTrial(subscriptionId string, opts ...Option) (*Subscription, error) {
-	return c.convertTrial(context.Background(), subscriptionId, opts...)
+	ctx := context.Background()
+	return c.convertTrial(ctx, subscriptionId, opts...)
 }
 
 // ConvertTrialWithContext Convert trial subscription
@@ -5167,7 +5337,7 @@ func (c *Client) convertTrial(ctx context.Context, subscriptionId string, opts .
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Subscription{}
-	err = c.Call(context.Background(), http.MethodPut, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -5176,7 +5346,8 @@ func (c *Client) convertTrial(ctx context.Context, subscriptionId string, opts .
 
 // GetSubscriptionChange wraps GetSubscriptionChangeWithContext using the background context
 func (c *Client) GetSubscriptionChange(subscriptionId string, opts ...Option) (*SubscriptionChange, error) {
-	return c.getSubscriptionChange(context.Background(), subscriptionId, opts...)
+	ctx := context.Background()
+	return c.getSubscriptionChange(ctx, subscriptionId, opts...)
 }
 
 // GetSubscriptionChangeWithContext Fetch a subscription's pending change
@@ -5195,7 +5366,7 @@ func (c *Client) getSubscriptionChange(ctx context.Context, subscriptionId strin
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &SubscriptionChange{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -5204,7 +5375,11 @@ func (c *Client) getSubscriptionChange(ctx context.Context, subscriptionId strin
 
 // CreateSubscriptionChange wraps CreateSubscriptionChangeWithContext using the background context
 func (c *Client) CreateSubscriptionChange(subscriptionId string, body *SubscriptionChangeCreate, opts ...Option) (*SubscriptionChange, error) {
-	return c.createSubscriptionChange(context.Background(), subscriptionId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.createSubscriptionChange(ctx, subscriptionId, body, opts...)
 }
 
 // CreateSubscriptionChangeWithContext Create a new subscription change
@@ -5223,7 +5398,7 @@ func (c *Client) createSubscriptionChange(ctx context.Context, subscriptionId st
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &SubscriptionChange{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -5232,7 +5407,8 @@ func (c *Client) createSubscriptionChange(ctx context.Context, subscriptionId st
 
 // RemoveSubscriptionChange wraps RemoveSubscriptionChangeWithContext using the background context
 func (c *Client) RemoveSubscriptionChange(subscriptionId string, opts ...Option) (*Empty, error) {
-	return c.removeSubscriptionChange(context.Background(), subscriptionId, opts...)
+	ctx := context.Background()
+	return c.removeSubscriptionChange(ctx, subscriptionId, opts...)
 }
 
 // RemoveSubscriptionChangeWithContext Delete the pending subscription change
@@ -5251,7 +5427,7 @@ func (c *Client) removeSubscriptionChange(ctx context.Context, subscriptionId st
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Empty{}
-	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -5260,7 +5436,11 @@ func (c *Client) removeSubscriptionChange(ctx context.Context, subscriptionId st
 
 // PreviewSubscriptionChange wraps PreviewSubscriptionChangeWithContext using the background context
 func (c *Client) PreviewSubscriptionChange(subscriptionId string, body *SubscriptionChangeCreate, opts ...Option) (*SubscriptionChangePreview, error) {
-	return c.previewSubscriptionChange(context.Background(), subscriptionId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.previewSubscriptionChange(ctx, subscriptionId, body, opts...)
 }
 
 // PreviewSubscriptionChangeWithContext Preview a new subscription change
@@ -5279,7 +5459,7 @@ func (c *Client) previewSubscriptionChange(ctx context.Context, subscriptionId s
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &SubscriptionChangePreview{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -5665,7 +5845,11 @@ func (c *Client) ListUsage(subscriptionId string, addOnId string, params *ListUs
 
 // CreateUsage wraps CreateUsageWithContext using the background context
 func (c *Client) CreateUsage(subscriptionId string, addOnId string, body *UsageCreate, opts ...Option) (*Usage, error) {
-	return c.createUsage(context.Background(), subscriptionId, addOnId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.createUsage(ctx, subscriptionId, addOnId, body, opts...)
 }
 
 // CreateUsageWithContext Log a usage record on this subscription add-on
@@ -5684,7 +5868,7 @@ func (c *Client) createUsage(ctx context.Context, subscriptionId string, addOnId
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Usage{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -5693,7 +5877,8 @@ func (c *Client) createUsage(ctx context.Context, subscriptionId string, addOnId
 
 // GetUsage wraps GetUsageWithContext using the background context
 func (c *Client) GetUsage(usageId string, opts ...Option) (*Usage, error) {
-	return c.getUsage(context.Background(), usageId, opts...)
+	ctx := context.Background()
+	return c.getUsage(ctx, usageId, opts...)
 }
 
 // GetUsageWithContext Get a usage record
@@ -5712,7 +5897,7 @@ func (c *Client) getUsage(ctx context.Context, usageId string, opts ...Option) (
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Usage{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -5721,7 +5906,11 @@ func (c *Client) getUsage(ctx context.Context, usageId string, opts ...Option) (
 
 // UpdateUsage wraps UpdateUsageWithContext using the background context
 func (c *Client) UpdateUsage(usageId string, body *UsageCreate, opts ...Option) (*Usage, error) {
-	return c.updateUsage(context.Background(), usageId, body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.updateUsage(ctx, usageId, body, opts...)
 }
 
 // UpdateUsageWithContext Update a usage record
@@ -5740,7 +5929,7 @@ func (c *Client) updateUsage(ctx context.Context, usageId string, body *UsageCre
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Usage{}
-	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -5749,7 +5938,8 @@ func (c *Client) updateUsage(ctx context.Context, usageId string, body *UsageCre
 
 // RemoveUsage wraps RemoveUsageWithContext using the background context
 func (c *Client) RemoveUsage(usageId string, opts ...Option) (*Empty, error) {
-	return c.removeUsage(context.Background(), usageId, opts...)
+	ctx := context.Background()
+	return c.removeUsage(ctx, usageId, opts...)
 }
 
 // RemoveUsageWithContext Delete a usage record.
@@ -5768,7 +5958,7 @@ func (c *Client) removeUsage(ctx context.Context, usageId string, opts ...Option
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Empty{}
-	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -5879,7 +6069,8 @@ func (c *Client) ListTransactions(params *ListTransactionsParams, opts ...Option
 
 // GetTransaction wraps GetTransactionWithContext using the background context
 func (c *Client) GetTransaction(transactionId string, opts ...Option) (*Transaction, error) {
-	return c.getTransaction(context.Background(), transactionId, opts...)
+	ctx := context.Background()
+	return c.getTransaction(ctx, transactionId, opts...)
 }
 
 // GetTransactionWithContext Fetch a transaction
@@ -5898,7 +6089,7 @@ func (c *Client) getTransaction(ctx context.Context, transactionId string, opts 
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &Transaction{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -5907,7 +6098,8 @@ func (c *Client) getTransaction(ctx context.Context, transactionId string, opts 
 
 // GetUniqueCouponCode wraps GetUniqueCouponCodeWithContext using the background context
 func (c *Client) GetUniqueCouponCode(uniqueCouponCodeId string, opts ...Option) (*UniqueCouponCode, error) {
-	return c.getUniqueCouponCode(context.Background(), uniqueCouponCodeId, opts...)
+	ctx := context.Background()
+	return c.getUniqueCouponCode(ctx, uniqueCouponCodeId, opts...)
 }
 
 // GetUniqueCouponCodeWithContext Fetch a unique coupon code
@@ -5926,7 +6118,7 @@ func (c *Client) getUniqueCouponCode(ctx context.Context, uniqueCouponCodeId str
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &UniqueCouponCode{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -5935,7 +6127,8 @@ func (c *Client) getUniqueCouponCode(ctx context.Context, uniqueCouponCodeId str
 
 // DeactivateUniqueCouponCode wraps DeactivateUniqueCouponCodeWithContext using the background context
 func (c *Client) DeactivateUniqueCouponCode(uniqueCouponCodeId string, opts ...Option) (*UniqueCouponCode, error) {
-	return c.deactivateUniqueCouponCode(context.Background(), uniqueCouponCodeId, opts...)
+	ctx := context.Background()
+	return c.deactivateUniqueCouponCode(ctx, uniqueCouponCodeId, opts...)
 }
 
 // DeactivateUniqueCouponCodeWithContext Deactivate a unique coupon code
@@ -5954,7 +6147,7 @@ func (c *Client) deactivateUniqueCouponCode(ctx context.Context, uniqueCouponCod
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &UniqueCouponCode{}
-	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -5963,7 +6156,8 @@ func (c *Client) deactivateUniqueCouponCode(ctx context.Context, uniqueCouponCod
 
 // ReactivateUniqueCouponCode wraps ReactivateUniqueCouponCodeWithContext using the background context
 func (c *Client) ReactivateUniqueCouponCode(uniqueCouponCodeId string, opts ...Option) (*UniqueCouponCode, error) {
-	return c.reactivateUniqueCouponCode(context.Background(), uniqueCouponCodeId, opts...)
+	ctx := context.Background()
+	return c.reactivateUniqueCouponCode(ctx, uniqueCouponCodeId, opts...)
 }
 
 // ReactivateUniqueCouponCodeWithContext Restore a unique coupon code
@@ -5982,7 +6176,7 @@ func (c *Client) reactivateUniqueCouponCode(ctx context.Context, uniqueCouponCod
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &UniqueCouponCode{}
-	err = c.Call(context.Background(), http.MethodPut, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPut, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -5991,7 +6185,11 @@ func (c *Client) reactivateUniqueCouponCode(ctx context.Context, uniqueCouponCod
 
 // CreatePurchase wraps CreatePurchaseWithContext using the background context
 func (c *Client) CreatePurchase(body *PurchaseCreate, opts ...Option) (*InvoiceCollection, error) {
-	return c.createPurchase(context.Background(), body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.createPurchase(ctx, body, opts...)
 }
 
 // CreatePurchaseWithContext Create a new purchase
@@ -6010,7 +6208,7 @@ func (c *Client) createPurchase(ctx context.Context, body *PurchaseCreate, opts 
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &InvoiceCollection{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -6019,7 +6217,11 @@ func (c *Client) createPurchase(ctx context.Context, body *PurchaseCreate, opts 
 
 // PreviewPurchase wraps PreviewPurchaseWithContext using the background context
 func (c *Client) PreviewPurchase(body *PurchaseCreate, opts ...Option) (*InvoiceCollection, error) {
-	return c.previewPurchase(context.Background(), body, opts...)
+	ctx := context.Background()
+	if body.Params.Context != nil {
+		ctx = body.Params.Context
+	}
+	return c.previewPurchase(ctx, body, opts...)
 }
 
 // PreviewPurchaseWithContext Preview a new purchase
@@ -6038,7 +6240,7 @@ func (c *Client) previewPurchase(ctx context.Context, body *PurchaseCreate, opts
 	}
 	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &InvoiceCollection{}
-	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -6047,7 +6249,8 @@ func (c *Client) previewPurchase(ctx context.Context, body *PurchaseCreate, opts
 
 // GetExportDates wraps GetExportDatesWithContext using the background context
 func (c *Client) GetExportDates(opts ...Option) (*ExportDates, error) {
-	return c.getExportDates(context.Background(), opts...)
+	ctx := context.Background()
+	return c.getExportDates(ctx, opts...)
 }
 
 // GetExportDatesWithContext List the dates that have an available export to download.
@@ -6066,7 +6269,7 @@ func (c *Client) getExportDates(ctx context.Context, opts ...Option) (*ExportDat
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &ExportDates{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -6075,7 +6278,8 @@ func (c *Client) getExportDates(ctx context.Context, opts ...Option) (*ExportDat
 
 // GetExportFiles wraps GetExportFilesWithContext using the background context
 func (c *Client) GetExportFiles(exportDate string, opts ...Option) (*ExportFiles, error) {
-	return c.getExportFiles(context.Background(), exportDate, opts...)
+	ctx := context.Background()
+	return c.getExportFiles(ctx, exportDate, opts...)
 }
 
 // GetExportFilesWithContext List of the export files that are available to download.
@@ -6094,7 +6298,7 @@ func (c *Client) getExportFiles(ctx context.Context, exportDate string, opts ...
 	}
 	requestOptions := NewRequestOptions(opts...)
 	result := &ExportFiles{}
-	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}

--- a/client_operations.go
+++ b/client_operations.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 	"strings"
@@ -17,259 +18,352 @@ const (
 )
 
 type ClientInterface interface {
-	ListSites(params *ListSitesParams) *SiteList
+	ListSites(params *ListSitesParams, opts ...Option) *SiteList
 
-	GetSite(siteId string) (*Site, error)
+	GetSite(siteId string, opts ...Option) (*Site, error)
+	GetSiteWithContext(ctx context.Context, siteId string, opts ...Option) (*Site, error)
 
-	ListAccounts(params *ListAccountsParams) *AccountList
+	ListAccounts(params *ListAccountsParams, opts ...Option) *AccountList
 
-	CreateAccount(body *AccountCreate) (*Account, error)
+	CreateAccount(body *AccountCreate, opts ...Option) (*Account, error)
+	CreateAccountWithContext(ctx context.Context, body *AccountCreate, opts ...Option) (*Account, error)
 
-	GetAccount(accountId string) (*Account, error)
+	GetAccount(accountId string, opts ...Option) (*Account, error)
+	GetAccountWithContext(ctx context.Context, accountId string, opts ...Option) (*Account, error)
 
-	UpdateAccount(accountId string, body *AccountUpdate) (*Account, error)
+	UpdateAccount(accountId string, body *AccountUpdate, opts ...Option) (*Account, error)
+	UpdateAccountWithContext(ctx context.Context, accountId string, body *AccountUpdate, opts ...Option) (*Account, error)
 
-	DeactivateAccount(accountId string) (*Account, error)
+	DeactivateAccount(accountId string, opts ...Option) (*Account, error)
+	DeactivateAccountWithContext(ctx context.Context, accountId string, opts ...Option) (*Account, error)
 
-	GetAccountAcquisition(accountId string) (*AccountAcquisition, error)
+	GetAccountAcquisition(accountId string, opts ...Option) (*AccountAcquisition, error)
+	GetAccountAcquisitionWithContext(ctx context.Context, accountId string, opts ...Option) (*AccountAcquisition, error)
 
-	UpdateAccountAcquisition(accountId string, body *AccountAcquisitionUpdatable) (*AccountAcquisition, error)
+	UpdateAccountAcquisition(accountId string, body *AccountAcquisitionUpdatable, opts ...Option) (*AccountAcquisition, error)
+	UpdateAccountAcquisitionWithContext(ctx context.Context, accountId string, body *AccountAcquisitionUpdatable, opts ...Option) (*AccountAcquisition, error)
 
-	RemoveAccountAcquisition(accountId string) (*Empty, error)
+	RemoveAccountAcquisition(accountId string, opts ...Option) (*Empty, error)
+	RemoveAccountAcquisitionWithContext(ctx context.Context, accountId string, opts ...Option) (*Empty, error)
 
-	ReactivateAccount(accountId string) (*Account, error)
+	ReactivateAccount(accountId string, opts ...Option) (*Account, error)
+	ReactivateAccountWithContext(ctx context.Context, accountId string, opts ...Option) (*Account, error)
 
-	GetAccountBalance(accountId string) (*AccountBalance, error)
+	GetAccountBalance(accountId string, opts ...Option) (*AccountBalance, error)
+	GetAccountBalanceWithContext(ctx context.Context, accountId string, opts ...Option) (*AccountBalance, error)
 
-	GetBillingInfo(accountId string) (*BillingInfo, error)
+	GetBillingInfo(accountId string, opts ...Option) (*BillingInfo, error)
+	GetBillingInfoWithContext(ctx context.Context, accountId string, opts ...Option) (*BillingInfo, error)
 
-	UpdateBillingInfo(accountId string, body *BillingInfoCreate) (*BillingInfo, error)
+	UpdateBillingInfo(accountId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error)
+	UpdateBillingInfoWithContext(ctx context.Context, accountId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error)
 
-	RemoveBillingInfo(accountId string) (*Empty, error)
+	RemoveBillingInfo(accountId string, opts ...Option) (*Empty, error)
+	RemoveBillingInfoWithContext(ctx context.Context, accountId string, opts ...Option) (*Empty, error)
 
-	ListBillingInfos(accountId string, params *ListBillingInfosParams) *BillingInfoList
+	ListBillingInfos(accountId string, params *ListBillingInfosParams, opts ...Option) *BillingInfoList
 
-	CreateBillingInfo(accountId string, body *BillingInfoCreate) (*BillingInfo, error)
+	CreateBillingInfo(accountId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error)
+	CreateBillingInfoWithContext(ctx context.Context, accountId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error)
 
-	GetABillingInfo(accountId string, billingInfoId string) (*BillingInfo, error)
+	GetABillingInfo(accountId string, billingInfoId string, opts ...Option) (*BillingInfo, error)
+	GetABillingInfoWithContext(ctx context.Context, accountId string, billingInfoId string, opts ...Option) (*BillingInfo, error)
 
-	UpdateABillingInfo(accountId string, billingInfoId string, body *BillingInfoCreate) (*BillingInfo, error)
+	UpdateABillingInfo(accountId string, billingInfoId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error)
+	UpdateABillingInfoWithContext(ctx context.Context, accountId string, billingInfoId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error)
 
-	RemoveABillingInfo(accountId string, billingInfoId string) (*Empty, error)
+	RemoveABillingInfo(accountId string, billingInfoId string, opts ...Option) (*Empty, error)
+	RemoveABillingInfoWithContext(ctx context.Context, accountId string, billingInfoId string, opts ...Option) (*Empty, error)
 
-	ListAccountCouponRedemptions(accountId string, params *ListAccountCouponRedemptionsParams) *CouponRedemptionList
+	ListAccountCouponRedemptions(accountId string, params *ListAccountCouponRedemptionsParams, opts ...Option) *CouponRedemptionList
 
-	GetActiveCouponRedemption(accountId string) (*CouponRedemption, error)
+	GetActiveCouponRedemption(accountId string, opts ...Option) (*CouponRedemption, error)
+	GetActiveCouponRedemptionWithContext(ctx context.Context, accountId string, opts ...Option) (*CouponRedemption, error)
 
-	CreateCouponRedemption(accountId string, body *CouponRedemptionCreate) (*CouponRedemption, error)
+	CreateCouponRedemption(accountId string, body *CouponRedemptionCreate, opts ...Option) (*CouponRedemption, error)
+	CreateCouponRedemptionWithContext(ctx context.Context, accountId string, body *CouponRedemptionCreate, opts ...Option) (*CouponRedemption, error)
 
-	RemoveCouponRedemption(accountId string) (*CouponRedemption, error)
+	RemoveCouponRedemption(accountId string, opts ...Option) (*CouponRedemption, error)
+	RemoveCouponRedemptionWithContext(ctx context.Context, accountId string, opts ...Option) (*CouponRedemption, error)
 
-	ListAccountCreditPayments(accountId string, params *ListAccountCreditPaymentsParams) *CreditPaymentList
+	ListAccountCreditPayments(accountId string, params *ListAccountCreditPaymentsParams, opts ...Option) *CreditPaymentList
 
-	ListAccountInvoices(accountId string, params *ListAccountInvoicesParams) *InvoiceList
+	ListAccountInvoices(accountId string, params *ListAccountInvoicesParams, opts ...Option) *InvoiceList
 
-	CreateInvoice(accountId string, body *InvoiceCreate) (*InvoiceCollection, error)
+	CreateInvoice(accountId string, body *InvoiceCreate, opts ...Option) (*InvoiceCollection, error)
+	CreateInvoiceWithContext(ctx context.Context, accountId string, body *InvoiceCreate, opts ...Option) (*InvoiceCollection, error)
 
-	PreviewInvoice(accountId string, body *InvoiceCreate) (*InvoiceCollection, error)
+	PreviewInvoice(accountId string, body *InvoiceCreate, opts ...Option) (*InvoiceCollection, error)
+	PreviewInvoiceWithContext(ctx context.Context, accountId string, body *InvoiceCreate, opts ...Option) (*InvoiceCollection, error)
 
-	ListAccountLineItems(accountId string, params *ListAccountLineItemsParams) *LineItemList
+	ListAccountLineItems(accountId string, params *ListAccountLineItemsParams, opts ...Option) *LineItemList
 
-	CreateLineItem(accountId string, body *LineItemCreate) (*LineItem, error)
+	CreateLineItem(accountId string, body *LineItemCreate, opts ...Option) (*LineItem, error)
+	CreateLineItemWithContext(ctx context.Context, accountId string, body *LineItemCreate, opts ...Option) (*LineItem, error)
 
-	ListAccountNotes(accountId string, params *ListAccountNotesParams) *AccountNoteList
+	ListAccountNotes(accountId string, params *ListAccountNotesParams, opts ...Option) *AccountNoteList
 
-	GetAccountNote(accountId string, accountNoteId string) (*AccountNote, error)
+	GetAccountNote(accountId string, accountNoteId string, opts ...Option) (*AccountNote, error)
+	GetAccountNoteWithContext(ctx context.Context, accountId string, accountNoteId string, opts ...Option) (*AccountNote, error)
 
-	ListShippingAddresses(accountId string, params *ListShippingAddressesParams) *ShippingAddressList
+	ListShippingAddresses(accountId string, params *ListShippingAddressesParams, opts ...Option) *ShippingAddressList
 
-	CreateShippingAddress(accountId string, body *ShippingAddressCreate) (*ShippingAddress, error)
+	CreateShippingAddress(accountId string, body *ShippingAddressCreate, opts ...Option) (*ShippingAddress, error)
+	CreateShippingAddressWithContext(ctx context.Context, accountId string, body *ShippingAddressCreate, opts ...Option) (*ShippingAddress, error)
 
-	GetShippingAddress(accountId string, shippingAddressId string) (*ShippingAddress, error)
+	GetShippingAddress(accountId string, shippingAddressId string, opts ...Option) (*ShippingAddress, error)
+	GetShippingAddressWithContext(ctx context.Context, accountId string, shippingAddressId string, opts ...Option) (*ShippingAddress, error)
 
-	UpdateShippingAddress(accountId string, shippingAddressId string, body *ShippingAddressUpdate) (*ShippingAddress, error)
+	UpdateShippingAddress(accountId string, shippingAddressId string, body *ShippingAddressUpdate, opts ...Option) (*ShippingAddress, error)
+	UpdateShippingAddressWithContext(ctx context.Context, accountId string, shippingAddressId string, body *ShippingAddressUpdate, opts ...Option) (*ShippingAddress, error)
 
-	RemoveShippingAddress(accountId string, shippingAddressId string) (*Empty, error)
+	RemoveShippingAddress(accountId string, shippingAddressId string, opts ...Option) (*Empty, error)
+	RemoveShippingAddressWithContext(ctx context.Context, accountId string, shippingAddressId string, opts ...Option) (*Empty, error)
 
-	ListAccountSubscriptions(accountId string, params *ListAccountSubscriptionsParams) *SubscriptionList
+	ListAccountSubscriptions(accountId string, params *ListAccountSubscriptionsParams, opts ...Option) *SubscriptionList
 
-	ListAccountTransactions(accountId string, params *ListAccountTransactionsParams) *TransactionList
+	ListAccountTransactions(accountId string, params *ListAccountTransactionsParams, opts ...Option) *TransactionList
 
-	ListChildAccounts(accountId string, params *ListChildAccountsParams) *AccountList
+	ListChildAccounts(accountId string, params *ListChildAccountsParams, opts ...Option) *AccountList
 
-	ListAccountAcquisition(params *ListAccountAcquisitionParams) *AccountAcquisitionList
+	ListAccountAcquisition(params *ListAccountAcquisitionParams, opts ...Option) *AccountAcquisitionList
 
-	ListCoupons(params *ListCouponsParams) *CouponList
+	ListCoupons(params *ListCouponsParams, opts ...Option) *CouponList
 
-	CreateCoupon(body *CouponCreate) (*Coupon, error)
+	CreateCoupon(body *CouponCreate, opts ...Option) (*Coupon, error)
+	CreateCouponWithContext(ctx context.Context, body *CouponCreate, opts ...Option) (*Coupon, error)
 
-	GetCoupon(couponId string) (*Coupon, error)
+	GetCoupon(couponId string, opts ...Option) (*Coupon, error)
+	GetCouponWithContext(ctx context.Context, couponId string, opts ...Option) (*Coupon, error)
 
-	UpdateCoupon(couponId string, body *CouponUpdate) (*Coupon, error)
+	UpdateCoupon(couponId string, body *CouponUpdate, opts ...Option) (*Coupon, error)
+	UpdateCouponWithContext(ctx context.Context, couponId string, body *CouponUpdate, opts ...Option) (*Coupon, error)
 
-	DeactivateCoupon(couponId string) (*Coupon, error)
+	DeactivateCoupon(couponId string, opts ...Option) (*Coupon, error)
+	DeactivateCouponWithContext(ctx context.Context, couponId string, opts ...Option) (*Coupon, error)
 
-	RestoreCoupon(couponId string, body *CouponUpdate) (*Coupon, error)
+	RestoreCoupon(couponId string, body *CouponUpdate, opts ...Option) (*Coupon, error)
+	RestoreCouponWithContext(ctx context.Context, couponId string, body *CouponUpdate, opts ...Option) (*Coupon, error)
 
-	ListUniqueCouponCodes(couponId string, params *ListUniqueCouponCodesParams) *UniqueCouponCodeList
+	ListUniqueCouponCodes(couponId string, params *ListUniqueCouponCodesParams, opts ...Option) *UniqueCouponCodeList
 
-	ListCreditPayments(params *ListCreditPaymentsParams) *CreditPaymentList
+	ListCreditPayments(params *ListCreditPaymentsParams, opts ...Option) *CreditPaymentList
 
-	GetCreditPayment(creditPaymentId string) (*CreditPayment, error)
+	GetCreditPayment(creditPaymentId string, opts ...Option) (*CreditPayment, error)
+	GetCreditPaymentWithContext(ctx context.Context, creditPaymentId string, opts ...Option) (*CreditPayment, error)
 
-	ListCustomFieldDefinitions(params *ListCustomFieldDefinitionsParams) *CustomFieldDefinitionList
+	ListCustomFieldDefinitions(params *ListCustomFieldDefinitionsParams, opts ...Option) *CustomFieldDefinitionList
 
-	GetCustomFieldDefinition(customFieldDefinitionId string) (*CustomFieldDefinition, error)
+	GetCustomFieldDefinition(customFieldDefinitionId string, opts ...Option) (*CustomFieldDefinition, error)
+	GetCustomFieldDefinitionWithContext(ctx context.Context, customFieldDefinitionId string, opts ...Option) (*CustomFieldDefinition, error)
 
-	ListItems(params *ListItemsParams) *ItemList
+	ListItems(params *ListItemsParams, opts ...Option) *ItemList
 
-	CreateItem(body *ItemCreate) (*Item, error)
+	CreateItem(body *ItemCreate, opts ...Option) (*Item, error)
+	CreateItemWithContext(ctx context.Context, body *ItemCreate, opts ...Option) (*Item, error)
 
-	GetItem(itemId string) (*Item, error)
+	GetItem(itemId string, opts ...Option) (*Item, error)
+	GetItemWithContext(ctx context.Context, itemId string, opts ...Option) (*Item, error)
 
-	UpdateItem(itemId string, body *ItemUpdate) (*Item, error)
+	UpdateItem(itemId string, body *ItemUpdate, opts ...Option) (*Item, error)
+	UpdateItemWithContext(ctx context.Context, itemId string, body *ItemUpdate, opts ...Option) (*Item, error)
 
-	DeactivateItem(itemId string) (*Item, error)
+	DeactivateItem(itemId string, opts ...Option) (*Item, error)
+	DeactivateItemWithContext(ctx context.Context, itemId string, opts ...Option) (*Item, error)
 
-	ReactivateItem(itemId string) (*Item, error)
+	ReactivateItem(itemId string, opts ...Option) (*Item, error)
+	ReactivateItemWithContext(ctx context.Context, itemId string, opts ...Option) (*Item, error)
 
-	ListMeasuredUnit(params *ListMeasuredUnitParams) *MeasuredUnitList
+	ListMeasuredUnit(params *ListMeasuredUnitParams, opts ...Option) *MeasuredUnitList
 
-	CreateMeasuredUnit(body *MeasuredUnitCreate) (*MeasuredUnit, error)
+	CreateMeasuredUnit(body *MeasuredUnitCreate, opts ...Option) (*MeasuredUnit, error)
+	CreateMeasuredUnitWithContext(ctx context.Context, body *MeasuredUnitCreate, opts ...Option) (*MeasuredUnit, error)
 
-	GetMeasuredUnit(measuredUnitId string) (*MeasuredUnit, error)
+	GetMeasuredUnit(measuredUnitId string, opts ...Option) (*MeasuredUnit, error)
+	GetMeasuredUnitWithContext(ctx context.Context, measuredUnitId string, opts ...Option) (*MeasuredUnit, error)
 
-	UpdateMeasuredUnit(measuredUnitId string, body *MeasuredUnitUpdate) (*MeasuredUnit, error)
+	UpdateMeasuredUnit(measuredUnitId string, body *MeasuredUnitUpdate, opts ...Option) (*MeasuredUnit, error)
+	UpdateMeasuredUnitWithContext(ctx context.Context, measuredUnitId string, body *MeasuredUnitUpdate, opts ...Option) (*MeasuredUnit, error)
 
-	RemoveMeasuredUnit(measuredUnitId string) (*MeasuredUnit, error)
+	RemoveMeasuredUnit(measuredUnitId string, opts ...Option) (*MeasuredUnit, error)
+	RemoveMeasuredUnitWithContext(ctx context.Context, measuredUnitId string, opts ...Option) (*MeasuredUnit, error)
 
-	ListInvoices(params *ListInvoicesParams) *InvoiceList
+	ListInvoices(params *ListInvoicesParams, opts ...Option) *InvoiceList
 
-	GetInvoice(invoiceId string) (*Invoice, error)
+	GetInvoice(invoiceId string, opts ...Option) (*Invoice, error)
+	GetInvoiceWithContext(ctx context.Context, invoiceId string, opts ...Option) (*Invoice, error)
 
-	PutInvoice(invoiceId string, body *InvoiceUpdatable) (*Invoice, error)
+	PutInvoice(invoiceId string, body *InvoiceUpdatable, opts ...Option) (*Invoice, error)
+	PutInvoiceWithContext(ctx context.Context, invoiceId string, body *InvoiceUpdatable, opts ...Option) (*Invoice, error)
 
-	CollectInvoice(invoiceId string, params *CollectInvoiceParams) (*Invoice, error)
+	CollectInvoice(invoiceId string, params *CollectInvoiceParams, opts ...Option) (*Invoice, error)
+	CollectInvoiceWithContext(ctx context.Context, invoiceId string, params *CollectInvoiceParams, opts ...Option) (*Invoice, error)
 
-	FailInvoice(invoiceId string) (*Invoice, error)
+	FailInvoice(invoiceId string, opts ...Option) (*Invoice, error)
+	FailInvoiceWithContext(ctx context.Context, invoiceId string, opts ...Option) (*Invoice, error)
 
-	MarkInvoiceSuccessful(invoiceId string) (*Invoice, error)
+	MarkInvoiceSuccessful(invoiceId string, opts ...Option) (*Invoice, error)
+	MarkInvoiceSuccessfulWithContext(ctx context.Context, invoiceId string, opts ...Option) (*Invoice, error)
 
-	ReopenInvoice(invoiceId string) (*Invoice, error)
+	ReopenInvoice(invoiceId string, opts ...Option) (*Invoice, error)
+	ReopenInvoiceWithContext(ctx context.Context, invoiceId string, opts ...Option) (*Invoice, error)
 
-	VoidInvoice(invoiceId string) (*Invoice, error)
+	VoidInvoice(invoiceId string, opts ...Option) (*Invoice, error)
+	VoidInvoiceWithContext(ctx context.Context, invoiceId string, opts ...Option) (*Invoice, error)
 
-	RecordExternalTransaction(invoiceId string, body *ExternalTransaction) (*Transaction, error)
+	RecordExternalTransaction(invoiceId string, body *ExternalTransaction, opts ...Option) (*Transaction, error)
+	RecordExternalTransactionWithContext(ctx context.Context, invoiceId string, body *ExternalTransaction, opts ...Option) (*Transaction, error)
 
-	ListInvoiceLineItems(invoiceId string, params *ListInvoiceLineItemsParams) *LineItemList
+	ListInvoiceLineItems(invoiceId string, params *ListInvoiceLineItemsParams, opts ...Option) *LineItemList
 
-	ListInvoiceCouponRedemptions(invoiceId string, params *ListInvoiceCouponRedemptionsParams) *CouponRedemptionList
+	ListInvoiceCouponRedemptions(invoiceId string, params *ListInvoiceCouponRedemptionsParams, opts ...Option) *CouponRedemptionList
 
-	ListRelatedInvoices(invoiceId string) *InvoiceList
+	ListRelatedInvoices(invoiceId string, opts ...Option) *InvoiceList
 
-	RefundInvoice(invoiceId string, body *InvoiceRefund) (*Invoice, error)
+	RefundInvoice(invoiceId string, body *InvoiceRefund, opts ...Option) (*Invoice, error)
+	RefundInvoiceWithContext(ctx context.Context, invoiceId string, body *InvoiceRefund, opts ...Option) (*Invoice, error)
 
-	ListLineItems(params *ListLineItemsParams) *LineItemList
+	ListLineItems(params *ListLineItemsParams, opts ...Option) *LineItemList
 
-	GetLineItem(lineItemId string) (*LineItem, error)
+	GetLineItem(lineItemId string, opts ...Option) (*LineItem, error)
+	GetLineItemWithContext(ctx context.Context, lineItemId string, opts ...Option) (*LineItem, error)
 
-	RemoveLineItem(lineItemId string) (*Empty, error)
+	RemoveLineItem(lineItemId string, opts ...Option) (*Empty, error)
+	RemoveLineItemWithContext(ctx context.Context, lineItemId string, opts ...Option) (*Empty, error)
 
-	ListPlans(params *ListPlansParams) *PlanList
+	ListPlans(params *ListPlansParams, opts ...Option) *PlanList
 
-	CreatePlan(body *PlanCreate) (*Plan, error)
+	CreatePlan(body *PlanCreate, opts ...Option) (*Plan, error)
+	CreatePlanWithContext(ctx context.Context, body *PlanCreate, opts ...Option) (*Plan, error)
 
-	GetPlan(planId string) (*Plan, error)
+	GetPlan(planId string, opts ...Option) (*Plan, error)
+	GetPlanWithContext(ctx context.Context, planId string, opts ...Option) (*Plan, error)
 
-	UpdatePlan(planId string, body *PlanUpdate) (*Plan, error)
+	UpdatePlan(planId string, body *PlanUpdate, opts ...Option) (*Plan, error)
+	UpdatePlanWithContext(ctx context.Context, planId string, body *PlanUpdate, opts ...Option) (*Plan, error)
 
-	RemovePlan(planId string) (*Plan, error)
+	RemovePlan(planId string, opts ...Option) (*Plan, error)
+	RemovePlanWithContext(ctx context.Context, planId string, opts ...Option) (*Plan, error)
 
-	ListPlanAddOns(planId string, params *ListPlanAddOnsParams) *AddOnList
+	ListPlanAddOns(planId string, params *ListPlanAddOnsParams, opts ...Option) *AddOnList
 
-	CreatePlanAddOn(planId string, body *AddOnCreate) (*AddOn, error)
+	CreatePlanAddOn(planId string, body *AddOnCreate, opts ...Option) (*AddOn, error)
+	CreatePlanAddOnWithContext(ctx context.Context, planId string, body *AddOnCreate, opts ...Option) (*AddOn, error)
 
-	GetPlanAddOn(planId string, addOnId string) (*AddOn, error)
+	GetPlanAddOn(planId string, addOnId string, opts ...Option) (*AddOn, error)
+	GetPlanAddOnWithContext(ctx context.Context, planId string, addOnId string, opts ...Option) (*AddOn, error)
 
-	UpdatePlanAddOn(planId string, addOnId string, body *AddOnUpdate) (*AddOn, error)
+	UpdatePlanAddOn(planId string, addOnId string, body *AddOnUpdate, opts ...Option) (*AddOn, error)
+	UpdatePlanAddOnWithContext(ctx context.Context, planId string, addOnId string, body *AddOnUpdate, opts ...Option) (*AddOn, error)
 
-	RemovePlanAddOn(planId string, addOnId string) (*AddOn, error)
+	RemovePlanAddOn(planId string, addOnId string, opts ...Option) (*AddOn, error)
+	RemovePlanAddOnWithContext(ctx context.Context, planId string, addOnId string, opts ...Option) (*AddOn, error)
 
-	ListAddOns(params *ListAddOnsParams) *AddOnList
+	ListAddOns(params *ListAddOnsParams, opts ...Option) *AddOnList
 
-	GetAddOn(addOnId string) (*AddOn, error)
+	GetAddOn(addOnId string, opts ...Option) (*AddOn, error)
+	GetAddOnWithContext(ctx context.Context, addOnId string, opts ...Option) (*AddOn, error)
 
-	ListShippingMethods(params *ListShippingMethodsParams) *ShippingMethodList
+	ListShippingMethods(params *ListShippingMethodsParams, opts ...Option) *ShippingMethodList
 
-	CreateShippingMethod(body *ShippingMethodCreate) (*ShippingMethod, error)
+	CreateShippingMethod(body *ShippingMethodCreate, opts ...Option) (*ShippingMethod, error)
+	CreateShippingMethodWithContext(ctx context.Context, body *ShippingMethodCreate, opts ...Option) (*ShippingMethod, error)
 
-	GetShippingMethod(id string) (*ShippingMethod, error)
+	GetShippingMethod(id string, opts ...Option) (*ShippingMethod, error)
+	GetShippingMethodWithContext(ctx context.Context, id string, opts ...Option) (*ShippingMethod, error)
 
-	UpdateShippingMethod(shippingMethodId string, body *ShippingMethodUpdate) (*ShippingMethod, error)
+	UpdateShippingMethod(shippingMethodId string, body *ShippingMethodUpdate, opts ...Option) (*ShippingMethod, error)
+	UpdateShippingMethodWithContext(ctx context.Context, shippingMethodId string, body *ShippingMethodUpdate, opts ...Option) (*ShippingMethod, error)
 
-	DeactivateShippingMethod(shippingMethodId string) (*ShippingMethod, error)
+	DeactivateShippingMethod(shippingMethodId string, opts ...Option) (*ShippingMethod, error)
+	DeactivateShippingMethodWithContext(ctx context.Context, shippingMethodId string, opts ...Option) (*ShippingMethod, error)
 
-	ListSubscriptions(params *ListSubscriptionsParams) *SubscriptionList
+	ListSubscriptions(params *ListSubscriptionsParams, opts ...Option) *SubscriptionList
 
-	CreateSubscription(body *SubscriptionCreate) (*Subscription, error)
+	CreateSubscription(body *SubscriptionCreate, opts ...Option) (*Subscription, error)
+	CreateSubscriptionWithContext(ctx context.Context, body *SubscriptionCreate, opts ...Option) (*Subscription, error)
 
-	GetSubscription(subscriptionId string) (*Subscription, error)
+	GetSubscription(subscriptionId string, opts ...Option) (*Subscription, error)
+	GetSubscriptionWithContext(ctx context.Context, subscriptionId string, opts ...Option) (*Subscription, error)
 
-	ModifySubscription(subscriptionId string, body *SubscriptionUpdate) (*Subscription, error)
+	ModifySubscription(subscriptionId string, body *SubscriptionUpdate, opts ...Option) (*Subscription, error)
+	ModifySubscriptionWithContext(ctx context.Context, subscriptionId string, body *SubscriptionUpdate, opts ...Option) (*Subscription, error)
 
-	TerminateSubscription(subscriptionId string, params *TerminateSubscriptionParams) (*Subscription, error)
+	TerminateSubscription(subscriptionId string, params *TerminateSubscriptionParams, opts ...Option) (*Subscription, error)
+	TerminateSubscriptionWithContext(ctx context.Context, subscriptionId string, params *TerminateSubscriptionParams, opts ...Option) (*Subscription, error)
 
-	CancelSubscription(subscriptionId string, params *CancelSubscriptionParams) (*Subscription, error)
+	CancelSubscription(subscriptionId string, params *CancelSubscriptionParams, opts ...Option) (*Subscription, error)
+	CancelSubscriptionWithContext(ctx context.Context, subscriptionId string, params *CancelSubscriptionParams, opts ...Option) (*Subscription, error)
 
-	ReactivateSubscription(subscriptionId string) (*Subscription, error)
+	ReactivateSubscription(subscriptionId string, opts ...Option) (*Subscription, error)
+	ReactivateSubscriptionWithContext(ctx context.Context, subscriptionId string, opts ...Option) (*Subscription, error)
 
-	PauseSubscription(subscriptionId string, body *SubscriptionPause) (*Subscription, error)
+	PauseSubscription(subscriptionId string, body *SubscriptionPause, opts ...Option) (*Subscription, error)
+	PauseSubscriptionWithContext(ctx context.Context, subscriptionId string, body *SubscriptionPause, opts ...Option) (*Subscription, error)
 
-	ResumeSubscription(subscriptionId string) (*Subscription, error)
+	ResumeSubscription(subscriptionId string, opts ...Option) (*Subscription, error)
+	ResumeSubscriptionWithContext(ctx context.Context, subscriptionId string, opts ...Option) (*Subscription, error)
 
-	ConvertTrial(subscriptionId string) (*Subscription, error)
+	ConvertTrial(subscriptionId string, opts ...Option) (*Subscription, error)
+	ConvertTrialWithContext(ctx context.Context, subscriptionId string, opts ...Option) (*Subscription, error)
 
-	GetSubscriptionChange(subscriptionId string) (*SubscriptionChange, error)
+	GetSubscriptionChange(subscriptionId string, opts ...Option) (*SubscriptionChange, error)
+	GetSubscriptionChangeWithContext(ctx context.Context, subscriptionId string, opts ...Option) (*SubscriptionChange, error)
 
-	CreateSubscriptionChange(subscriptionId string, body *SubscriptionChangeCreate) (*SubscriptionChange, error)
+	CreateSubscriptionChange(subscriptionId string, body *SubscriptionChangeCreate, opts ...Option) (*SubscriptionChange, error)
+	CreateSubscriptionChangeWithContext(ctx context.Context, subscriptionId string, body *SubscriptionChangeCreate, opts ...Option) (*SubscriptionChange, error)
 
-	RemoveSubscriptionChange(subscriptionId string) (*Empty, error)
+	RemoveSubscriptionChange(subscriptionId string, opts ...Option) (*Empty, error)
+	RemoveSubscriptionChangeWithContext(ctx context.Context, subscriptionId string, opts ...Option) (*Empty, error)
 
-	PreviewSubscriptionChange(subscriptionId string, body *SubscriptionChangeCreate) (*SubscriptionChangePreview, error)
+	PreviewSubscriptionChange(subscriptionId string, body *SubscriptionChangeCreate, opts ...Option) (*SubscriptionChangePreview, error)
+	PreviewSubscriptionChangeWithContext(ctx context.Context, subscriptionId string, body *SubscriptionChangeCreate, opts ...Option) (*SubscriptionChangePreview, error)
 
-	ListSubscriptionInvoices(subscriptionId string, params *ListSubscriptionInvoicesParams) *InvoiceList
+	ListSubscriptionInvoices(subscriptionId string, params *ListSubscriptionInvoicesParams, opts ...Option) *InvoiceList
 
-	ListSubscriptionLineItems(subscriptionId string, params *ListSubscriptionLineItemsParams) *LineItemList
+	ListSubscriptionLineItems(subscriptionId string, params *ListSubscriptionLineItemsParams, opts ...Option) *LineItemList
 
-	ListSubscriptionCouponRedemptions(subscriptionId string, params *ListSubscriptionCouponRedemptionsParams) *CouponRedemptionList
+	ListSubscriptionCouponRedemptions(subscriptionId string, params *ListSubscriptionCouponRedemptionsParams, opts ...Option) *CouponRedemptionList
 
-	ListUsage(subscriptionId string, addOnId string, params *ListUsageParams) *UsageList
+	ListUsage(subscriptionId string, addOnId string, params *ListUsageParams, opts ...Option) *UsageList
 
-	CreateUsage(subscriptionId string, addOnId string, body *UsageCreate) (*Usage, error)
+	CreateUsage(subscriptionId string, addOnId string, body *UsageCreate, opts ...Option) (*Usage, error)
+	CreateUsageWithContext(ctx context.Context, subscriptionId string, addOnId string, body *UsageCreate, opts ...Option) (*Usage, error)
 
-	GetUsage(usageId string) (*Usage, error)
+	GetUsage(usageId string, opts ...Option) (*Usage, error)
+	GetUsageWithContext(ctx context.Context, usageId string, opts ...Option) (*Usage, error)
 
-	UpdateUsage(usageId string, body *UsageCreate) (*Usage, error)
+	UpdateUsage(usageId string, body *UsageCreate, opts ...Option) (*Usage, error)
+	UpdateUsageWithContext(ctx context.Context, usageId string, body *UsageCreate, opts ...Option) (*Usage, error)
 
-	RemoveUsage(usageId string) (*Empty, error)
+	RemoveUsage(usageId string, opts ...Option) (*Empty, error)
+	RemoveUsageWithContext(ctx context.Context, usageId string, opts ...Option) (*Empty, error)
 
-	ListTransactions(params *ListTransactionsParams) *TransactionList
+	ListTransactions(params *ListTransactionsParams, opts ...Option) *TransactionList
 
-	GetTransaction(transactionId string) (*Transaction, error)
+	GetTransaction(transactionId string, opts ...Option) (*Transaction, error)
+	GetTransactionWithContext(ctx context.Context, transactionId string, opts ...Option) (*Transaction, error)
 
-	GetUniqueCouponCode(uniqueCouponCodeId string) (*UniqueCouponCode, error)
+	GetUniqueCouponCode(uniqueCouponCodeId string, opts ...Option) (*UniqueCouponCode, error)
+	GetUniqueCouponCodeWithContext(ctx context.Context, uniqueCouponCodeId string, opts ...Option) (*UniqueCouponCode, error)
 
-	DeactivateUniqueCouponCode(uniqueCouponCodeId string) (*UniqueCouponCode, error)
+	DeactivateUniqueCouponCode(uniqueCouponCodeId string, opts ...Option) (*UniqueCouponCode, error)
+	DeactivateUniqueCouponCodeWithContext(ctx context.Context, uniqueCouponCodeId string, opts ...Option) (*UniqueCouponCode, error)
 
-	ReactivateUniqueCouponCode(uniqueCouponCodeId string) (*UniqueCouponCode, error)
+	ReactivateUniqueCouponCode(uniqueCouponCodeId string, opts ...Option) (*UniqueCouponCode, error)
+	ReactivateUniqueCouponCodeWithContext(ctx context.Context, uniqueCouponCodeId string, opts ...Option) (*UniqueCouponCode, error)
 
-	CreatePurchase(body *PurchaseCreate) (*InvoiceCollection, error)
+	CreatePurchase(body *PurchaseCreate, opts ...Option) (*InvoiceCollection, error)
+	CreatePurchaseWithContext(ctx context.Context, body *PurchaseCreate, opts ...Option) (*InvoiceCollection, error)
 
-	PreviewPurchase(body *PurchaseCreate) (*InvoiceCollection, error)
+	PreviewPurchase(body *PurchaseCreate, opts ...Option) (*InvoiceCollection, error)
+	PreviewPurchaseWithContext(ctx context.Context, body *PurchaseCreate, opts ...Option) (*InvoiceCollection, error)
 
-	GetExportDates() (*ExportDates, error)
+	GetExportDates(opts ...Option) (*ExportDates, error)
+	GetExportDatesWithContext(ctx context.Context, opts ...Option) (*ExportDates, error)
 
-	GetExportFiles(exportDate string) (*ExportFiles, error)
+	GetExportFiles(exportDate string, opts ...Option) (*ExportFiles, error)
+	GetExportFilesWithContext(ctx context.Context, exportDate string, opts ...Option) (*ExportFiles, error)
 }
 
 type ListSitesParams struct {
@@ -341,27 +435,38 @@ func (list *ListSitesParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_sites
 //
 // Returns: A list of sites.
-func (c *Client) ListSites(params *ListSitesParams) *SiteList {
+func (c *Client) ListSites(params *ListSitesParams, opts ...Option) *SiteList {
 	path, err := c.InterpolatePath("/sites")
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewSiteList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewSiteList(c, path, requestOptions)
 }
 
-// GetSite Fetch a site
+// GetSite wraps GetSiteWithContext using the background context
+func (c *Client) GetSite(siteId string, opts ...Option) (*Site, error) {
+	return c.getSite(context.Background(), siteId, opts...)
+}
+
+// GetSiteWithContext Fetch a site
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_site
 //
 // Returns: A site.
-func (c *Client) GetSite(siteId string) (*Site, error) {
+func (c *Client) GetSiteWithContext(ctx context.Context, siteId string, opts ...Option) (*Site, error) {
+	return c.getSite(ctx, siteId, opts...)
+}
+
+func (c *Client) getSite(ctx context.Context, siteId string, opts ...Option) (*Site, error) {
 	path, err := c.InterpolatePath("/sites/{site_id}", siteId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Site{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -468,225 +573,346 @@ func (list *ListAccountsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_accounts
 //
 // Returns: A list of the site's accounts.
-func (c *Client) ListAccounts(params *ListAccountsParams) *AccountList {
+func (c *Client) ListAccounts(params *ListAccountsParams, opts ...Option) *AccountList {
 	path, err := c.InterpolatePath("/accounts")
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewAccountList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewAccountList(c, path, requestOptions)
 }
 
-// CreateAccount Create an account
+// CreateAccount wraps CreateAccountWithContext using the background context
+func (c *Client) CreateAccount(body *AccountCreate, opts ...Option) (*Account, error) {
+	return c.createAccount(context.Background(), body, opts...)
+}
+
+// CreateAccountWithContext Create an account
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_account
 //
 // Returns: An account.
-func (c *Client) CreateAccount(body *AccountCreate) (*Account, error) {
+func (c *Client) CreateAccountWithContext(ctx context.Context, body *AccountCreate, opts ...Option) (*Account, error) {
+	return c.createAccount(ctx, body, opts...)
+}
+
+func (c *Client) createAccount(ctx context.Context, body *AccountCreate, opts ...Option) (*Account, error) {
 	path, err := c.InterpolatePath("/accounts")
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Account{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// GetAccount Fetch an account
+// GetAccount wraps GetAccountWithContext using the background context
+func (c *Client) GetAccount(accountId string, opts ...Option) (*Account, error) {
+	return c.getAccount(context.Background(), accountId, opts...)
+}
+
+// GetAccountWithContext Fetch an account
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_account
 //
 // Returns: An account.
-func (c *Client) GetAccount(accountId string) (*Account, error) {
+func (c *Client) GetAccountWithContext(ctx context.Context, accountId string, opts ...Option) (*Account, error) {
+	return c.getAccount(ctx, accountId, opts...)
+}
+
+func (c *Client) getAccount(ctx context.Context, accountId string, opts ...Option) (*Account, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Account{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// UpdateAccount Modify an account
+// UpdateAccount wraps UpdateAccountWithContext using the background context
+func (c *Client) UpdateAccount(accountId string, body *AccountUpdate, opts ...Option) (*Account, error) {
+	return c.updateAccount(context.Background(), accountId, body, opts...)
+}
+
+// UpdateAccountWithContext Modify an account
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_account
 //
 // Returns: An account.
-func (c *Client) UpdateAccount(accountId string, body *AccountUpdate) (*Account, error) {
+func (c *Client) UpdateAccountWithContext(ctx context.Context, accountId string, body *AccountUpdate, opts ...Option) (*Account, error) {
+	return c.updateAccount(ctx, accountId, body, opts...)
+}
+
+func (c *Client) updateAccount(ctx context.Context, accountId string, body *AccountUpdate, opts ...Option) (*Account, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Account{}
-	err = c.Call(http.MethodPut, path, body, result)
+	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// DeactivateAccount Deactivate an account
+// DeactivateAccount wraps DeactivateAccountWithContext using the background context
+func (c *Client) DeactivateAccount(accountId string, opts ...Option) (*Account, error) {
+	return c.deactivateAccount(context.Background(), accountId, opts...)
+}
+
+// DeactivateAccountWithContext Deactivate an account
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/deactivate_account
 //
 // Returns: An account.
-func (c *Client) DeactivateAccount(accountId string) (*Account, error) {
+func (c *Client) DeactivateAccountWithContext(ctx context.Context, accountId string, opts ...Option) (*Account, error) {
+	return c.deactivateAccount(ctx, accountId, opts...)
+}
+
+func (c *Client) deactivateAccount(ctx context.Context, accountId string, opts ...Option) (*Account, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Account{}
-	err = c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// GetAccountAcquisition Fetch an account's acquisition data
+// GetAccountAcquisition wraps GetAccountAcquisitionWithContext using the background context
+func (c *Client) GetAccountAcquisition(accountId string, opts ...Option) (*AccountAcquisition, error) {
+	return c.getAccountAcquisition(context.Background(), accountId, opts...)
+}
+
+// GetAccountAcquisitionWithContext Fetch an account's acquisition data
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_account_acquisition
 //
 // Returns: An account's acquisition data.
-func (c *Client) GetAccountAcquisition(accountId string) (*AccountAcquisition, error) {
+func (c *Client) GetAccountAcquisitionWithContext(ctx context.Context, accountId string, opts ...Option) (*AccountAcquisition, error) {
+	return c.getAccountAcquisition(ctx, accountId, opts...)
+}
+
+func (c *Client) getAccountAcquisition(ctx context.Context, accountId string, opts ...Option) (*AccountAcquisition, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/acquisition", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &AccountAcquisition{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// UpdateAccountAcquisition Update an account's acquisition data
+// UpdateAccountAcquisition wraps UpdateAccountAcquisitionWithContext using the background context
+func (c *Client) UpdateAccountAcquisition(accountId string, body *AccountAcquisitionUpdatable, opts ...Option) (*AccountAcquisition, error) {
+	return c.updateAccountAcquisition(context.Background(), accountId, body, opts...)
+}
+
+// UpdateAccountAcquisitionWithContext Update an account's acquisition data
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_account_acquisition
 //
 // Returns: An account's updated acquisition data.
-func (c *Client) UpdateAccountAcquisition(accountId string, body *AccountAcquisitionUpdatable) (*AccountAcquisition, error) {
+func (c *Client) UpdateAccountAcquisitionWithContext(ctx context.Context, accountId string, body *AccountAcquisitionUpdatable, opts ...Option) (*AccountAcquisition, error) {
+	return c.updateAccountAcquisition(ctx, accountId, body, opts...)
+}
+
+func (c *Client) updateAccountAcquisition(ctx context.Context, accountId string, body *AccountAcquisitionUpdatable, opts ...Option) (*AccountAcquisition, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/acquisition", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &AccountAcquisition{}
-	err = c.Call(http.MethodPut, path, body, result)
+	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// RemoveAccountAcquisition Remove an account's acquisition data
+// RemoveAccountAcquisition wraps RemoveAccountAcquisitionWithContext using the background context
+func (c *Client) RemoveAccountAcquisition(accountId string, opts ...Option) (*Empty, error) {
+	return c.removeAccountAcquisition(context.Background(), accountId, opts...)
+}
+
+// RemoveAccountAcquisitionWithContext Remove an account's acquisition data
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_account_acquisition
 //
 // Returns: Acquisition data was succesfully deleted.
-func (c *Client) RemoveAccountAcquisition(accountId string) (*Empty, error) {
+func (c *Client) RemoveAccountAcquisitionWithContext(ctx context.Context, accountId string, opts ...Option) (*Empty, error) {
+	return c.removeAccountAcquisition(ctx, accountId, opts...)
+}
+
+func (c *Client) removeAccountAcquisition(ctx context.Context, accountId string, opts ...Option) (*Empty, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/acquisition", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Empty{}
-	err = c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// ReactivateAccount Reactivate an inactive account
+// ReactivateAccount wraps ReactivateAccountWithContext using the background context
+func (c *Client) ReactivateAccount(accountId string, opts ...Option) (*Account, error) {
+	return c.reactivateAccount(context.Background(), accountId, opts...)
+}
+
+// ReactivateAccountWithContext Reactivate an inactive account
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/reactivate_account
 //
 // Returns: An account.
-func (c *Client) ReactivateAccount(accountId string) (*Account, error) {
+func (c *Client) ReactivateAccountWithContext(ctx context.Context, accountId string, opts ...Option) (*Account, error) {
+	return c.reactivateAccount(ctx, accountId, opts...)
+}
+
+func (c *Client) reactivateAccount(ctx context.Context, accountId string, opts ...Option) (*Account, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/reactivate", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Account{}
-	err = c.Call(http.MethodPut, path, nil, result)
+	err = c.Call(context.Background(), http.MethodPut, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// GetAccountBalance Fetch an account's balance and past due status
+// GetAccountBalance wraps GetAccountBalanceWithContext using the background context
+func (c *Client) GetAccountBalance(accountId string, opts ...Option) (*AccountBalance, error) {
+	return c.getAccountBalance(context.Background(), accountId, opts...)
+}
+
+// GetAccountBalanceWithContext Fetch an account's balance and past due status
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_account_balance
 //
 // Returns: An account's balance.
-func (c *Client) GetAccountBalance(accountId string) (*AccountBalance, error) {
+func (c *Client) GetAccountBalanceWithContext(ctx context.Context, accountId string, opts ...Option) (*AccountBalance, error) {
+	return c.getAccountBalance(ctx, accountId, opts...)
+}
+
+func (c *Client) getAccountBalance(ctx context.Context, accountId string, opts ...Option) (*AccountBalance, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/balance", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &AccountBalance{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// GetBillingInfo Fetch an account's billing information
+// GetBillingInfo wraps GetBillingInfoWithContext using the background context
+func (c *Client) GetBillingInfo(accountId string, opts ...Option) (*BillingInfo, error) {
+	return c.getBillingInfo(context.Background(), accountId, opts...)
+}
+
+// GetBillingInfoWithContext Fetch an account's billing information
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_billing_info
 //
 // Returns: An account's billing information.
-func (c *Client) GetBillingInfo(accountId string) (*BillingInfo, error) {
+func (c *Client) GetBillingInfoWithContext(ctx context.Context, accountId string, opts ...Option) (*BillingInfo, error) {
+	return c.getBillingInfo(ctx, accountId, opts...)
+}
+
+func (c *Client) getBillingInfo(ctx context.Context, accountId string, opts ...Option) (*BillingInfo, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/billing_info", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &BillingInfo{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// UpdateBillingInfo Set an account's billing information
+// UpdateBillingInfo wraps UpdateBillingInfoWithContext using the background context
+func (c *Client) UpdateBillingInfo(accountId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error) {
+	return c.updateBillingInfo(context.Background(), accountId, body, opts...)
+}
+
+// UpdateBillingInfoWithContext Set an account's billing information
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_billing_info
 //
 // Returns: Updated billing information.
-func (c *Client) UpdateBillingInfo(accountId string, body *BillingInfoCreate) (*BillingInfo, error) {
+func (c *Client) UpdateBillingInfoWithContext(ctx context.Context, accountId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error) {
+	return c.updateBillingInfo(ctx, accountId, body, opts...)
+}
+
+func (c *Client) updateBillingInfo(ctx context.Context, accountId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/billing_info", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &BillingInfo{}
-	err = c.Call(http.MethodPut, path, body, result)
+	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// RemoveBillingInfo Remove an account's billing information
+// RemoveBillingInfo wraps RemoveBillingInfoWithContext using the background context
+func (c *Client) RemoveBillingInfo(accountId string, opts ...Option) (*Empty, error) {
+	return c.removeBillingInfo(context.Background(), accountId, opts...)
+}
+
+// RemoveBillingInfoWithContext Remove an account's billing information
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_billing_info
 //
 // Returns: Billing information deleted
-func (c *Client) RemoveBillingInfo(accountId string) (*Empty, error) {
+func (c *Client) RemoveBillingInfoWithContext(ctx context.Context, accountId string, opts ...Option) (*Empty, error) {
+	return c.removeBillingInfo(ctx, accountId, opts...)
+}
+
+func (c *Client) removeBillingInfo(ctx context.Context, accountId string, opts ...Option) (*Empty, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/billing_info", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Empty{}
-	err = c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -757,81 +983,122 @@ func (list *ListBillingInfosParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_billing_infos
 //
 // Returns: A list of the the billing information for an account's
-func (c *Client) ListBillingInfos(accountId string, params *ListBillingInfosParams) *BillingInfoList {
+func (c *Client) ListBillingInfos(accountId string, params *ListBillingInfosParams, opts ...Option) *BillingInfoList {
 	path, err := c.InterpolatePath("/accounts/{account_id}/billing_infos", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewBillingInfoList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewBillingInfoList(c, path, requestOptions)
 }
 
-// CreateBillingInfo Set an account's billing information when the wallet feature is enabled
+// CreateBillingInfo wraps CreateBillingInfoWithContext using the background context
+func (c *Client) CreateBillingInfo(accountId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error) {
+	return c.createBillingInfo(context.Background(), accountId, body, opts...)
+}
+
+// CreateBillingInfoWithContext Set an account's billing information when the wallet feature is enabled
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_billing_info
 //
 // Returns: Updated billing information.
-func (c *Client) CreateBillingInfo(accountId string, body *BillingInfoCreate) (*BillingInfo, error) {
+func (c *Client) CreateBillingInfoWithContext(ctx context.Context, accountId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error) {
+	return c.createBillingInfo(ctx, accountId, body, opts...)
+}
+
+func (c *Client) createBillingInfo(ctx context.Context, accountId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/billing_infos", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &BillingInfo{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// GetABillingInfo Fetch a billing info
+// GetABillingInfo wraps GetABillingInfoWithContext using the background context
+func (c *Client) GetABillingInfo(accountId string, billingInfoId string, opts ...Option) (*BillingInfo, error) {
+	return c.getABillingInfo(context.Background(), accountId, billingInfoId, opts...)
+}
+
+// GetABillingInfoWithContext Fetch a billing info
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_a_billing_info
 //
 // Returns: A billing info.
-func (c *Client) GetABillingInfo(accountId string, billingInfoId string) (*BillingInfo, error) {
+func (c *Client) GetABillingInfoWithContext(ctx context.Context, accountId string, billingInfoId string, opts ...Option) (*BillingInfo, error) {
+	return c.getABillingInfo(ctx, accountId, billingInfoId, opts...)
+}
+
+func (c *Client) getABillingInfo(ctx context.Context, accountId string, billingInfoId string, opts ...Option) (*BillingInfo, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/billing_infos/{billing_info_id}", accountId, billingInfoId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &BillingInfo{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// UpdateABillingInfo Update an account's billing information
+// UpdateABillingInfo wraps UpdateABillingInfoWithContext using the background context
+func (c *Client) UpdateABillingInfo(accountId string, billingInfoId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error) {
+	return c.updateABillingInfo(context.Background(), accountId, billingInfoId, body, opts...)
+}
+
+// UpdateABillingInfoWithContext Update an account's billing information
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_a_billing_info
 //
 // Returns: Updated billing information.
-func (c *Client) UpdateABillingInfo(accountId string, billingInfoId string, body *BillingInfoCreate) (*BillingInfo, error) {
+func (c *Client) UpdateABillingInfoWithContext(ctx context.Context, accountId string, billingInfoId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error) {
+	return c.updateABillingInfo(ctx, accountId, billingInfoId, body, opts...)
+}
+
+func (c *Client) updateABillingInfo(ctx context.Context, accountId string, billingInfoId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/billing_infos/{billing_info_id}", accountId, billingInfoId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &BillingInfo{}
-	err = c.Call(http.MethodPut, path, body, result)
+	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// RemoveABillingInfo Remove an account's billing information
+// RemoveABillingInfo wraps RemoveABillingInfoWithContext using the background context
+func (c *Client) RemoveABillingInfo(accountId string, billingInfoId string, opts ...Option) (*Empty, error) {
+	return c.removeABillingInfo(context.Background(), accountId, billingInfoId, opts...)
+}
+
+// RemoveABillingInfoWithContext Remove an account's billing information
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_a_billing_info
 //
 // Returns: Billing information deleted
-func (c *Client) RemoveABillingInfo(accountId string, billingInfoId string) (*Empty, error) {
+func (c *Client) RemoveABillingInfoWithContext(ctx context.Context, accountId string, billingInfoId string, opts ...Option) (*Empty, error) {
+	return c.removeABillingInfo(ctx, accountId, billingInfoId, opts...)
+}
+
+func (c *Client) removeABillingInfo(ctx context.Context, accountId string, billingInfoId string, opts ...Option) (*Empty, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/billing_infos/{billing_info_id}", accountId, billingInfoId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Empty{}
-	err = c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -909,63 +1176,94 @@ func (list *ListAccountCouponRedemptionsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_account_coupon_redemptions
 //
 // Returns: A list of the the coupon redemptions on an account.
-func (c *Client) ListAccountCouponRedemptions(accountId string, params *ListAccountCouponRedemptionsParams) *CouponRedemptionList {
+func (c *Client) ListAccountCouponRedemptions(accountId string, params *ListAccountCouponRedemptionsParams, opts ...Option) *CouponRedemptionList {
 	path, err := c.InterpolatePath("/accounts/{account_id}/coupon_redemptions", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewCouponRedemptionList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewCouponRedemptionList(c, path, requestOptions)
 }
 
-// GetActiveCouponRedemption Show the coupon redemption that is active on an account
+// GetActiveCouponRedemption wraps GetActiveCouponRedemptionWithContext using the background context
+func (c *Client) GetActiveCouponRedemption(accountId string, opts ...Option) (*CouponRedemption, error) {
+	return c.getActiveCouponRedemption(context.Background(), accountId, opts...)
+}
+
+// GetActiveCouponRedemptionWithContext Show the coupon redemption that is active on an account
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_active_coupon_redemption
 //
 // Returns: An active coupon redemption on an account.
-func (c *Client) GetActiveCouponRedemption(accountId string) (*CouponRedemption, error) {
+func (c *Client) GetActiveCouponRedemptionWithContext(ctx context.Context, accountId string, opts ...Option) (*CouponRedemption, error) {
+	return c.getActiveCouponRedemption(ctx, accountId, opts...)
+}
+
+func (c *Client) getActiveCouponRedemption(ctx context.Context, accountId string, opts ...Option) (*CouponRedemption, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/coupon_redemptions/active", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &CouponRedemption{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// CreateCouponRedemption Generate an active coupon redemption on an account
+// CreateCouponRedemption wraps CreateCouponRedemptionWithContext using the background context
+func (c *Client) CreateCouponRedemption(accountId string, body *CouponRedemptionCreate, opts ...Option) (*CouponRedemption, error) {
+	return c.createCouponRedemption(context.Background(), accountId, body, opts...)
+}
+
+// CreateCouponRedemptionWithContext Generate an active coupon redemption on an account
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_coupon_redemption
 //
 // Returns: Returns the new coupon redemption.
-func (c *Client) CreateCouponRedemption(accountId string, body *CouponRedemptionCreate) (*CouponRedemption, error) {
+func (c *Client) CreateCouponRedemptionWithContext(ctx context.Context, accountId string, body *CouponRedemptionCreate, opts ...Option) (*CouponRedemption, error) {
+	return c.createCouponRedemption(ctx, accountId, body, opts...)
+}
+
+func (c *Client) createCouponRedemption(ctx context.Context, accountId string, body *CouponRedemptionCreate, opts ...Option) (*CouponRedemption, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/coupon_redemptions/active", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &CouponRedemption{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// RemoveCouponRedemption Delete the active coupon redemption from an account
+// RemoveCouponRedemption wraps RemoveCouponRedemptionWithContext using the background context
+func (c *Client) RemoveCouponRedemption(accountId string, opts ...Option) (*CouponRedemption, error) {
+	return c.removeCouponRedemption(context.Background(), accountId, opts...)
+}
+
+// RemoveCouponRedemptionWithContext Delete the active coupon redemption from an account
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_coupon_redemption
 //
 // Returns: Coupon redemption deleted.
-func (c *Client) RemoveCouponRedemption(accountId string) (*CouponRedemption, error) {
+func (c *Client) RemoveCouponRedemptionWithContext(ctx context.Context, accountId string, opts ...Option) (*CouponRedemption, error) {
+	return c.removeCouponRedemption(ctx, accountId, opts...)
+}
+
+func (c *Client) removeCouponRedemption(ctx context.Context, accountId string, opts ...Option) (*CouponRedemption, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/coupon_redemptions/active", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &CouponRedemption{}
-	err = c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1035,13 +1333,14 @@ func (list *ListAccountCreditPaymentsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_account_credit_payments
 //
 // Returns: A list of the account's credit payments.
-func (c *Client) ListAccountCreditPayments(accountId string, params *ListAccountCreditPaymentsParams) *CreditPaymentList {
+func (c *Client) ListAccountCreditPayments(accountId string, params *ListAccountCreditPaymentsParams, opts ...Option) *CreditPaymentList {
 	path, err := c.InterpolatePath("/accounts/{account_id}/credit_payments", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewCreditPaymentList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewCreditPaymentList(c, path, requestOptions)
 }
 
 type ListAccountInvoicesParams struct {
@@ -1133,45 +1432,66 @@ func (list *ListAccountInvoicesParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_account_invoices
 //
 // Returns: A list of the account's invoices.
-func (c *Client) ListAccountInvoices(accountId string, params *ListAccountInvoicesParams) *InvoiceList {
+func (c *Client) ListAccountInvoices(accountId string, params *ListAccountInvoicesParams, opts ...Option) *InvoiceList {
 	path, err := c.InterpolatePath("/accounts/{account_id}/invoices", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewInvoiceList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewInvoiceList(c, path, requestOptions)
 }
 
-// CreateInvoice Create an invoice for pending line items
+// CreateInvoice wraps CreateInvoiceWithContext using the background context
+func (c *Client) CreateInvoice(accountId string, body *InvoiceCreate, opts ...Option) (*InvoiceCollection, error) {
+	return c.createInvoice(context.Background(), accountId, body, opts...)
+}
+
+// CreateInvoiceWithContext Create an invoice for pending line items
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_invoice
 //
 // Returns: Returns the new invoices.
-func (c *Client) CreateInvoice(accountId string, body *InvoiceCreate) (*InvoiceCollection, error) {
+func (c *Client) CreateInvoiceWithContext(ctx context.Context, accountId string, body *InvoiceCreate, opts ...Option) (*InvoiceCollection, error) {
+	return c.createInvoice(ctx, accountId, body, opts...)
+}
+
+func (c *Client) createInvoice(ctx context.Context, accountId string, body *InvoiceCreate, opts ...Option) (*InvoiceCollection, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/invoices", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &InvoiceCollection{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// PreviewInvoice Preview new invoice for pending line items
+// PreviewInvoice wraps PreviewInvoiceWithContext using the background context
+func (c *Client) PreviewInvoice(accountId string, body *InvoiceCreate, opts ...Option) (*InvoiceCollection, error) {
+	return c.previewInvoice(context.Background(), accountId, body, opts...)
+}
+
+// PreviewInvoiceWithContext Preview new invoice for pending line items
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/preview_invoice
 //
 // Returns: Returns the invoice previews.
-func (c *Client) PreviewInvoice(accountId string, body *InvoiceCreate) (*InvoiceCollection, error) {
+func (c *Client) PreviewInvoiceWithContext(ctx context.Context, accountId string, body *InvoiceCreate, opts ...Option) (*InvoiceCollection, error) {
+	return c.previewInvoice(ctx, accountId, body, opts...)
+}
+
+func (c *Client) previewInvoice(ctx context.Context, accountId string, body *InvoiceCreate, opts ...Option) (*InvoiceCollection, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/invoices/preview", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &InvoiceCollection{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1277,27 +1597,38 @@ func (list *ListAccountLineItemsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_account_line_items
 //
 // Returns: A list of the account's line items.
-func (c *Client) ListAccountLineItems(accountId string, params *ListAccountLineItemsParams) *LineItemList {
+func (c *Client) ListAccountLineItems(accountId string, params *ListAccountLineItemsParams, opts ...Option) *LineItemList {
 	path, err := c.InterpolatePath("/accounts/{account_id}/line_items", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewLineItemList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewLineItemList(c, path, requestOptions)
 }
 
-// CreateLineItem Create a new line item for the account
+// CreateLineItem wraps CreateLineItemWithContext using the background context
+func (c *Client) CreateLineItem(accountId string, body *LineItemCreate, opts ...Option) (*LineItem, error) {
+	return c.createLineItem(context.Background(), accountId, body, opts...)
+}
+
+// CreateLineItemWithContext Create a new line item for the account
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_line_item
 //
 // Returns: Returns the new line item.
-func (c *Client) CreateLineItem(accountId string, body *LineItemCreate) (*LineItem, error) {
+func (c *Client) CreateLineItemWithContext(ctx context.Context, accountId string, body *LineItemCreate, opts ...Option) (*LineItem, error) {
+	return c.createLineItem(ctx, accountId, body, opts...)
+}
+
+func (c *Client) createLineItem(ctx context.Context, accountId string, body *LineItemCreate, opts ...Option) (*LineItem, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/line_items", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &LineItem{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1343,27 +1674,38 @@ func (list *ListAccountNotesParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_account_notes
 //
 // Returns: A list of an account's notes.
-func (c *Client) ListAccountNotes(accountId string, params *ListAccountNotesParams) *AccountNoteList {
+func (c *Client) ListAccountNotes(accountId string, params *ListAccountNotesParams, opts ...Option) *AccountNoteList {
 	path, err := c.InterpolatePath("/accounts/{account_id}/notes", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewAccountNoteList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewAccountNoteList(c, path, requestOptions)
 }
 
-// GetAccountNote Fetch an account note
+// GetAccountNote wraps GetAccountNoteWithContext using the background context
+func (c *Client) GetAccountNote(accountId string, accountNoteId string, opts ...Option) (*AccountNote, error) {
+	return c.getAccountNote(context.Background(), accountId, accountNoteId, opts...)
+}
+
+// GetAccountNoteWithContext Fetch an account note
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_account_note
 //
 // Returns: An account note.
-func (c *Client) GetAccountNote(accountId string, accountNoteId string) (*AccountNote, error) {
+func (c *Client) GetAccountNoteWithContext(ctx context.Context, accountId string, accountNoteId string, opts ...Option) (*AccountNote, error) {
+	return c.getAccountNote(ctx, accountId, accountNoteId, opts...)
+}
+
+func (c *Client) getAccountNote(ctx context.Context, accountId string, accountNoteId string, opts ...Option) (*AccountNote, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/notes/{account_note_id}", accountId, accountNoteId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &AccountNote{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1448,81 +1790,122 @@ func (list *ListShippingAddressesParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_shipping_addresses
 //
 // Returns: A list of an account's shipping addresses.
-func (c *Client) ListShippingAddresses(accountId string, params *ListShippingAddressesParams) *ShippingAddressList {
+func (c *Client) ListShippingAddresses(accountId string, params *ListShippingAddressesParams, opts ...Option) *ShippingAddressList {
 	path, err := c.InterpolatePath("/accounts/{account_id}/shipping_addresses", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewShippingAddressList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewShippingAddressList(c, path, requestOptions)
 }
 
-// CreateShippingAddress Create a new shipping address for the account
+// CreateShippingAddress wraps CreateShippingAddressWithContext using the background context
+func (c *Client) CreateShippingAddress(accountId string, body *ShippingAddressCreate, opts ...Option) (*ShippingAddress, error) {
+	return c.createShippingAddress(context.Background(), accountId, body, opts...)
+}
+
+// CreateShippingAddressWithContext Create a new shipping address for the account
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_shipping_address
 //
 // Returns: Returns the new shipping address.
-func (c *Client) CreateShippingAddress(accountId string, body *ShippingAddressCreate) (*ShippingAddress, error) {
+func (c *Client) CreateShippingAddressWithContext(ctx context.Context, accountId string, body *ShippingAddressCreate, opts ...Option) (*ShippingAddress, error) {
+	return c.createShippingAddress(ctx, accountId, body, opts...)
+}
+
+func (c *Client) createShippingAddress(ctx context.Context, accountId string, body *ShippingAddressCreate, opts ...Option) (*ShippingAddress, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/shipping_addresses", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &ShippingAddress{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// GetShippingAddress Fetch an account's shipping address
+// GetShippingAddress wraps GetShippingAddressWithContext using the background context
+func (c *Client) GetShippingAddress(accountId string, shippingAddressId string, opts ...Option) (*ShippingAddress, error) {
+	return c.getShippingAddress(context.Background(), accountId, shippingAddressId, opts...)
+}
+
+// GetShippingAddressWithContext Fetch an account's shipping address
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_shipping_address
 //
 // Returns: A shipping address.
-func (c *Client) GetShippingAddress(accountId string, shippingAddressId string) (*ShippingAddress, error) {
+func (c *Client) GetShippingAddressWithContext(ctx context.Context, accountId string, shippingAddressId string, opts ...Option) (*ShippingAddress, error) {
+	return c.getShippingAddress(ctx, accountId, shippingAddressId, opts...)
+}
+
+func (c *Client) getShippingAddress(ctx context.Context, accountId string, shippingAddressId string, opts ...Option) (*ShippingAddress, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", accountId, shippingAddressId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &ShippingAddress{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// UpdateShippingAddress Update an account's shipping address
+// UpdateShippingAddress wraps UpdateShippingAddressWithContext using the background context
+func (c *Client) UpdateShippingAddress(accountId string, shippingAddressId string, body *ShippingAddressUpdate, opts ...Option) (*ShippingAddress, error) {
+	return c.updateShippingAddress(context.Background(), accountId, shippingAddressId, body, opts...)
+}
+
+// UpdateShippingAddressWithContext Update an account's shipping address
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_shipping_address
 //
 // Returns: The updated shipping address.
-func (c *Client) UpdateShippingAddress(accountId string, shippingAddressId string, body *ShippingAddressUpdate) (*ShippingAddress, error) {
+func (c *Client) UpdateShippingAddressWithContext(ctx context.Context, accountId string, shippingAddressId string, body *ShippingAddressUpdate, opts ...Option) (*ShippingAddress, error) {
+	return c.updateShippingAddress(ctx, accountId, shippingAddressId, body, opts...)
+}
+
+func (c *Client) updateShippingAddress(ctx context.Context, accountId string, shippingAddressId string, body *ShippingAddressUpdate, opts ...Option) (*ShippingAddress, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", accountId, shippingAddressId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &ShippingAddress{}
-	err = c.Call(http.MethodPut, path, body, result)
+	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// RemoveShippingAddress Remove an account's shipping address
+// RemoveShippingAddress wraps RemoveShippingAddressWithContext using the background context
+func (c *Client) RemoveShippingAddress(accountId string, shippingAddressId string, opts ...Option) (*Empty, error) {
+	return c.removeShippingAddress(context.Background(), accountId, shippingAddressId, opts...)
+}
+
+// RemoveShippingAddressWithContext Remove an account's shipping address
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_shipping_address
 //
 // Returns: Shipping address deleted.
-func (c *Client) RemoveShippingAddress(accountId string, shippingAddressId string) (*Empty, error) {
+func (c *Client) RemoveShippingAddressWithContext(ctx context.Context, accountId string, shippingAddressId string, opts ...Option) (*Empty, error) {
+	return c.removeShippingAddress(ctx, accountId, shippingAddressId, opts...)
+}
+
+func (c *Client) removeShippingAddress(ctx context.Context, accountId string, shippingAddressId string, opts ...Option) (*Empty, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", accountId, shippingAddressId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Empty{}
-	err = c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -1617,13 +2000,14 @@ func (list *ListAccountSubscriptionsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_account_subscriptions
 //
 // Returns: A list of the account's subscriptions.
-func (c *Client) ListAccountSubscriptions(accountId string, params *ListAccountSubscriptionsParams) *SubscriptionList {
+func (c *Client) ListAccountSubscriptions(accountId string, params *ListAccountSubscriptionsParams, opts ...Option) *SubscriptionList {
 	path, err := c.InterpolatePath("/accounts/{account_id}/subscriptions", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewSubscriptionList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewSubscriptionList(c, path, requestOptions)
 }
 
 type ListAccountTransactionsParams struct {
@@ -1718,13 +2102,14 @@ func (list *ListAccountTransactionsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_account_transactions
 //
 // Returns: A list of the account's transactions.
-func (c *Client) ListAccountTransactions(accountId string, params *ListAccountTransactionsParams) *TransactionList {
+func (c *Client) ListAccountTransactions(accountId string, params *ListAccountTransactionsParams, opts ...Option) *TransactionList {
 	path, err := c.InterpolatePath("/accounts/{account_id}/transactions", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewTransactionList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewTransactionList(c, path, requestOptions)
 }
 
 type ListChildAccountsParams struct {
@@ -1827,13 +2212,14 @@ func (list *ListChildAccountsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_child_accounts
 //
 // Returns: A list of an account's child accounts.
-func (c *Client) ListChildAccounts(accountId string, params *ListChildAccountsParams) *AccountList {
+func (c *Client) ListChildAccounts(accountId string, params *ListChildAccountsParams, opts ...Option) *AccountList {
 	path, err := c.InterpolatePath("/accounts/{account_id}/accounts", accountId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewAccountList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewAccountList(c, path, requestOptions)
 }
 
 type ListAccountAcquisitionParams struct {
@@ -1914,13 +2300,14 @@ func (list *ListAccountAcquisitionParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_account_acquisition
 //
 // Returns: A list of the site's account acquisition data.
-func (c *Client) ListAccountAcquisition(params *ListAccountAcquisitionParams) *AccountAcquisitionList {
+func (c *Client) ListAccountAcquisition(params *ListAccountAcquisitionParams, opts ...Option) *AccountAcquisitionList {
 	path, err := c.InterpolatePath("/acquisitions")
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewAccountAcquisitionList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewAccountAcquisitionList(c, path, requestOptions)
 }
 
 type ListCouponsParams struct {
@@ -2001,99 +2388,150 @@ func (list *ListCouponsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_coupons
 //
 // Returns: A list of the site's coupons.
-func (c *Client) ListCoupons(params *ListCouponsParams) *CouponList {
+func (c *Client) ListCoupons(params *ListCouponsParams, opts ...Option) *CouponList {
 	path, err := c.InterpolatePath("/coupons")
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewCouponList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewCouponList(c, path, requestOptions)
 }
 
-// CreateCoupon Create a new coupon
+// CreateCoupon wraps CreateCouponWithContext using the background context
+func (c *Client) CreateCoupon(body *CouponCreate, opts ...Option) (*Coupon, error) {
+	return c.createCoupon(context.Background(), body, opts...)
+}
+
+// CreateCouponWithContext Create a new coupon
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_coupon
 //
 // Returns: A new coupon.
-func (c *Client) CreateCoupon(body *CouponCreate) (*Coupon, error) {
+func (c *Client) CreateCouponWithContext(ctx context.Context, body *CouponCreate, opts ...Option) (*Coupon, error) {
+	return c.createCoupon(ctx, body, opts...)
+}
+
+func (c *Client) createCoupon(ctx context.Context, body *CouponCreate, opts ...Option) (*Coupon, error) {
 	path, err := c.InterpolatePath("/coupons")
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Coupon{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// GetCoupon Fetch a coupon
+// GetCoupon wraps GetCouponWithContext using the background context
+func (c *Client) GetCoupon(couponId string, opts ...Option) (*Coupon, error) {
+	return c.getCoupon(context.Background(), couponId, opts...)
+}
+
+// GetCouponWithContext Fetch a coupon
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_coupon
 //
 // Returns: A coupon.
-func (c *Client) GetCoupon(couponId string) (*Coupon, error) {
+func (c *Client) GetCouponWithContext(ctx context.Context, couponId string, opts ...Option) (*Coupon, error) {
+	return c.getCoupon(ctx, couponId, opts...)
+}
+
+func (c *Client) getCoupon(ctx context.Context, couponId string, opts ...Option) (*Coupon, error) {
 	path, err := c.InterpolatePath("/coupons/{coupon_id}", couponId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Coupon{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// UpdateCoupon Update an active coupon
+// UpdateCoupon wraps UpdateCouponWithContext using the background context
+func (c *Client) UpdateCoupon(couponId string, body *CouponUpdate, opts ...Option) (*Coupon, error) {
+	return c.updateCoupon(context.Background(), couponId, body, opts...)
+}
+
+// UpdateCouponWithContext Update an active coupon
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_coupon
 //
 // Returns: The updated coupon.
-func (c *Client) UpdateCoupon(couponId string, body *CouponUpdate) (*Coupon, error) {
+func (c *Client) UpdateCouponWithContext(ctx context.Context, couponId string, body *CouponUpdate, opts ...Option) (*Coupon, error) {
+	return c.updateCoupon(ctx, couponId, body, opts...)
+}
+
+func (c *Client) updateCoupon(ctx context.Context, couponId string, body *CouponUpdate, opts ...Option) (*Coupon, error) {
 	path, err := c.InterpolatePath("/coupons/{coupon_id}", couponId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Coupon{}
-	err = c.Call(http.MethodPut, path, body, result)
+	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// DeactivateCoupon Expire a coupon
+// DeactivateCoupon wraps DeactivateCouponWithContext using the background context
+func (c *Client) DeactivateCoupon(couponId string, opts ...Option) (*Coupon, error) {
+	return c.deactivateCoupon(context.Background(), couponId, opts...)
+}
+
+// DeactivateCouponWithContext Expire a coupon
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/deactivate_coupon
 //
 // Returns: The expired Coupon
-func (c *Client) DeactivateCoupon(couponId string) (*Coupon, error) {
+func (c *Client) DeactivateCouponWithContext(ctx context.Context, couponId string, opts ...Option) (*Coupon, error) {
+	return c.deactivateCoupon(ctx, couponId, opts...)
+}
+
+func (c *Client) deactivateCoupon(ctx context.Context, couponId string, opts ...Option) (*Coupon, error) {
 	path, err := c.InterpolatePath("/coupons/{coupon_id}", couponId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Coupon{}
-	err = c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// RestoreCoupon Restore an inactive coupon
+// RestoreCoupon wraps RestoreCouponWithContext using the background context
+func (c *Client) RestoreCoupon(couponId string, body *CouponUpdate, opts ...Option) (*Coupon, error) {
+	return c.restoreCoupon(context.Background(), couponId, body, opts...)
+}
+
+// RestoreCouponWithContext Restore an inactive coupon
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/restore_coupon
 //
 // Returns: The restored coupon.
-func (c *Client) RestoreCoupon(couponId string, body *CouponUpdate) (*Coupon, error) {
+func (c *Client) RestoreCouponWithContext(ctx context.Context, couponId string, body *CouponUpdate, opts ...Option) (*Coupon, error) {
+	return c.restoreCoupon(ctx, couponId, body, opts...)
+}
+
+func (c *Client) restoreCoupon(ctx context.Context, couponId string, body *CouponUpdate, opts ...Option) (*Coupon, error) {
 	path, err := c.InterpolatePath("/coupons/{coupon_id}/restore", couponId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Coupon{}
-	err = c.Call(http.MethodPut, path, body, result)
+	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2178,13 +2616,14 @@ func (list *ListUniqueCouponCodesParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_unique_coupon_codes
 //
 // Returns: A list of unique coupon codes that were generated
-func (c *Client) ListUniqueCouponCodes(couponId string, params *ListUniqueCouponCodesParams) *UniqueCouponCodeList {
+func (c *Client) ListUniqueCouponCodes(couponId string, params *ListUniqueCouponCodesParams, opts ...Option) *UniqueCouponCodeList {
 	path, err := c.InterpolatePath("/coupons/{coupon_id}/unique_coupon_codes", couponId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewUniqueCouponCodeList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewUniqueCouponCodeList(c, path, requestOptions)
 }
 
 type ListCreditPaymentsParams struct {
@@ -2250,27 +2689,38 @@ func (list *ListCreditPaymentsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_credit_payments
 //
 // Returns: A list of the site's credit payments.
-func (c *Client) ListCreditPayments(params *ListCreditPaymentsParams) *CreditPaymentList {
+func (c *Client) ListCreditPayments(params *ListCreditPaymentsParams, opts ...Option) *CreditPaymentList {
 	path, err := c.InterpolatePath("/credit_payments")
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewCreditPaymentList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewCreditPaymentList(c, path, requestOptions)
 }
 
-// GetCreditPayment Fetch a credit payment
+// GetCreditPayment wraps GetCreditPaymentWithContext using the background context
+func (c *Client) GetCreditPayment(creditPaymentId string, opts ...Option) (*CreditPayment, error) {
+	return c.getCreditPayment(context.Background(), creditPaymentId, opts...)
+}
+
+// GetCreditPaymentWithContext Fetch a credit payment
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_credit_payment
 //
 // Returns: A credit payment.
-func (c *Client) GetCreditPayment(creditPaymentId string) (*CreditPayment, error) {
+func (c *Client) GetCreditPaymentWithContext(ctx context.Context, creditPaymentId string, opts ...Option) (*CreditPayment, error) {
+	return c.getCreditPayment(ctx, creditPaymentId, opts...)
+}
+
+func (c *Client) getCreditPayment(ctx context.Context, creditPaymentId string, opts ...Option) (*CreditPayment, error) {
 	path, err := c.InterpolatePath("/credit_payments/{credit_payment_id}", creditPaymentId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &CreditPayment{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2362,27 +2812,38 @@ func (list *ListCustomFieldDefinitionsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_custom_field_definitions
 //
 // Returns: A list of the site's custom field definitions.
-func (c *Client) ListCustomFieldDefinitions(params *ListCustomFieldDefinitionsParams) *CustomFieldDefinitionList {
+func (c *Client) ListCustomFieldDefinitions(params *ListCustomFieldDefinitionsParams, opts ...Option) *CustomFieldDefinitionList {
 	path, err := c.InterpolatePath("/custom_field_definitions")
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewCustomFieldDefinitionList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewCustomFieldDefinitionList(c, path, requestOptions)
 }
 
-// GetCustomFieldDefinition Fetch an custom field definition
+// GetCustomFieldDefinition wraps GetCustomFieldDefinitionWithContext using the background context
+func (c *Client) GetCustomFieldDefinition(customFieldDefinitionId string, opts ...Option) (*CustomFieldDefinition, error) {
+	return c.getCustomFieldDefinition(context.Background(), customFieldDefinitionId, opts...)
+}
+
+// GetCustomFieldDefinitionWithContext Fetch an custom field definition
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_custom_field_definition
 //
 // Returns: An custom field definition.
-func (c *Client) GetCustomFieldDefinition(customFieldDefinitionId string) (*CustomFieldDefinition, error) {
+func (c *Client) GetCustomFieldDefinitionWithContext(ctx context.Context, customFieldDefinitionId string, opts ...Option) (*CustomFieldDefinition, error) {
+	return c.getCustomFieldDefinition(ctx, customFieldDefinitionId, opts...)
+}
+
+func (c *Client) getCustomFieldDefinition(ctx context.Context, customFieldDefinitionId string, opts ...Option) (*CustomFieldDefinition, error) {
 	path, err := c.InterpolatePath("/custom_field_definitions/{custom_field_definition_id}", customFieldDefinitionId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &CustomFieldDefinition{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2474,99 +2935,150 @@ func (list *ListItemsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_items
 //
 // Returns: A list of the site's items.
-func (c *Client) ListItems(params *ListItemsParams) *ItemList {
+func (c *Client) ListItems(params *ListItemsParams, opts ...Option) *ItemList {
 	path, err := c.InterpolatePath("/items")
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewItemList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewItemList(c, path, requestOptions)
 }
 
-// CreateItem Create a new item
+// CreateItem wraps CreateItemWithContext using the background context
+func (c *Client) CreateItem(body *ItemCreate, opts ...Option) (*Item, error) {
+	return c.createItem(context.Background(), body, opts...)
+}
+
+// CreateItemWithContext Create a new item
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_item
 //
 // Returns: A new item.
-func (c *Client) CreateItem(body *ItemCreate) (*Item, error) {
+func (c *Client) CreateItemWithContext(ctx context.Context, body *ItemCreate, opts ...Option) (*Item, error) {
+	return c.createItem(ctx, body, opts...)
+}
+
+func (c *Client) createItem(ctx context.Context, body *ItemCreate, opts ...Option) (*Item, error) {
 	path, err := c.InterpolatePath("/items")
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Item{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// GetItem Fetch an item
+// GetItem wraps GetItemWithContext using the background context
+func (c *Client) GetItem(itemId string, opts ...Option) (*Item, error) {
+	return c.getItem(context.Background(), itemId, opts...)
+}
+
+// GetItemWithContext Fetch an item
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_item
 //
 // Returns: An item.
-func (c *Client) GetItem(itemId string) (*Item, error) {
+func (c *Client) GetItemWithContext(ctx context.Context, itemId string, opts ...Option) (*Item, error) {
+	return c.getItem(ctx, itemId, opts...)
+}
+
+func (c *Client) getItem(ctx context.Context, itemId string, opts ...Option) (*Item, error) {
 	path, err := c.InterpolatePath("/items/{item_id}", itemId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Item{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// UpdateItem Update an active item
+// UpdateItem wraps UpdateItemWithContext using the background context
+func (c *Client) UpdateItem(itemId string, body *ItemUpdate, opts ...Option) (*Item, error) {
+	return c.updateItem(context.Background(), itemId, body, opts...)
+}
+
+// UpdateItemWithContext Update an active item
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_item
 //
 // Returns: The updated item.
-func (c *Client) UpdateItem(itemId string, body *ItemUpdate) (*Item, error) {
+func (c *Client) UpdateItemWithContext(ctx context.Context, itemId string, body *ItemUpdate, opts ...Option) (*Item, error) {
+	return c.updateItem(ctx, itemId, body, opts...)
+}
+
+func (c *Client) updateItem(ctx context.Context, itemId string, body *ItemUpdate, opts ...Option) (*Item, error) {
 	path, err := c.InterpolatePath("/items/{item_id}", itemId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Item{}
-	err = c.Call(http.MethodPut, path, body, result)
+	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// DeactivateItem Deactivate an item
+// DeactivateItem wraps DeactivateItemWithContext using the background context
+func (c *Client) DeactivateItem(itemId string, opts ...Option) (*Item, error) {
+	return c.deactivateItem(context.Background(), itemId, opts...)
+}
+
+// DeactivateItemWithContext Deactivate an item
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/deactivate_item
 //
 // Returns: An item.
-func (c *Client) DeactivateItem(itemId string) (*Item, error) {
+func (c *Client) DeactivateItemWithContext(ctx context.Context, itemId string, opts ...Option) (*Item, error) {
+	return c.deactivateItem(ctx, itemId, opts...)
+}
+
+func (c *Client) deactivateItem(ctx context.Context, itemId string, opts ...Option) (*Item, error) {
 	path, err := c.InterpolatePath("/items/{item_id}", itemId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Item{}
-	err = c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// ReactivateItem Reactivate an inactive item
+// ReactivateItem wraps ReactivateItemWithContext using the background context
+func (c *Client) ReactivateItem(itemId string, opts ...Option) (*Item, error) {
+	return c.reactivateItem(context.Background(), itemId, opts...)
+}
+
+// ReactivateItemWithContext Reactivate an inactive item
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/reactivate_item
 //
 // Returns: An item.
-func (c *Client) ReactivateItem(itemId string) (*Item, error) {
+func (c *Client) ReactivateItemWithContext(ctx context.Context, itemId string, opts ...Option) (*Item, error) {
+	return c.reactivateItem(ctx, itemId, opts...)
+}
+
+func (c *Client) reactivateItem(ctx context.Context, itemId string, opts ...Option) (*Item, error) {
 	path, err := c.InterpolatePath("/items/{item_id}/reactivate", itemId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Item{}
-	err = c.Call(http.MethodPut, path, nil, result)
+	err = c.Call(context.Background(), http.MethodPut, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2658,81 +3170,122 @@ func (list *ListMeasuredUnitParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_measured_unit
 //
 // Returns: A list of the site's measured units.
-func (c *Client) ListMeasuredUnit(params *ListMeasuredUnitParams) *MeasuredUnitList {
+func (c *Client) ListMeasuredUnit(params *ListMeasuredUnitParams, opts ...Option) *MeasuredUnitList {
 	path, err := c.InterpolatePath("/measured_units")
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewMeasuredUnitList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewMeasuredUnitList(c, path, requestOptions)
 }
 
-// CreateMeasuredUnit Create a new measured unit
+// CreateMeasuredUnit wraps CreateMeasuredUnitWithContext using the background context
+func (c *Client) CreateMeasuredUnit(body *MeasuredUnitCreate, opts ...Option) (*MeasuredUnit, error) {
+	return c.createMeasuredUnit(context.Background(), body, opts...)
+}
+
+// CreateMeasuredUnitWithContext Create a new measured unit
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_measured_unit
 //
 // Returns: A new measured unit.
-func (c *Client) CreateMeasuredUnit(body *MeasuredUnitCreate) (*MeasuredUnit, error) {
+func (c *Client) CreateMeasuredUnitWithContext(ctx context.Context, body *MeasuredUnitCreate, opts ...Option) (*MeasuredUnit, error) {
+	return c.createMeasuredUnit(ctx, body, opts...)
+}
+
+func (c *Client) createMeasuredUnit(ctx context.Context, body *MeasuredUnitCreate, opts ...Option) (*MeasuredUnit, error) {
 	path, err := c.InterpolatePath("/measured_units")
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &MeasuredUnit{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// GetMeasuredUnit Fetch a measured unit
+// GetMeasuredUnit wraps GetMeasuredUnitWithContext using the background context
+func (c *Client) GetMeasuredUnit(measuredUnitId string, opts ...Option) (*MeasuredUnit, error) {
+	return c.getMeasuredUnit(context.Background(), measuredUnitId, opts...)
+}
+
+// GetMeasuredUnitWithContext Fetch a measured unit
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_measured_unit
 //
 // Returns: An item.
-func (c *Client) GetMeasuredUnit(measuredUnitId string) (*MeasuredUnit, error) {
+func (c *Client) GetMeasuredUnitWithContext(ctx context.Context, measuredUnitId string, opts ...Option) (*MeasuredUnit, error) {
+	return c.getMeasuredUnit(ctx, measuredUnitId, opts...)
+}
+
+func (c *Client) getMeasuredUnit(ctx context.Context, measuredUnitId string, opts ...Option) (*MeasuredUnit, error) {
 	path, err := c.InterpolatePath("/measured_units/{measured_unit_id}", measuredUnitId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &MeasuredUnit{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// UpdateMeasuredUnit Update a measured unit
+// UpdateMeasuredUnit wraps UpdateMeasuredUnitWithContext using the background context
+func (c *Client) UpdateMeasuredUnit(measuredUnitId string, body *MeasuredUnitUpdate, opts ...Option) (*MeasuredUnit, error) {
+	return c.updateMeasuredUnit(context.Background(), measuredUnitId, body, opts...)
+}
+
+// UpdateMeasuredUnitWithContext Update a measured unit
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_measured_unit
 //
 // Returns: The updated measured_unit.
-func (c *Client) UpdateMeasuredUnit(measuredUnitId string, body *MeasuredUnitUpdate) (*MeasuredUnit, error) {
+func (c *Client) UpdateMeasuredUnitWithContext(ctx context.Context, measuredUnitId string, body *MeasuredUnitUpdate, opts ...Option) (*MeasuredUnit, error) {
+	return c.updateMeasuredUnit(ctx, measuredUnitId, body, opts...)
+}
+
+func (c *Client) updateMeasuredUnit(ctx context.Context, measuredUnitId string, body *MeasuredUnitUpdate, opts ...Option) (*MeasuredUnit, error) {
 	path, err := c.InterpolatePath("/measured_units/{measured_unit_id}", measuredUnitId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &MeasuredUnit{}
-	err = c.Call(http.MethodPut, path, body, result)
+	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// RemoveMeasuredUnit Remove a measured unit
+// RemoveMeasuredUnit wraps RemoveMeasuredUnitWithContext using the background context
+func (c *Client) RemoveMeasuredUnit(measuredUnitId string, opts ...Option) (*MeasuredUnit, error) {
+	return c.removeMeasuredUnit(context.Background(), measuredUnitId, opts...)
+}
+
+// RemoveMeasuredUnitWithContext Remove a measured unit
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_measured_unit
 //
 // Returns: A measured unit.
-func (c *Client) RemoveMeasuredUnit(measuredUnitId string) (*MeasuredUnit, error) {
+func (c *Client) RemoveMeasuredUnitWithContext(ctx context.Context, measuredUnitId string, opts ...Option) (*MeasuredUnit, error) {
+	return c.removeMeasuredUnit(ctx, measuredUnitId, opts...)
+}
+
+func (c *Client) removeMeasuredUnit(ctx context.Context, measuredUnitId string, opts ...Option) (*MeasuredUnit, error) {
 	path, err := c.InterpolatePath("/measured_units/{measured_unit_id}", measuredUnitId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &MeasuredUnit{}
-	err = c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2828,45 +3381,66 @@ func (list *ListInvoicesParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_invoices
 //
 // Returns: A list of the site's invoices.
-func (c *Client) ListInvoices(params *ListInvoicesParams) *InvoiceList {
+func (c *Client) ListInvoices(params *ListInvoicesParams, opts ...Option) *InvoiceList {
 	path, err := c.InterpolatePath("/invoices")
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewInvoiceList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewInvoiceList(c, path, requestOptions)
 }
 
-// GetInvoice Fetch an invoice
+// GetInvoice wraps GetInvoiceWithContext using the background context
+func (c *Client) GetInvoice(invoiceId string, opts ...Option) (*Invoice, error) {
+	return c.getInvoice(context.Background(), invoiceId, opts...)
+}
+
+// GetInvoiceWithContext Fetch an invoice
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_invoice
 //
 // Returns: An invoice.
-func (c *Client) GetInvoice(invoiceId string) (*Invoice, error) {
+func (c *Client) GetInvoiceWithContext(ctx context.Context, invoiceId string, opts ...Option) (*Invoice, error) {
+	return c.getInvoice(ctx, invoiceId, opts...)
+}
+
+func (c *Client) getInvoice(ctx context.Context, invoiceId string, opts ...Option) (*Invoice, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}", invoiceId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Invoice{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// PutInvoice Update an invoice
+// PutInvoice wraps PutInvoiceWithContext using the background context
+func (c *Client) PutInvoice(invoiceId string, body *InvoiceUpdatable, opts ...Option) (*Invoice, error) {
+	return c.putInvoice(context.Background(), invoiceId, body, opts...)
+}
+
+// PutInvoiceWithContext Update an invoice
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/put_invoice
 //
 // Returns: An invoice.
-func (c *Client) PutInvoice(invoiceId string, body *InvoiceUpdatable) (*Invoice, error) {
+func (c *Client) PutInvoiceWithContext(ctx context.Context, invoiceId string, body *InvoiceUpdatable, opts ...Option) (*Invoice, error) {
+	return c.putInvoice(ctx, invoiceId, body, opts...)
+}
+
+func (c *Client) putInvoice(ctx context.Context, invoiceId string, body *InvoiceUpdatable, opts ...Option) (*Invoice, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}", invoiceId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Invoice{}
-	err = c.Call(http.MethodPut, path, body, result)
+	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -2889,108 +3463,174 @@ func (list *CollectInvoiceParams) toParams() *Params {
 	}
 }
 
-// CollectInvoice Collect a pending or past due, automatic invoice
+func (list *CollectInvoiceParams) URLParams() []KeyValue {
+	var options []KeyValue
+
+	return options
+}
+
+// CollectInvoice wraps CollectInvoiceWithContext using the background context
+func (c *Client) CollectInvoice(invoiceId string, params *CollectInvoiceParams, opts ...Option) (*Invoice, error) {
+	return c.collectInvoice(context.Background(), invoiceId, params, opts...)
+}
+
+// CollectInvoiceWithContext Collect a pending or past due, automatic invoice
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/collect_invoice
 //
 // Returns: The updated invoice.
-func (c *Client) CollectInvoice(invoiceId string, params *CollectInvoiceParams) (*Invoice, error) {
+func (c *Client) CollectInvoiceWithContext(ctx context.Context, invoiceId string, params *CollectInvoiceParams, opts ...Option) (*Invoice, error) {
+	return c.collectInvoice(ctx, invoiceId, params, opts...)
+}
+
+func (c *Client) collectInvoice(ctx context.Context, invoiceId string, params *CollectInvoiceParams, opts ...Option) (*Invoice, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/collect", invoiceId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Invoice{}
-	err = c.Call(http.MethodPut, path, params, result)
+	err = c.Call(context.Background(), http.MethodPut, path, nil, params, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// FailInvoice Mark an open invoice as failed
+// FailInvoice wraps FailInvoiceWithContext using the background context
+func (c *Client) FailInvoice(invoiceId string, opts ...Option) (*Invoice, error) {
+	return c.failInvoice(context.Background(), invoiceId, opts...)
+}
+
+// FailInvoiceWithContext Mark an open invoice as failed
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/fail_invoice
 //
 // Returns: The updated invoice.
-func (c *Client) FailInvoice(invoiceId string) (*Invoice, error) {
+func (c *Client) FailInvoiceWithContext(ctx context.Context, invoiceId string, opts ...Option) (*Invoice, error) {
+	return c.failInvoice(ctx, invoiceId, opts...)
+}
+
+func (c *Client) failInvoice(ctx context.Context, invoiceId string, opts ...Option) (*Invoice, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/mark_failed", invoiceId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Invoice{}
-	err = c.Call(http.MethodPut, path, nil, result)
+	err = c.Call(context.Background(), http.MethodPut, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// MarkInvoiceSuccessful Mark an open invoice as successful
+// MarkInvoiceSuccessful wraps MarkInvoiceSuccessfulWithContext using the background context
+func (c *Client) MarkInvoiceSuccessful(invoiceId string, opts ...Option) (*Invoice, error) {
+	return c.markInvoiceSuccessful(context.Background(), invoiceId, opts...)
+}
+
+// MarkInvoiceSuccessfulWithContext Mark an open invoice as successful
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/mark_invoice_successful
 //
 // Returns: The updated invoice.
-func (c *Client) MarkInvoiceSuccessful(invoiceId string) (*Invoice, error) {
+func (c *Client) MarkInvoiceSuccessfulWithContext(ctx context.Context, invoiceId string, opts ...Option) (*Invoice, error) {
+	return c.markInvoiceSuccessful(ctx, invoiceId, opts...)
+}
+
+func (c *Client) markInvoiceSuccessful(ctx context.Context, invoiceId string, opts ...Option) (*Invoice, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/mark_successful", invoiceId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Invoice{}
-	err = c.Call(http.MethodPut, path, nil, result)
+	err = c.Call(context.Background(), http.MethodPut, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// ReopenInvoice Reopen a closed, manual invoice
+// ReopenInvoice wraps ReopenInvoiceWithContext using the background context
+func (c *Client) ReopenInvoice(invoiceId string, opts ...Option) (*Invoice, error) {
+	return c.reopenInvoice(context.Background(), invoiceId, opts...)
+}
+
+// ReopenInvoiceWithContext Reopen a closed, manual invoice
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/reopen_invoice
 //
 // Returns: The updated invoice.
-func (c *Client) ReopenInvoice(invoiceId string) (*Invoice, error) {
+func (c *Client) ReopenInvoiceWithContext(ctx context.Context, invoiceId string, opts ...Option) (*Invoice, error) {
+	return c.reopenInvoice(ctx, invoiceId, opts...)
+}
+
+func (c *Client) reopenInvoice(ctx context.Context, invoiceId string, opts ...Option) (*Invoice, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/reopen", invoiceId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Invoice{}
-	err = c.Call(http.MethodPut, path, nil, result)
+	err = c.Call(context.Background(), http.MethodPut, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// VoidInvoice Void a credit invoice.
+// VoidInvoice wraps VoidInvoiceWithContext using the background context
+func (c *Client) VoidInvoice(invoiceId string, opts ...Option) (*Invoice, error) {
+	return c.voidInvoice(context.Background(), invoiceId, opts...)
+}
+
+// VoidInvoiceWithContext Void a credit invoice.
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/void_invoice
 //
 // Returns: The updated invoice.
-func (c *Client) VoidInvoice(invoiceId string) (*Invoice, error) {
+func (c *Client) VoidInvoiceWithContext(ctx context.Context, invoiceId string, opts ...Option) (*Invoice, error) {
+	return c.voidInvoice(ctx, invoiceId, opts...)
+}
+
+func (c *Client) voidInvoice(ctx context.Context, invoiceId string, opts ...Option) (*Invoice, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/void", invoiceId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Invoice{}
-	err = c.Call(http.MethodPut, path, nil, result)
+	err = c.Call(context.Background(), http.MethodPut, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// RecordExternalTransaction Record an external payment for a manual invoices.
+// RecordExternalTransaction wraps RecordExternalTransactionWithContext using the background context
+func (c *Client) RecordExternalTransaction(invoiceId string, body *ExternalTransaction, opts ...Option) (*Transaction, error) {
+	return c.recordExternalTransaction(context.Background(), invoiceId, body, opts...)
+}
+
+// RecordExternalTransactionWithContext Record an external payment for a manual invoices.
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/record_external_transaction
 //
 // Returns: The recorded transaction.
-func (c *Client) RecordExternalTransaction(invoiceId string, body *ExternalTransaction) (*Transaction, error) {
+func (c *Client) RecordExternalTransactionWithContext(ctx context.Context, invoiceId string, body *ExternalTransaction, opts ...Option) (*Transaction, error) {
+	return c.recordExternalTransaction(ctx, invoiceId, body, opts...)
+}
+
+func (c *Client) recordExternalTransaction(ctx context.Context, invoiceId string, body *ExternalTransaction, opts ...Option) (*Transaction, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/transactions", invoiceId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Transaction{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3096,13 +3736,14 @@ func (list *ListInvoiceLineItemsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_invoice_line_items
 //
 // Returns: A list of the invoice's line items.
-func (c *Client) ListInvoiceLineItems(invoiceId string, params *ListInvoiceLineItemsParams) *LineItemList {
+func (c *Client) ListInvoiceLineItems(invoiceId string, params *ListInvoiceLineItemsParams, opts ...Option) *LineItemList {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/line_items", invoiceId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewLineItemList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewLineItemList(c, path, requestOptions)
 }
 
 type ListInvoiceCouponRedemptionsParams struct {
@@ -3169,13 +3810,14 @@ func (list *ListInvoiceCouponRedemptionsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_invoice_coupon_redemptions
 //
 // Returns: A list of the the coupon redemptions associated with the invoice.
-func (c *Client) ListInvoiceCouponRedemptions(invoiceId string, params *ListInvoiceCouponRedemptionsParams) *CouponRedemptionList {
+func (c *Client) ListInvoiceCouponRedemptions(invoiceId string, params *ListInvoiceCouponRedemptionsParams, opts ...Option) *CouponRedemptionList {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/coupon_redemptions", invoiceId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewCouponRedemptionList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewCouponRedemptionList(c, path, requestOptions)
 }
 
 // ListRelatedInvoices List an invoice's related credit or charge invoices
@@ -3183,26 +3825,37 @@ func (c *Client) ListInvoiceCouponRedemptions(invoiceId string, params *ListInvo
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_related_invoices
 //
 // Returns: A list of the credit or charge invoices associated with the invoice.
-func (c *Client) ListRelatedInvoices(invoiceId string) *InvoiceList {
+func (c *Client) ListRelatedInvoices(invoiceId string, opts ...Option) *InvoiceList {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/related_invoices", invoiceId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	return NewInvoiceList(c, path)
+	requestOptions := NewRequestOptions(opts...)
+	return NewInvoiceList(c, path, requestOptions)
 }
 
-// RefundInvoice Refund an invoice
+// RefundInvoice wraps RefundInvoiceWithContext using the background context
+func (c *Client) RefundInvoice(invoiceId string, body *InvoiceRefund, opts ...Option) (*Invoice, error) {
+	return c.refundInvoice(context.Background(), invoiceId, body, opts...)
+}
+
+// RefundInvoiceWithContext Refund an invoice
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/refund_invoice
 //
 // Returns: Returns the new credit invoice.
-func (c *Client) RefundInvoice(invoiceId string, body *InvoiceRefund) (*Invoice, error) {
+func (c *Client) RefundInvoiceWithContext(ctx context.Context, invoiceId string, body *InvoiceRefund, opts ...Option) (*Invoice, error) {
+	return c.refundInvoice(ctx, invoiceId, body, opts...)
+}
+
+func (c *Client) refundInvoice(ctx context.Context, invoiceId string, body *InvoiceRefund, opts ...Option) (*Invoice, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/refund", invoiceId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Invoice{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3308,45 +3961,66 @@ func (list *ListLineItemsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_line_items
 //
 // Returns: A list of the site's line items.
-func (c *Client) ListLineItems(params *ListLineItemsParams) *LineItemList {
+func (c *Client) ListLineItems(params *ListLineItemsParams, opts ...Option) *LineItemList {
 	path, err := c.InterpolatePath("/line_items")
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewLineItemList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewLineItemList(c, path, requestOptions)
 }
 
-// GetLineItem Fetch a line item
+// GetLineItem wraps GetLineItemWithContext using the background context
+func (c *Client) GetLineItem(lineItemId string, opts ...Option) (*LineItem, error) {
+	return c.getLineItem(context.Background(), lineItemId, opts...)
+}
+
+// GetLineItemWithContext Fetch a line item
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_line_item
 //
 // Returns: A line item.
-func (c *Client) GetLineItem(lineItemId string) (*LineItem, error) {
+func (c *Client) GetLineItemWithContext(ctx context.Context, lineItemId string, opts ...Option) (*LineItem, error) {
+	return c.getLineItem(ctx, lineItemId, opts...)
+}
+
+func (c *Client) getLineItem(ctx context.Context, lineItemId string, opts ...Option) (*LineItem, error) {
 	path, err := c.InterpolatePath("/line_items/{line_item_id}", lineItemId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &LineItem{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// RemoveLineItem Delete an uninvoiced line item
+// RemoveLineItem wraps RemoveLineItemWithContext using the background context
+func (c *Client) RemoveLineItem(lineItemId string, opts ...Option) (*Empty, error) {
+	return c.removeLineItem(context.Background(), lineItemId, opts...)
+}
+
+// RemoveLineItemWithContext Delete an uninvoiced line item
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_line_item
 //
 // Returns: Line item deleted.
-func (c *Client) RemoveLineItem(lineItemId string) (*Empty, error) {
+func (c *Client) RemoveLineItemWithContext(ctx context.Context, lineItemId string, opts ...Option) (*Empty, error) {
+	return c.removeLineItem(ctx, lineItemId, opts...)
+}
+
+func (c *Client) removeLineItem(ctx context.Context, lineItemId string, opts ...Option) (*Empty, error) {
 	path, err := c.InterpolatePath("/line_items/{line_item_id}", lineItemId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Empty{}
-	err = c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3438,81 +4112,122 @@ func (list *ListPlansParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_plans
 //
 // Returns: A list of plans.
-func (c *Client) ListPlans(params *ListPlansParams) *PlanList {
+func (c *Client) ListPlans(params *ListPlansParams, opts ...Option) *PlanList {
 	path, err := c.InterpolatePath("/plans")
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewPlanList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewPlanList(c, path, requestOptions)
 }
 
-// CreatePlan Create a plan
+// CreatePlan wraps CreatePlanWithContext using the background context
+func (c *Client) CreatePlan(body *PlanCreate, opts ...Option) (*Plan, error) {
+	return c.createPlan(context.Background(), body, opts...)
+}
+
+// CreatePlanWithContext Create a plan
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_plan
 //
 // Returns: A plan.
-func (c *Client) CreatePlan(body *PlanCreate) (*Plan, error) {
+func (c *Client) CreatePlanWithContext(ctx context.Context, body *PlanCreate, opts ...Option) (*Plan, error) {
+	return c.createPlan(ctx, body, opts...)
+}
+
+func (c *Client) createPlan(ctx context.Context, body *PlanCreate, opts ...Option) (*Plan, error) {
 	path, err := c.InterpolatePath("/plans")
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Plan{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// GetPlan Fetch a plan
+// GetPlan wraps GetPlanWithContext using the background context
+func (c *Client) GetPlan(planId string, opts ...Option) (*Plan, error) {
+	return c.getPlan(context.Background(), planId, opts...)
+}
+
+// GetPlanWithContext Fetch a plan
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_plan
 //
 // Returns: A plan.
-func (c *Client) GetPlan(planId string) (*Plan, error) {
+func (c *Client) GetPlanWithContext(ctx context.Context, planId string, opts ...Option) (*Plan, error) {
+	return c.getPlan(ctx, planId, opts...)
+}
+
+func (c *Client) getPlan(ctx context.Context, planId string, opts ...Option) (*Plan, error) {
 	path, err := c.InterpolatePath("/plans/{plan_id}", planId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Plan{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// UpdatePlan Update a plan
+// UpdatePlan wraps UpdatePlanWithContext using the background context
+func (c *Client) UpdatePlan(planId string, body *PlanUpdate, opts ...Option) (*Plan, error) {
+	return c.updatePlan(context.Background(), planId, body, opts...)
+}
+
+// UpdatePlanWithContext Update a plan
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_plan
 //
 // Returns: A plan.
-func (c *Client) UpdatePlan(planId string, body *PlanUpdate) (*Plan, error) {
+func (c *Client) UpdatePlanWithContext(ctx context.Context, planId string, body *PlanUpdate, opts ...Option) (*Plan, error) {
+	return c.updatePlan(ctx, planId, body, opts...)
+}
+
+func (c *Client) updatePlan(ctx context.Context, planId string, body *PlanUpdate, opts ...Option) (*Plan, error) {
 	path, err := c.InterpolatePath("/plans/{plan_id}", planId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Plan{}
-	err = c.Call(http.MethodPut, path, body, result)
+	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// RemovePlan Remove a plan
+// RemovePlan wraps RemovePlanWithContext using the background context
+func (c *Client) RemovePlan(planId string, opts ...Option) (*Plan, error) {
+	return c.removePlan(context.Background(), planId, opts...)
+}
+
+// RemovePlanWithContext Remove a plan
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_plan
 //
 // Returns: Plan deleted
-func (c *Client) RemovePlan(planId string) (*Plan, error) {
+func (c *Client) RemovePlanWithContext(ctx context.Context, planId string, opts ...Option) (*Plan, error) {
+	return c.removePlan(ctx, planId, opts...)
+}
+
+func (c *Client) removePlan(ctx context.Context, planId string, opts ...Option) (*Plan, error) {
 	path, err := c.InterpolatePath("/plans/{plan_id}", planId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Plan{}
-	err = c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3604,81 +4319,122 @@ func (list *ListPlanAddOnsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_plan_add_ons
 //
 // Returns: A list of add-ons.
-func (c *Client) ListPlanAddOns(planId string, params *ListPlanAddOnsParams) *AddOnList {
+func (c *Client) ListPlanAddOns(planId string, params *ListPlanAddOnsParams, opts ...Option) *AddOnList {
 	path, err := c.InterpolatePath("/plans/{plan_id}/add_ons", planId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewAddOnList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewAddOnList(c, path, requestOptions)
 }
 
-// CreatePlanAddOn Create an add-on
+// CreatePlanAddOn wraps CreatePlanAddOnWithContext using the background context
+func (c *Client) CreatePlanAddOn(planId string, body *AddOnCreate, opts ...Option) (*AddOn, error) {
+	return c.createPlanAddOn(context.Background(), planId, body, opts...)
+}
+
+// CreatePlanAddOnWithContext Create an add-on
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_plan_add_on
 //
 // Returns: An add-on.
-func (c *Client) CreatePlanAddOn(planId string, body *AddOnCreate) (*AddOn, error) {
+func (c *Client) CreatePlanAddOnWithContext(ctx context.Context, planId string, body *AddOnCreate, opts ...Option) (*AddOn, error) {
+	return c.createPlanAddOn(ctx, planId, body, opts...)
+}
+
+func (c *Client) createPlanAddOn(ctx context.Context, planId string, body *AddOnCreate, opts ...Option) (*AddOn, error) {
 	path, err := c.InterpolatePath("/plans/{plan_id}/add_ons", planId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &AddOn{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// GetPlanAddOn Fetch a plan's add-on
+// GetPlanAddOn wraps GetPlanAddOnWithContext using the background context
+func (c *Client) GetPlanAddOn(planId string, addOnId string, opts ...Option) (*AddOn, error) {
+	return c.getPlanAddOn(context.Background(), planId, addOnId, opts...)
+}
+
+// GetPlanAddOnWithContext Fetch a plan's add-on
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_plan_add_on
 //
 // Returns: An add-on.
-func (c *Client) GetPlanAddOn(planId string, addOnId string) (*AddOn, error) {
+func (c *Client) GetPlanAddOnWithContext(ctx context.Context, planId string, addOnId string, opts ...Option) (*AddOn, error) {
+	return c.getPlanAddOn(ctx, planId, addOnId, opts...)
+}
+
+func (c *Client) getPlanAddOn(ctx context.Context, planId string, addOnId string, opts ...Option) (*AddOn, error) {
 	path, err := c.InterpolatePath("/plans/{plan_id}/add_ons/{add_on_id}", planId, addOnId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &AddOn{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// UpdatePlanAddOn Update an add-on
+// UpdatePlanAddOn wraps UpdatePlanAddOnWithContext using the background context
+func (c *Client) UpdatePlanAddOn(planId string, addOnId string, body *AddOnUpdate, opts ...Option) (*AddOn, error) {
+	return c.updatePlanAddOn(context.Background(), planId, addOnId, body, opts...)
+}
+
+// UpdatePlanAddOnWithContext Update an add-on
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_plan_add_on
 //
 // Returns: An add-on.
-func (c *Client) UpdatePlanAddOn(planId string, addOnId string, body *AddOnUpdate) (*AddOn, error) {
+func (c *Client) UpdatePlanAddOnWithContext(ctx context.Context, planId string, addOnId string, body *AddOnUpdate, opts ...Option) (*AddOn, error) {
+	return c.updatePlanAddOn(ctx, planId, addOnId, body, opts...)
+}
+
+func (c *Client) updatePlanAddOn(ctx context.Context, planId string, addOnId string, body *AddOnUpdate, opts ...Option) (*AddOn, error) {
 	path, err := c.InterpolatePath("/plans/{plan_id}/add_ons/{add_on_id}", planId, addOnId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &AddOn{}
-	err = c.Call(http.MethodPut, path, body, result)
+	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// RemovePlanAddOn Remove an add-on
+// RemovePlanAddOn wraps RemovePlanAddOnWithContext using the background context
+func (c *Client) RemovePlanAddOn(planId string, addOnId string, opts ...Option) (*AddOn, error) {
+	return c.removePlanAddOn(context.Background(), planId, addOnId, opts...)
+}
+
+// RemovePlanAddOnWithContext Remove an add-on
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_plan_add_on
 //
 // Returns: Add-on deleted
-func (c *Client) RemovePlanAddOn(planId string, addOnId string) (*AddOn, error) {
+func (c *Client) RemovePlanAddOnWithContext(ctx context.Context, planId string, addOnId string, opts ...Option) (*AddOn, error) {
+	return c.removePlanAddOn(ctx, planId, addOnId, opts...)
+}
+
+func (c *Client) removePlanAddOn(ctx context.Context, planId string, addOnId string, opts ...Option) (*AddOn, error) {
 	path, err := c.InterpolatePath("/plans/{plan_id}/add_ons/{add_on_id}", planId, addOnId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &AddOn{}
-	err = c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3770,27 +4526,38 @@ func (list *ListAddOnsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_add_ons
 //
 // Returns: A list of add-ons.
-func (c *Client) ListAddOns(params *ListAddOnsParams) *AddOnList {
+func (c *Client) ListAddOns(params *ListAddOnsParams, opts ...Option) *AddOnList {
 	path, err := c.InterpolatePath("/add_ons")
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewAddOnList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewAddOnList(c, path, requestOptions)
 }
 
-// GetAddOn Fetch an add-on
+// GetAddOn wraps GetAddOnWithContext using the background context
+func (c *Client) GetAddOn(addOnId string, opts ...Option) (*AddOn, error) {
+	return c.getAddOn(context.Background(), addOnId, opts...)
+}
+
+// GetAddOnWithContext Fetch an add-on
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_add_on
 //
 // Returns: An add-on.
-func (c *Client) GetAddOn(addOnId string) (*AddOn, error) {
+func (c *Client) GetAddOnWithContext(ctx context.Context, addOnId string, opts ...Option) (*AddOn, error) {
+	return c.getAddOn(ctx, addOnId, opts...)
+}
+
+func (c *Client) getAddOn(ctx context.Context, addOnId string, opts ...Option) (*AddOn, error) {
 	path, err := c.InterpolatePath("/add_ons/{add_on_id}", addOnId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &AddOn{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -3875,81 +4642,122 @@ func (list *ListShippingMethodsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_shipping_methods
 //
 // Returns: A list of the site's shipping methods.
-func (c *Client) ListShippingMethods(params *ListShippingMethodsParams) *ShippingMethodList {
+func (c *Client) ListShippingMethods(params *ListShippingMethodsParams, opts ...Option) *ShippingMethodList {
 	path, err := c.InterpolatePath("/shipping_methods")
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewShippingMethodList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewShippingMethodList(c, path, requestOptions)
 }
 
-// CreateShippingMethod Create a new shipping method
+// CreateShippingMethod wraps CreateShippingMethodWithContext using the background context
+func (c *Client) CreateShippingMethod(body *ShippingMethodCreate, opts ...Option) (*ShippingMethod, error) {
+	return c.createShippingMethod(context.Background(), body, opts...)
+}
+
+// CreateShippingMethodWithContext Create a new shipping method
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_shipping_method
 //
 // Returns: A new shipping method.
-func (c *Client) CreateShippingMethod(body *ShippingMethodCreate) (*ShippingMethod, error) {
+func (c *Client) CreateShippingMethodWithContext(ctx context.Context, body *ShippingMethodCreate, opts ...Option) (*ShippingMethod, error) {
+	return c.createShippingMethod(ctx, body, opts...)
+}
+
+func (c *Client) createShippingMethod(ctx context.Context, body *ShippingMethodCreate, opts ...Option) (*ShippingMethod, error) {
 	path, err := c.InterpolatePath("/shipping_methods")
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &ShippingMethod{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// GetShippingMethod Fetch a shipping method
+// GetShippingMethod wraps GetShippingMethodWithContext using the background context
+func (c *Client) GetShippingMethod(id string, opts ...Option) (*ShippingMethod, error) {
+	return c.getShippingMethod(context.Background(), id, opts...)
+}
+
+// GetShippingMethodWithContext Fetch a shipping method
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_shipping_method
 //
 // Returns: A shipping method.
-func (c *Client) GetShippingMethod(id string) (*ShippingMethod, error) {
+func (c *Client) GetShippingMethodWithContext(ctx context.Context, id string, opts ...Option) (*ShippingMethod, error) {
+	return c.getShippingMethod(ctx, id, opts...)
+}
+
+func (c *Client) getShippingMethod(ctx context.Context, id string, opts ...Option) (*ShippingMethod, error) {
 	path, err := c.InterpolatePath("/shipping_methods/{id}", id)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &ShippingMethod{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// UpdateShippingMethod Update an active Shipping Method
+// UpdateShippingMethod wraps UpdateShippingMethodWithContext using the background context
+func (c *Client) UpdateShippingMethod(shippingMethodId string, body *ShippingMethodUpdate, opts ...Option) (*ShippingMethod, error) {
+	return c.updateShippingMethod(context.Background(), shippingMethodId, body, opts...)
+}
+
+// UpdateShippingMethodWithContext Update an active Shipping Method
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_shipping_method
 //
 // Returns: The updated shipping method.
-func (c *Client) UpdateShippingMethod(shippingMethodId string, body *ShippingMethodUpdate) (*ShippingMethod, error) {
+func (c *Client) UpdateShippingMethodWithContext(ctx context.Context, shippingMethodId string, body *ShippingMethodUpdate, opts ...Option) (*ShippingMethod, error) {
+	return c.updateShippingMethod(ctx, shippingMethodId, body, opts...)
+}
+
+func (c *Client) updateShippingMethod(ctx context.Context, shippingMethodId string, body *ShippingMethodUpdate, opts ...Option) (*ShippingMethod, error) {
 	path, err := c.InterpolatePath("/shipping_methods/{shipping_method_id}", shippingMethodId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &ShippingMethod{}
-	err = c.Call(http.MethodPut, path, body, result)
+	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// DeactivateShippingMethod Deactivate a shipping method
+// DeactivateShippingMethod wraps DeactivateShippingMethodWithContext using the background context
+func (c *Client) DeactivateShippingMethod(shippingMethodId string, opts ...Option) (*ShippingMethod, error) {
+	return c.deactivateShippingMethod(context.Background(), shippingMethodId, opts...)
+}
+
+// DeactivateShippingMethodWithContext Deactivate a shipping method
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/deactivate_shipping_method
 //
 // Returns: A shipping method.
-func (c *Client) DeactivateShippingMethod(shippingMethodId string) (*ShippingMethod, error) {
+func (c *Client) DeactivateShippingMethodWithContext(ctx context.Context, shippingMethodId string, opts ...Option) (*ShippingMethod, error) {
+	return c.deactivateShippingMethod(ctx, shippingMethodId, opts...)
+}
+
+func (c *Client) deactivateShippingMethod(ctx context.Context, shippingMethodId string, opts ...Option) (*ShippingMethod, error) {
 	path, err := c.InterpolatePath("/shipping_methods/{shipping_method_id}", shippingMethodId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &ShippingMethod{}
-	err = c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4044,63 +4852,94 @@ func (list *ListSubscriptionsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_subscriptions
 //
 // Returns: A list of the site's subscriptions.
-func (c *Client) ListSubscriptions(params *ListSubscriptionsParams) *SubscriptionList {
+func (c *Client) ListSubscriptions(params *ListSubscriptionsParams, opts ...Option) *SubscriptionList {
 	path, err := c.InterpolatePath("/subscriptions")
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewSubscriptionList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewSubscriptionList(c, path, requestOptions)
 }
 
-// CreateSubscription Create a new subscription
+// CreateSubscription wraps CreateSubscriptionWithContext using the background context
+func (c *Client) CreateSubscription(body *SubscriptionCreate, opts ...Option) (*Subscription, error) {
+	return c.createSubscription(context.Background(), body, opts...)
+}
+
+// CreateSubscriptionWithContext Create a new subscription
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_subscription
 //
 // Returns: A subscription.
-func (c *Client) CreateSubscription(body *SubscriptionCreate) (*Subscription, error) {
+func (c *Client) CreateSubscriptionWithContext(ctx context.Context, body *SubscriptionCreate, opts ...Option) (*Subscription, error) {
+	return c.createSubscription(ctx, body, opts...)
+}
+
+func (c *Client) createSubscription(ctx context.Context, body *SubscriptionCreate, opts ...Option) (*Subscription, error) {
 	path, err := c.InterpolatePath("/subscriptions")
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Subscription{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// GetSubscription Fetch a subscription
+// GetSubscription wraps GetSubscriptionWithContext using the background context
+func (c *Client) GetSubscription(subscriptionId string, opts ...Option) (*Subscription, error) {
+	return c.getSubscription(context.Background(), subscriptionId, opts...)
+}
+
+// GetSubscriptionWithContext Fetch a subscription
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_subscription
 //
 // Returns: A subscription.
-func (c *Client) GetSubscription(subscriptionId string) (*Subscription, error) {
+func (c *Client) GetSubscriptionWithContext(ctx context.Context, subscriptionId string, opts ...Option) (*Subscription, error) {
+	return c.getSubscription(ctx, subscriptionId, opts...)
+}
+
+func (c *Client) getSubscription(ctx context.Context, subscriptionId string, opts ...Option) (*Subscription, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}", subscriptionId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Subscription{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// ModifySubscription Modify a subscription
+// ModifySubscription wraps ModifySubscriptionWithContext using the background context
+func (c *Client) ModifySubscription(subscriptionId string, body *SubscriptionUpdate, opts ...Option) (*Subscription, error) {
+	return c.modifySubscription(context.Background(), subscriptionId, body, opts...)
+}
+
+// ModifySubscriptionWithContext Modify a subscription
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/modify_subscription
 //
 // Returns: A subscription.
-func (c *Client) ModifySubscription(subscriptionId string, body *SubscriptionUpdate) (*Subscription, error) {
+func (c *Client) ModifySubscriptionWithContext(ctx context.Context, subscriptionId string, body *SubscriptionUpdate, opts ...Option) (*Subscription, error) {
+	return c.modifySubscription(ctx, subscriptionId, body, opts...)
+}
+
+func (c *Client) modifySubscription(ctx context.Context, subscriptionId string, body *SubscriptionUpdate, opts ...Option) (*Subscription, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}", subscriptionId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Subscription{}
-	err = c.Call(http.MethodPut, path, body, result)
+	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4145,18 +4984,28 @@ func (list *TerminateSubscriptionParams) URLParams() []KeyValue {
 	return options
 }
 
-// TerminateSubscription Terminate a subscription
+// TerminateSubscription wraps TerminateSubscriptionWithContext using the background context
+func (c *Client) TerminateSubscription(subscriptionId string, params *TerminateSubscriptionParams, opts ...Option) (*Subscription, error) {
+	return c.terminateSubscription(context.Background(), subscriptionId, params, opts...)
+}
+
+// TerminateSubscriptionWithContext Terminate a subscription
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/terminate_subscription
 //
 // Returns: An expired subscription.
-func (c *Client) TerminateSubscription(subscriptionId string, params *TerminateSubscriptionParams) (*Subscription, error) {
+func (c *Client) TerminateSubscriptionWithContext(ctx context.Context, subscriptionId string, params *TerminateSubscriptionParams, opts ...Option) (*Subscription, error) {
+	return c.terminateSubscription(ctx, subscriptionId, params, opts...)
+}
+
+func (c *Client) terminateSubscription(ctx context.Context, subscriptionId string, params *TerminateSubscriptionParams, opts ...Option) (*Subscription, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}", subscriptionId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Subscription{}
-	err = c.Call(http.MethodDelete, path, params, result)
+	err = c.Call(context.Background(), http.MethodDelete, path, nil, params, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4179,162 +5028,258 @@ func (list *CancelSubscriptionParams) toParams() *Params {
 	}
 }
 
-// CancelSubscription Cancel a subscription
+func (list *CancelSubscriptionParams) URLParams() []KeyValue {
+	var options []KeyValue
+
+	return options
+}
+
+// CancelSubscription wraps CancelSubscriptionWithContext using the background context
+func (c *Client) CancelSubscription(subscriptionId string, params *CancelSubscriptionParams, opts ...Option) (*Subscription, error) {
+	return c.cancelSubscription(context.Background(), subscriptionId, params, opts...)
+}
+
+// CancelSubscriptionWithContext Cancel a subscription
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/cancel_subscription
 //
 // Returns: A canceled or failed subscription.
-func (c *Client) CancelSubscription(subscriptionId string, params *CancelSubscriptionParams) (*Subscription, error) {
+func (c *Client) CancelSubscriptionWithContext(ctx context.Context, subscriptionId string, params *CancelSubscriptionParams, opts ...Option) (*Subscription, error) {
+	return c.cancelSubscription(ctx, subscriptionId, params, opts...)
+}
+
+func (c *Client) cancelSubscription(ctx context.Context, subscriptionId string, params *CancelSubscriptionParams, opts ...Option) (*Subscription, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/cancel", subscriptionId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Subscription{}
-	err = c.Call(http.MethodPut, path, params, result)
+	err = c.Call(context.Background(), http.MethodPut, path, nil, params, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// ReactivateSubscription Reactivate a canceled subscription
+// ReactivateSubscription wraps ReactivateSubscriptionWithContext using the background context
+func (c *Client) ReactivateSubscription(subscriptionId string, opts ...Option) (*Subscription, error) {
+	return c.reactivateSubscription(context.Background(), subscriptionId, opts...)
+}
+
+// ReactivateSubscriptionWithContext Reactivate a canceled subscription
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/reactivate_subscription
 //
 // Returns: An active subscription.
-func (c *Client) ReactivateSubscription(subscriptionId string) (*Subscription, error) {
+func (c *Client) ReactivateSubscriptionWithContext(ctx context.Context, subscriptionId string, opts ...Option) (*Subscription, error) {
+	return c.reactivateSubscription(ctx, subscriptionId, opts...)
+}
+
+func (c *Client) reactivateSubscription(ctx context.Context, subscriptionId string, opts ...Option) (*Subscription, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/reactivate", subscriptionId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Subscription{}
-	err = c.Call(http.MethodPut, path, nil, result)
+	err = c.Call(context.Background(), http.MethodPut, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// PauseSubscription Pause subscription
+// PauseSubscription wraps PauseSubscriptionWithContext using the background context
+func (c *Client) PauseSubscription(subscriptionId string, body *SubscriptionPause, opts ...Option) (*Subscription, error) {
+	return c.pauseSubscription(context.Background(), subscriptionId, body, opts...)
+}
+
+// PauseSubscriptionWithContext Pause subscription
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/pause_subscription
 //
 // Returns: A subscription.
-func (c *Client) PauseSubscription(subscriptionId string, body *SubscriptionPause) (*Subscription, error) {
+func (c *Client) PauseSubscriptionWithContext(ctx context.Context, subscriptionId string, body *SubscriptionPause, opts ...Option) (*Subscription, error) {
+	return c.pauseSubscription(ctx, subscriptionId, body, opts...)
+}
+
+func (c *Client) pauseSubscription(ctx context.Context, subscriptionId string, body *SubscriptionPause, opts ...Option) (*Subscription, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/pause", subscriptionId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Subscription{}
-	err = c.Call(http.MethodPut, path, body, result)
+	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// ResumeSubscription Resume subscription
+// ResumeSubscription wraps ResumeSubscriptionWithContext using the background context
+func (c *Client) ResumeSubscription(subscriptionId string, opts ...Option) (*Subscription, error) {
+	return c.resumeSubscription(context.Background(), subscriptionId, opts...)
+}
+
+// ResumeSubscriptionWithContext Resume subscription
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/resume_subscription
 //
 // Returns: A subscription.
-func (c *Client) ResumeSubscription(subscriptionId string) (*Subscription, error) {
+func (c *Client) ResumeSubscriptionWithContext(ctx context.Context, subscriptionId string, opts ...Option) (*Subscription, error) {
+	return c.resumeSubscription(ctx, subscriptionId, opts...)
+}
+
+func (c *Client) resumeSubscription(ctx context.Context, subscriptionId string, opts ...Option) (*Subscription, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/resume", subscriptionId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Subscription{}
-	err = c.Call(http.MethodPut, path, nil, result)
+	err = c.Call(context.Background(), http.MethodPut, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// ConvertTrial Convert trial subscription
+// ConvertTrial wraps ConvertTrialWithContext using the background context
+func (c *Client) ConvertTrial(subscriptionId string, opts ...Option) (*Subscription, error) {
+	return c.convertTrial(context.Background(), subscriptionId, opts...)
+}
+
+// ConvertTrialWithContext Convert trial subscription
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/convert_trial
 //
 // Returns: A subscription.
-func (c *Client) ConvertTrial(subscriptionId string) (*Subscription, error) {
+func (c *Client) ConvertTrialWithContext(ctx context.Context, subscriptionId string, opts ...Option) (*Subscription, error) {
+	return c.convertTrial(ctx, subscriptionId, opts...)
+}
+
+func (c *Client) convertTrial(ctx context.Context, subscriptionId string, opts ...Option) (*Subscription, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/convert_trial", subscriptionId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Subscription{}
-	err = c.Call(http.MethodPut, path, nil, result)
+	err = c.Call(context.Background(), http.MethodPut, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// GetSubscriptionChange Fetch a subscription's pending change
+// GetSubscriptionChange wraps GetSubscriptionChangeWithContext using the background context
+func (c *Client) GetSubscriptionChange(subscriptionId string, opts ...Option) (*SubscriptionChange, error) {
+	return c.getSubscriptionChange(context.Background(), subscriptionId, opts...)
+}
+
+// GetSubscriptionChangeWithContext Fetch a subscription's pending change
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_subscription_change
 //
 // Returns: A subscription's pending change.
-func (c *Client) GetSubscriptionChange(subscriptionId string) (*SubscriptionChange, error) {
+func (c *Client) GetSubscriptionChangeWithContext(ctx context.Context, subscriptionId string, opts ...Option) (*SubscriptionChange, error) {
+	return c.getSubscriptionChange(ctx, subscriptionId, opts...)
+}
+
+func (c *Client) getSubscriptionChange(ctx context.Context, subscriptionId string, opts ...Option) (*SubscriptionChange, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/change", subscriptionId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &SubscriptionChange{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// CreateSubscriptionChange Create a new subscription change
+// CreateSubscriptionChange wraps CreateSubscriptionChangeWithContext using the background context
+func (c *Client) CreateSubscriptionChange(subscriptionId string, body *SubscriptionChangeCreate, opts ...Option) (*SubscriptionChange, error) {
+	return c.createSubscriptionChange(context.Background(), subscriptionId, body, opts...)
+}
+
+// CreateSubscriptionChangeWithContext Create a new subscription change
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_subscription_change
 //
 // Returns: A subscription change.
-func (c *Client) CreateSubscriptionChange(subscriptionId string, body *SubscriptionChangeCreate) (*SubscriptionChange, error) {
+func (c *Client) CreateSubscriptionChangeWithContext(ctx context.Context, subscriptionId string, body *SubscriptionChangeCreate, opts ...Option) (*SubscriptionChange, error) {
+	return c.createSubscriptionChange(ctx, subscriptionId, body, opts...)
+}
+
+func (c *Client) createSubscriptionChange(ctx context.Context, subscriptionId string, body *SubscriptionChangeCreate, opts ...Option) (*SubscriptionChange, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/change", subscriptionId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &SubscriptionChange{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// RemoveSubscriptionChange Delete the pending subscription change
+// RemoveSubscriptionChange wraps RemoveSubscriptionChangeWithContext using the background context
+func (c *Client) RemoveSubscriptionChange(subscriptionId string, opts ...Option) (*Empty, error) {
+	return c.removeSubscriptionChange(context.Background(), subscriptionId, opts...)
+}
+
+// RemoveSubscriptionChangeWithContext Delete the pending subscription change
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_subscription_change
 //
 // Returns: Subscription change was deleted.
-func (c *Client) RemoveSubscriptionChange(subscriptionId string) (*Empty, error) {
+func (c *Client) RemoveSubscriptionChangeWithContext(ctx context.Context, subscriptionId string, opts ...Option) (*Empty, error) {
+	return c.removeSubscriptionChange(ctx, subscriptionId, opts...)
+}
+
+func (c *Client) removeSubscriptionChange(ctx context.Context, subscriptionId string, opts ...Option) (*Empty, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/change", subscriptionId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Empty{}
-	err = c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// PreviewSubscriptionChange Preview a new subscription change
+// PreviewSubscriptionChange wraps PreviewSubscriptionChangeWithContext using the background context
+func (c *Client) PreviewSubscriptionChange(subscriptionId string, body *SubscriptionChangeCreate, opts ...Option) (*SubscriptionChangePreview, error) {
+	return c.previewSubscriptionChange(context.Background(), subscriptionId, body, opts...)
+}
+
+// PreviewSubscriptionChangeWithContext Preview a new subscription change
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/preview_subscription_change
 //
 // Returns: A subscription change.
-func (c *Client) PreviewSubscriptionChange(subscriptionId string, body *SubscriptionChangeCreate) (*SubscriptionChangePreview, error) {
+func (c *Client) PreviewSubscriptionChangeWithContext(ctx context.Context, subscriptionId string, body *SubscriptionChangeCreate, opts ...Option) (*SubscriptionChangePreview, error) {
+	return c.previewSubscriptionChange(ctx, subscriptionId, body, opts...)
+}
+
+func (c *Client) previewSubscriptionChange(ctx context.Context, subscriptionId string, body *SubscriptionChangeCreate, opts ...Option) (*SubscriptionChangePreview, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/change/preview", subscriptionId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &SubscriptionChangePreview{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4430,13 +5375,14 @@ func (list *ListSubscriptionInvoicesParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_subscription_invoices
 //
 // Returns: A list of the subscription's invoices.
-func (c *Client) ListSubscriptionInvoices(subscriptionId string, params *ListSubscriptionInvoicesParams) *InvoiceList {
+func (c *Client) ListSubscriptionInvoices(subscriptionId string, params *ListSubscriptionInvoicesParams, opts ...Option) *InvoiceList {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/invoices", subscriptionId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewInvoiceList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewInvoiceList(c, path, requestOptions)
 }
 
 type ListSubscriptionLineItemsParams struct {
@@ -4538,13 +5484,14 @@ func (list *ListSubscriptionLineItemsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_subscription_line_items
 //
 // Returns: A list of the subscription's line items.
-func (c *Client) ListSubscriptionLineItems(subscriptionId string, params *ListSubscriptionLineItemsParams) *LineItemList {
+func (c *Client) ListSubscriptionLineItems(subscriptionId string, params *ListSubscriptionLineItemsParams, opts ...Option) *LineItemList {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/line_items", subscriptionId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewLineItemList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewLineItemList(c, path, requestOptions)
 }
 
 type ListSubscriptionCouponRedemptionsParams struct {
@@ -4611,13 +5558,14 @@ func (list *ListSubscriptionCouponRedemptionsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_subscription_coupon_redemptions
 //
 // Returns: A list of the the coupon redemptions on a subscription.
-func (c *Client) ListSubscriptionCouponRedemptions(subscriptionId string, params *ListSubscriptionCouponRedemptionsParams) *CouponRedemptionList {
+func (c *Client) ListSubscriptionCouponRedemptions(subscriptionId string, params *ListSubscriptionCouponRedemptionsParams, opts ...Option) *CouponRedemptionList {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/coupon_redemptions", subscriptionId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewCouponRedemptionList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewCouponRedemptionList(c, path, requestOptions)
 }
 
 type ListUsageParams struct {
@@ -4705,81 +5653,122 @@ func (list *ListUsageParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_usage
 //
 // Returns: A list of the subscription add-on's usage records.
-func (c *Client) ListUsage(subscriptionId string, addOnId string, params *ListUsageParams) *UsageList {
+func (c *Client) ListUsage(subscriptionId string, addOnId string, params *ListUsageParams, opts ...Option) *UsageList {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/add_ons/{add_on_id}/usage", subscriptionId, addOnId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewUsageList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewUsageList(c, path, requestOptions)
 }
 
-// CreateUsage Log a usage record on this subscription add-on
+// CreateUsage wraps CreateUsageWithContext using the background context
+func (c *Client) CreateUsage(subscriptionId string, addOnId string, body *UsageCreate, opts ...Option) (*Usage, error) {
+	return c.createUsage(context.Background(), subscriptionId, addOnId, body, opts...)
+}
+
+// CreateUsageWithContext Log a usage record on this subscription add-on
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_usage
 //
 // Returns: The created usage record.
-func (c *Client) CreateUsage(subscriptionId string, addOnId string, body *UsageCreate) (*Usage, error) {
+func (c *Client) CreateUsageWithContext(ctx context.Context, subscriptionId string, addOnId string, body *UsageCreate, opts ...Option) (*Usage, error) {
+	return c.createUsage(ctx, subscriptionId, addOnId, body, opts...)
+}
+
+func (c *Client) createUsage(ctx context.Context, subscriptionId string, addOnId string, body *UsageCreate, opts ...Option) (*Usage, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/add_ons/{add_on_id}/usage", subscriptionId, addOnId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Usage{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// GetUsage Get a usage record
+// GetUsage wraps GetUsageWithContext using the background context
+func (c *Client) GetUsage(usageId string, opts ...Option) (*Usage, error) {
+	return c.getUsage(context.Background(), usageId, opts...)
+}
+
+// GetUsageWithContext Get a usage record
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_usage
 //
 // Returns: The usage record.
-func (c *Client) GetUsage(usageId string) (*Usage, error) {
+func (c *Client) GetUsageWithContext(ctx context.Context, usageId string, opts ...Option) (*Usage, error) {
+	return c.getUsage(ctx, usageId, opts...)
+}
+
+func (c *Client) getUsage(ctx context.Context, usageId string, opts ...Option) (*Usage, error) {
 	path, err := c.InterpolatePath("/usage/{usage_id}", usageId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Usage{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// UpdateUsage Update a usage record
+// UpdateUsage wraps UpdateUsageWithContext using the background context
+func (c *Client) UpdateUsage(usageId string, body *UsageCreate, opts ...Option) (*Usage, error) {
+	return c.updateUsage(context.Background(), usageId, body, opts...)
+}
+
+// UpdateUsageWithContext Update a usage record
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/update_usage
 //
 // Returns: The updated usage record.
-func (c *Client) UpdateUsage(usageId string, body *UsageCreate) (*Usage, error) {
+func (c *Client) UpdateUsageWithContext(ctx context.Context, usageId string, body *UsageCreate, opts ...Option) (*Usage, error) {
+	return c.updateUsage(ctx, usageId, body, opts...)
+}
+
+func (c *Client) updateUsage(ctx context.Context, usageId string, body *UsageCreate, opts ...Option) (*Usage, error) {
 	path, err := c.InterpolatePath("/usage/{usage_id}", usageId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &Usage{}
-	err = c.Call(http.MethodPut, path, body, result)
+	err = c.Call(context.Background(), http.MethodPut, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// RemoveUsage Delete a usage record.
+// RemoveUsage wraps RemoveUsageWithContext using the background context
+func (c *Client) RemoveUsage(usageId string, opts ...Option) (*Empty, error) {
+	return c.removeUsage(context.Background(), usageId, opts...)
+}
+
+// RemoveUsageWithContext Delete a usage record.
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/remove_usage
 //
 // Returns: Usage was successfully deleted.
-func (c *Client) RemoveUsage(usageId string) (*Empty, error) {
+func (c *Client) RemoveUsageWithContext(ctx context.Context, usageId string, opts ...Option) (*Empty, error) {
+	return c.removeUsage(ctx, usageId, opts...)
+}
+
+func (c *Client) removeUsage(ctx context.Context, usageId string, opts ...Option) (*Empty, error) {
 	path, err := c.InterpolatePath("/usage/{usage_id}", usageId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Empty{}
-	err = c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -4878,153 +5867,234 @@ func (list *ListTransactionsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/list_transactions
 //
 // Returns: A list of the site's transactions.
-func (c *Client) ListTransactions(params *ListTransactionsParams) *TransactionList {
+func (c *Client) ListTransactions(params *ListTransactionsParams, opts ...Option) *TransactionList {
 	path, err := c.InterpolatePath("/transactions")
 	if err != nil {
 		// NOOP in 3.x client
 	}
-	path = BuildUrl(path, params)
-	return NewTransactionList(c, path)
+	requestOptions := RequestOptionsFromParams(params.Params, opts...)
+	path = BuildURL(path, params)
+	return NewTransactionList(c, path, requestOptions)
 }
 
-// GetTransaction Fetch a transaction
+// GetTransaction wraps GetTransactionWithContext using the background context
+func (c *Client) GetTransaction(transactionId string, opts ...Option) (*Transaction, error) {
+	return c.getTransaction(context.Background(), transactionId, opts...)
+}
+
+// GetTransactionWithContext Fetch a transaction
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_transaction
 //
 // Returns: A transaction.
-func (c *Client) GetTransaction(transactionId string) (*Transaction, error) {
+func (c *Client) GetTransactionWithContext(ctx context.Context, transactionId string, opts ...Option) (*Transaction, error) {
+	return c.getTransaction(ctx, transactionId, opts...)
+}
+
+func (c *Client) getTransaction(ctx context.Context, transactionId string, opts ...Option) (*Transaction, error) {
 	path, err := c.InterpolatePath("/transactions/{transaction_id}", transactionId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &Transaction{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// GetUniqueCouponCode Fetch a unique coupon code
+// GetUniqueCouponCode wraps GetUniqueCouponCodeWithContext using the background context
+func (c *Client) GetUniqueCouponCode(uniqueCouponCodeId string, opts ...Option) (*UniqueCouponCode, error) {
+	return c.getUniqueCouponCode(context.Background(), uniqueCouponCodeId, opts...)
+}
+
+// GetUniqueCouponCodeWithContext Fetch a unique coupon code
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_unique_coupon_code
 //
 // Returns: A unique coupon code.
-func (c *Client) GetUniqueCouponCode(uniqueCouponCodeId string) (*UniqueCouponCode, error) {
+func (c *Client) GetUniqueCouponCodeWithContext(ctx context.Context, uniqueCouponCodeId string, opts ...Option) (*UniqueCouponCode, error) {
+	return c.getUniqueCouponCode(ctx, uniqueCouponCodeId, opts...)
+}
+
+func (c *Client) getUniqueCouponCode(ctx context.Context, uniqueCouponCodeId string, opts ...Option) (*UniqueCouponCode, error) {
 	path, err := c.InterpolatePath("/unique_coupon_codes/{unique_coupon_code_id}", uniqueCouponCodeId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &UniqueCouponCode{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// DeactivateUniqueCouponCode Deactivate a unique coupon code
+// DeactivateUniqueCouponCode wraps DeactivateUniqueCouponCodeWithContext using the background context
+func (c *Client) DeactivateUniqueCouponCode(uniqueCouponCodeId string, opts ...Option) (*UniqueCouponCode, error) {
+	return c.deactivateUniqueCouponCode(context.Background(), uniqueCouponCodeId, opts...)
+}
+
+// DeactivateUniqueCouponCodeWithContext Deactivate a unique coupon code
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/deactivate_unique_coupon_code
 //
 // Returns: A unique coupon code.
-func (c *Client) DeactivateUniqueCouponCode(uniqueCouponCodeId string) (*UniqueCouponCode, error) {
+func (c *Client) DeactivateUniqueCouponCodeWithContext(ctx context.Context, uniqueCouponCodeId string, opts ...Option) (*UniqueCouponCode, error) {
+	return c.deactivateUniqueCouponCode(ctx, uniqueCouponCodeId, opts...)
+}
+
+func (c *Client) deactivateUniqueCouponCode(ctx context.Context, uniqueCouponCodeId string, opts ...Option) (*UniqueCouponCode, error) {
 	path, err := c.InterpolatePath("/unique_coupon_codes/{unique_coupon_code_id}", uniqueCouponCodeId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &UniqueCouponCode{}
-	err = c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// ReactivateUniqueCouponCode Restore a unique coupon code
+// ReactivateUniqueCouponCode wraps ReactivateUniqueCouponCodeWithContext using the background context
+func (c *Client) ReactivateUniqueCouponCode(uniqueCouponCodeId string, opts ...Option) (*UniqueCouponCode, error) {
+	return c.reactivateUniqueCouponCode(context.Background(), uniqueCouponCodeId, opts...)
+}
+
+// ReactivateUniqueCouponCodeWithContext Restore a unique coupon code
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/reactivate_unique_coupon_code
 //
 // Returns: A unique coupon code.
-func (c *Client) ReactivateUniqueCouponCode(uniqueCouponCodeId string) (*UniqueCouponCode, error) {
+func (c *Client) ReactivateUniqueCouponCodeWithContext(ctx context.Context, uniqueCouponCodeId string, opts ...Option) (*UniqueCouponCode, error) {
+	return c.reactivateUniqueCouponCode(ctx, uniqueCouponCodeId, opts...)
+}
+
+func (c *Client) reactivateUniqueCouponCode(ctx context.Context, uniqueCouponCodeId string, opts ...Option) (*UniqueCouponCode, error) {
 	path, err := c.InterpolatePath("/unique_coupon_codes/{unique_coupon_code_id}/restore", uniqueCouponCodeId)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &UniqueCouponCode{}
-	err = c.Call(http.MethodPut, path, nil, result)
+	err = c.Call(context.Background(), http.MethodPut, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// CreatePurchase Create a new purchase
+// CreatePurchase wraps CreatePurchaseWithContext using the background context
+func (c *Client) CreatePurchase(body *PurchaseCreate, opts ...Option) (*InvoiceCollection, error) {
+	return c.createPurchase(context.Background(), body, opts...)
+}
+
+// CreatePurchaseWithContext Create a new purchase
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/create_purchase
 //
 // Returns: Returns the new invoices
-func (c *Client) CreatePurchase(body *PurchaseCreate) (*InvoiceCollection, error) {
+func (c *Client) CreatePurchaseWithContext(ctx context.Context, body *PurchaseCreate, opts ...Option) (*InvoiceCollection, error) {
+	return c.createPurchase(ctx, body, opts...)
+}
+
+func (c *Client) createPurchase(ctx context.Context, body *PurchaseCreate, opts ...Option) (*InvoiceCollection, error) {
 	path, err := c.InterpolatePath("/purchases")
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &InvoiceCollection{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// PreviewPurchase Preview a new purchase
+// PreviewPurchase wraps PreviewPurchaseWithContext using the background context
+func (c *Client) PreviewPurchase(body *PurchaseCreate, opts ...Option) (*InvoiceCollection, error) {
+	return c.previewPurchase(context.Background(), body, opts...)
+}
+
+// PreviewPurchaseWithContext Preview a new purchase
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/preview_purchase
 //
 // Returns: Returns preview of the new invoices
-func (c *Client) PreviewPurchase(body *PurchaseCreate) (*InvoiceCollection, error) {
+func (c *Client) PreviewPurchaseWithContext(ctx context.Context, body *PurchaseCreate, opts ...Option) (*InvoiceCollection, error) {
+	return c.previewPurchase(ctx, body, opts...)
+}
+
+func (c *Client) previewPurchase(ctx context.Context, body *PurchaseCreate, opts ...Option) (*InvoiceCollection, error) {
 	path, err := c.InterpolatePath("/purchases/preview")
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := RequestOptionsFromParams(body.Params, opts...)
 	result := &InvoiceCollection{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// GetExportDates List the dates that have an available export to download.
+// GetExportDates wraps GetExportDatesWithContext using the background context
+func (c *Client) GetExportDates(opts ...Option) (*ExportDates, error) {
+	return c.getExportDates(context.Background(), opts...)
+}
+
+// GetExportDatesWithContext List the dates that have an available export to download.
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_export_dates
 //
 // Returns: Returns a list of dates.
-func (c *Client) GetExportDates() (*ExportDates, error) {
+func (c *Client) GetExportDatesWithContext(ctx context.Context, opts ...Option) (*ExportDates, error) {
+	return c.getExportDates(ctx, opts...)
+}
+
+func (c *Client) getExportDates(ctx context.Context, opts ...Option) (*ExportDates, error) {
 	path, err := c.InterpolatePath("/export_dates")
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &ExportDates{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-// GetExportFiles List of the export files that are available to download.
+// GetExportFiles wraps GetExportFilesWithContext using the background context
+func (c *Client) GetExportFiles(exportDate string, opts ...Option) (*ExportFiles, error) {
+	return c.getExportFiles(context.Background(), exportDate, opts...)
+}
+
+// GetExportFilesWithContext List of the export files that are available to download.
 //
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/get_export_files
 //
 // Returns: Returns a list of export files to download.
-func (c *Client) GetExportFiles(exportDate string) (*ExportFiles, error) {
+func (c *Client) GetExportFilesWithContext(ctx context.Context, exportDate string, opts ...Option) (*ExportFiles, error) {
+	return c.getExportFiles(ctx, exportDate, opts...)
+}
+
+func (c *Client) getExportFiles(ctx context.Context, exportDate string, opts ...Option) (*ExportFiles, error) {
 	path, err := c.InterpolatePath("/export_dates/{export_date}/export_files", exportDate)
 	if err != nil {
 		// NOOP in 3.x client
 	}
+	requestOptions := NewRequestOptions(opts...)
 	result := &ExportFiles{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}

--- a/client_operations_test.go
+++ b/client_operations_test.go
@@ -1,8 +1,10 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"testing"
+	"time"
 )
 
 func TestCreateAccount(test *testing.T) {
@@ -25,6 +27,31 @@ func TestCreateAccount(test *testing.T) {
 	}
 
 	account, _ := client.CreateAccount(body)
+	t.Assert(account.Id, "abcd1234", "account.Id")
+}
+
+func TestCreateAccountWithContext(test *testing.T) {
+	t := &T{test}
+	ctx, _ := context.WithTimeout(context.Background(), 20*time.Second)
+	scenario := &Scenario{
+		T: t,
+		AssertRequest: func(req *http.Request) {
+			t.Assert(req.Method, http.MethodPost, "HTTP Method")
+			t.Assert(req.Context(), ctx, "Request Context")
+			t.Assert(req.URL.String(), "https://v3.recurly.com/accounts", "Request URL")
+			t.Assert(bodyToString(req.Body), `{"code":"new_account"}`, "Request Body")
+		},
+		MakeResponse: func(req *http.Request) *http.Response {
+			return mockResponse(req, 201, String(`{"id": "abcd1234"}`))
+		},
+	}
+	client := scenario.MockHTTPClient()
+
+	body := &AccountCreate{
+		Code: String("new_account"),
+	}
+
+	account, _ := client.CreateAccountWithContext(ctx, body)
 	t.Assert(account.Id, "abcd1234", "account.Id")
 }
 
@@ -71,4 +98,74 @@ func TestListAccounts(test *testing.T) {
 	t.Assert(accounts.Data[1].FirstName, "juniper", "list.Data[1].FirstName")
 	t.Assert(accounts.HasMore, true, "list.HasMore")
 	t.Assert(accounts.nextPagePath, "/accounts?cursor=efgh5678%3A1588803986.0&limit=1&order=desc&sort=created_at", "accounts.nextPagePath")
+}
+
+func TestListAccountsWithContext(test *testing.T) {
+	t := &T{test}
+	ctx, _ := context.WithTimeout(context.Background(), 20*time.Second)
+	scenario := &Scenario{
+		T: t,
+		AssertRequest: func(req *http.Request) {
+			t.Assert(req.Method, http.MethodGet, "HTTP Method")
+			t.Assert(req.Context(), ctx, "Request Context")
+			t.Assert(req.URL.String(), "https://v3.recurly.com/accounts?limit=1&order=desc&sort=created_at", "Request URL")
+		},
+		MakeResponse: func(req *http.Request) *http.Response {
+			return mockResponse(req, 200, String(`{
+				"object": "list",
+				"has_more": true,
+				"next": "/accounts?cursor=efgh5678%3A1588803986.0&limit=1&order=desc&sort=created_at",
+				"data": [
+					{
+						"id": "abcd1234", 
+						"first_name": "marigold",
+						"last_name": "sunflower"
+					},
+					{
+						"id": "efgh5678", 
+						"first_name": "juniper",
+						"last_name": "pinecone"
+					}
+				]
+			}`))
+		},
+	}
+	client := scenario.MockHTTPClient()
+
+	params := &ListAccountsParams{
+		Sort:  String("created_at"),
+		Order: String("desc"),
+		Limit: Int(1),
+	}
+	accounts := client.ListAccounts(params)
+	accounts.FetchWithContext(ctx)
+
+	t.Assert(accounts.Data[0].Id, "abcd1234", "list.Data[0].Id")
+	t.Assert(accounts.Data[1].FirstName, "juniper", "list.Data[1].FirstName")
+	t.Assert(accounts.HasMore, true, "list.HasMore")
+	t.Assert(accounts.nextPagePath, "/accounts?cursor=efgh5678%3A1588803986.0&limit=1&order=desc&sort=created_at", "accounts.nextPagePath")
+}
+
+func TestCreateAccountWithNilContext(test *testing.T) {
+	t := &T{test}
+	scenario := &Scenario{
+		T: t,
+		AssertRequest: func(req *http.Request) {
+			t.Assert(req.Method, http.MethodPost, "HTTP Method")
+			t.Assert(req.Context(), context.Background(), "Request Context")
+			t.Assert(req.URL.String(), "https://v3.recurly.com/accounts", "Request URL")
+			t.Assert(bodyToString(req.Body), `{"code":"new_account"}`, "Request Body")
+		},
+		MakeResponse: func(req *http.Request) *http.Response {
+			return mockResponse(req, 201, String(`{"id": "abcd1234"}`))
+		},
+	}
+	client := scenario.MockHTTPClient()
+
+	body := &AccountCreate{
+		Code: String("new_account"),
+	}
+
+	account, _ := client.CreateAccountWithContext(nil, body)
+	t.Assert(account.Id, "abcd1234", "account.Id")
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,7 +1,6 @@
 package recurly
 
 import (
-	"context"
 	"net/http"
 	"testing"
 )
@@ -232,24 +231,4 @@ func TestSetIdempotencyKey(test *testing.T) {
 	client := scenario.MockHTTPClient()
 
 	client.GetResource("abcd1234", WithIdempotencyKey(key))
-}
-
-func TestSetContext(test *testing.T) {
-	t := &T{test}
-
-	ctx := context.TODO()
-
-	scenario := &Scenario{
-		T: t,
-		AssertRequest: func(req *http.Request) {
-			t.Assert(req.Context(), ctx, "Set Context")
-		},
-		MakeResponse: func(req *http.Request) *http.Response {
-			// default headers set, we may want to customize though
-			return mockResponse(req, 200, String(`{"id": "abcd1234"}`))
-		},
-	}
-	client := scenario.MockHTTPClient()
-
-	client.GetResource("abcd1234", WithContext(ctx))
 }

--- a/coupon_discount.go
+++ b/coupon_discount.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -52,25 +53,27 @@ func (resource *couponDiscountList) setResponse(res *ResponseMetadata) {
 
 // CouponDiscountList allows you to paginate CouponDiscount objects
 type CouponDiscountList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []CouponDiscount
 }
 
-func NewCouponDiscountList(client HttpCaller, nextPagePath string) *CouponDiscountList {
+func NewCouponDiscountList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *CouponDiscountList {
 	return &CouponDiscountList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *CouponDiscountList) Fetch() error {
+func (list *CouponDiscountList) FetchWithContext(ctx context.Context) error {
 	resources := &couponDiscountList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -81,13 +84,23 @@ func (list *CouponDiscountList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *CouponDiscountList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *CouponDiscountList) Count() (*int64, error) {
+func (list *CouponDiscountList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &couponDiscountList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *CouponDiscountList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/coupon_discount_pricing.go
+++ b/coupon_discount_pricing.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -47,25 +48,27 @@ func (resource *couponDiscountPricingList) setResponse(res *ResponseMetadata) {
 
 // CouponDiscountPricingList allows you to paginate CouponDiscountPricing objects
 type CouponDiscountPricingList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []CouponDiscountPricing
 }
 
-func NewCouponDiscountPricingList(client HttpCaller, nextPagePath string) *CouponDiscountPricingList {
+func NewCouponDiscountPricingList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *CouponDiscountPricingList {
 	return &CouponDiscountPricingList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *CouponDiscountPricingList) Fetch() error {
+func (list *CouponDiscountPricingList) FetchWithContext(ctx context.Context) error {
 	resources := &couponDiscountPricingList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -76,13 +79,23 @@ func (list *CouponDiscountPricingList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *CouponDiscountPricingList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *CouponDiscountPricingList) Count() (*int64, error) {
+func (list *CouponDiscountPricingList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &couponDiscountPricingList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *CouponDiscountPricingList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/coupon_discount_trial.go
+++ b/coupon_discount_trial.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -47,25 +48,27 @@ func (resource *couponDiscountTrialList) setResponse(res *ResponseMetadata) {
 
 // CouponDiscountTrialList allows you to paginate CouponDiscountTrial objects
 type CouponDiscountTrialList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []CouponDiscountTrial
 }
 
-func NewCouponDiscountTrialList(client HttpCaller, nextPagePath string) *CouponDiscountTrialList {
+func NewCouponDiscountTrialList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *CouponDiscountTrialList {
 	return &CouponDiscountTrialList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *CouponDiscountTrialList) Fetch() error {
+func (list *CouponDiscountTrialList) FetchWithContext(ctx context.Context) error {
 	resources := &couponDiscountTrialList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -76,13 +79,23 @@ func (list *CouponDiscountTrialList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *CouponDiscountTrialList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *CouponDiscountTrialList) Count() (*int64, error) {
+func (list *CouponDiscountTrialList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &couponDiscountTrialList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *CouponDiscountTrialList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/coupon_mini.go
+++ b/coupon_mini.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -67,25 +68,27 @@ func (resource *couponMiniList) setResponse(res *ResponseMetadata) {
 
 // CouponMiniList allows you to paginate CouponMini objects
 type CouponMiniList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []CouponMini
 }
 
-func NewCouponMiniList(client HttpCaller, nextPagePath string) *CouponMiniList {
+func NewCouponMiniList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *CouponMiniList {
 	return &CouponMiniList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *CouponMiniList) Fetch() error {
+func (list *CouponMiniList) FetchWithContext(ctx context.Context) error {
 	resources := &couponMiniList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -96,13 +99,23 @@ func (list *CouponMiniList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *CouponMiniList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *CouponMiniList) Count() (*int64, error) {
+func (list *CouponMiniList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &couponMiniList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *CouponMiniList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/coupon_redemption.go
+++ b/coupon_redemption.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -71,25 +72,27 @@ func (resource *couponRedemptionList) setResponse(res *ResponseMetadata) {
 
 // CouponRedemptionList allows you to paginate CouponRedemption objects
 type CouponRedemptionList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []CouponRedemption
 }
 
-func NewCouponRedemptionList(client HttpCaller, nextPagePath string) *CouponRedemptionList {
+func NewCouponRedemptionList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *CouponRedemptionList {
 	return &CouponRedemptionList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *CouponRedemptionList) Fetch() error {
+func (list *CouponRedemptionList) FetchWithContext(ctx context.Context) error {
 	resources := &couponRedemptionList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -100,13 +103,23 @@ func (list *CouponRedemptionList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *CouponRedemptionList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *CouponRedemptionList) Count() (*int64, error) {
+func (list *CouponRedemptionList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &couponRedemptionList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *CouponRedemptionList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/coupon_redemption_mini.go
+++ b/coupon_redemption_mini.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -59,25 +60,27 @@ func (resource *couponRedemptionMiniList) setResponse(res *ResponseMetadata) {
 
 // CouponRedemptionMiniList allows you to paginate CouponRedemptionMini objects
 type CouponRedemptionMiniList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []CouponRedemptionMini
 }
 
-func NewCouponRedemptionMiniList(client HttpCaller, nextPagePath string) *CouponRedemptionMiniList {
+func NewCouponRedemptionMiniList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *CouponRedemptionMiniList {
 	return &CouponRedemptionMiniList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *CouponRedemptionMiniList) Fetch() error {
+func (list *CouponRedemptionMiniList) FetchWithContext(ctx context.Context) error {
 	resources := &couponRedemptionMiniList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -88,13 +91,23 @@ func (list *CouponRedemptionMiniList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *CouponRedemptionMiniList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *CouponRedemptionMiniList) Count() (*int64, error) {
+func (list *CouponRedemptionMiniList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &couponRedemptionMiniList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *CouponRedemptionMiniList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/credit_payment.go
+++ b/credit_payment.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -83,25 +84,27 @@ func (resource *creditPaymentList) setResponse(res *ResponseMetadata) {
 
 // CreditPaymentList allows you to paginate CreditPayment objects
 type CreditPaymentList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []CreditPayment
 }
 
-func NewCreditPaymentList(client HttpCaller, nextPagePath string) *CreditPaymentList {
+func NewCreditPaymentList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *CreditPaymentList {
 	return &CreditPaymentList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *CreditPaymentList) Fetch() error {
+func (list *CreditPaymentList) FetchWithContext(ctx context.Context) error {
 	resources := &creditPaymentList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -112,13 +115,23 @@ func (list *CreditPaymentList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *CreditPaymentList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *CreditPaymentList) Count() (*int64, error) {
+func (list *CreditPaymentList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &creditPaymentList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *CreditPaymentList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/custom_field.go
+++ b/custom_field.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -47,25 +48,27 @@ func (resource *customFieldList) setResponse(res *ResponseMetadata) {
 
 // CustomFieldList allows you to paginate CustomField objects
 type CustomFieldList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []CustomField
 }
 
-func NewCustomFieldList(client HttpCaller, nextPagePath string) *CustomFieldList {
+func NewCustomFieldList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *CustomFieldList {
 	return &CustomFieldList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *CustomFieldList) Fetch() error {
+func (list *CustomFieldList) FetchWithContext(ctx context.Context) error {
 	resources := &customFieldList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -76,13 +79,23 @@ func (list *CustomFieldList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *CustomFieldList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *CustomFieldList) Count() (*int64, error) {
+func (list *CustomFieldList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &customFieldList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *CustomFieldList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/custom_field_definition.go
+++ b/custom_field_definition.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -76,25 +77,27 @@ func (resource *customFieldDefinitionList) setResponse(res *ResponseMetadata) {
 
 // CustomFieldDefinitionList allows you to paginate CustomFieldDefinition objects
 type CustomFieldDefinitionList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []CustomFieldDefinition
 }
 
-func NewCustomFieldDefinitionList(client HttpCaller, nextPagePath string) *CustomFieldDefinitionList {
+func NewCustomFieldDefinitionList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *CustomFieldDefinitionList {
 	return &CustomFieldDefinitionList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *CustomFieldDefinitionList) Fetch() error {
+func (list *CustomFieldDefinitionList) FetchWithContext(ctx context.Context) error {
 	resources := &customFieldDefinitionList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -105,13 +108,23 @@ func (list *CustomFieldDefinitionList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *CustomFieldDefinitionList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *CustomFieldDefinitionList) Count() (*int64, error) {
+func (list *CustomFieldDefinitionList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &customFieldDefinitionList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *CustomFieldDefinitionList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/error_may_have_transaction.go
+++ b/error_may_have_transaction.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -53,25 +54,27 @@ func (resource *errorMayHaveTransactionList) setResponse(res *ResponseMetadata) 
 
 // ErrorMayHaveTransactionList allows you to paginate ErrorMayHaveTransaction objects
 type ErrorMayHaveTransactionList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []ErrorMayHaveTransaction
 }
 
-func NewErrorMayHaveTransactionList(client HttpCaller, nextPagePath string) *ErrorMayHaveTransactionList {
+func NewErrorMayHaveTransactionList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *ErrorMayHaveTransactionList {
 	return &ErrorMayHaveTransactionList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *ErrorMayHaveTransactionList) Fetch() error {
+func (list *ErrorMayHaveTransactionList) FetchWithContext(ctx context.Context) error {
 	resources := &errorMayHaveTransactionList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -82,13 +85,23 @@ func (list *ErrorMayHaveTransactionList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *ErrorMayHaveTransactionList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *ErrorMayHaveTransactionList) Count() (*int64, error) {
+func (list *ErrorMayHaveTransactionList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &errorMayHaveTransactionList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *ErrorMayHaveTransactionList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/export_dates.go
+++ b/export_dates.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -47,25 +48,27 @@ func (resource *exportDatesList) setResponse(res *ResponseMetadata) {
 
 // ExportDatesList allows you to paginate ExportDates objects
 type ExportDatesList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []ExportDates
 }
 
-func NewExportDatesList(client HttpCaller, nextPagePath string) *ExportDatesList {
+func NewExportDatesList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *ExportDatesList {
 	return &ExportDatesList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *ExportDatesList) Fetch() error {
+func (list *ExportDatesList) FetchWithContext(ctx context.Context) error {
 	resources := &exportDatesList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -76,13 +79,23 @@ func (list *ExportDatesList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *ExportDatesList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *ExportDatesList) Count() (*int64, error) {
+func (list *ExportDatesList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &exportDatesList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *ExportDatesList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/export_file.go
+++ b/export_file.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -50,25 +51,27 @@ func (resource *exportFileList) setResponse(res *ResponseMetadata) {
 
 // ExportFileList allows you to paginate ExportFile objects
 type ExportFileList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []ExportFile
 }
 
-func NewExportFileList(client HttpCaller, nextPagePath string) *ExportFileList {
+func NewExportFileList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *ExportFileList {
 	return &ExportFileList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *ExportFileList) Fetch() error {
+func (list *ExportFileList) FetchWithContext(ctx context.Context) error {
 	resources := &exportFileList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -79,13 +82,23 @@ func (list *ExportFileList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *ExportFileList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *ExportFileList) Count() (*int64, error) {
+func (list *ExportFileList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &exportFileList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *ExportFileList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/export_files.go
+++ b/export_files.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -46,25 +47,27 @@ func (resource *exportFilesList) setResponse(res *ResponseMetadata) {
 
 // ExportFilesList allows you to paginate ExportFiles objects
 type ExportFilesList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []ExportFiles
 }
 
-func NewExportFilesList(client HttpCaller, nextPagePath string) *ExportFilesList {
+func NewExportFilesList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *ExportFilesList {
 	return &ExportFilesList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *ExportFilesList) Fetch() error {
+func (list *ExportFilesList) FetchWithContext(ctx context.Context) error {
 	resources := &exportFilesList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -75,13 +78,23 @@ func (list *ExportFilesList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *ExportFilesList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *ExportFilesList) Count() (*int64, error) {
+func (list *ExportFilesList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &exportFilesList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *ExportFilesList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/fraud_info.go
+++ b/fraud_info.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -50,25 +51,27 @@ func (resource *fraudInfoList) setResponse(res *ResponseMetadata) {
 
 // FraudInfoList allows you to paginate FraudInfo objects
 type FraudInfoList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []FraudInfo
 }
 
-func NewFraudInfoList(client HttpCaller, nextPagePath string) *FraudInfoList {
+func NewFraudInfoList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *FraudInfoList {
 	return &FraudInfoList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *FraudInfoList) Fetch() error {
+func (list *FraudInfoList) FetchWithContext(ctx context.Context) error {
 	resources := &fraudInfoList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -79,13 +82,23 @@ func (list *FraudInfoList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *FraudInfoList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *FraudInfoList) Count() (*int64, error) {
+func (list *FraudInfoList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &fraudInfoList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *FraudInfoList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/invoice_collection.go
+++ b/invoice_collection.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -49,25 +50,27 @@ func (resource *invoiceCollectionList) setResponse(res *ResponseMetadata) {
 
 // InvoiceCollectionList allows you to paginate InvoiceCollection objects
 type InvoiceCollectionList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []InvoiceCollection
 }
 
-func NewInvoiceCollectionList(client HttpCaller, nextPagePath string) *InvoiceCollectionList {
+func NewInvoiceCollectionList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *InvoiceCollectionList {
 	return &InvoiceCollectionList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *InvoiceCollectionList) Fetch() error {
+func (list *InvoiceCollectionList) FetchWithContext(ctx context.Context) error {
 	resources := &invoiceCollectionList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -78,13 +81,23 @@ func (list *InvoiceCollectionList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *InvoiceCollectionList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *InvoiceCollectionList) Count() (*int64, error) {
+func (list *InvoiceCollectionList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &invoiceCollectionList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *InvoiceCollectionList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/invoice_mini.go
+++ b/invoice_mini.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -56,25 +57,27 @@ func (resource *invoiceMiniList) setResponse(res *ResponseMetadata) {
 
 // InvoiceMiniList allows you to paginate InvoiceMini objects
 type InvoiceMiniList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []InvoiceMini
 }
 
-func NewInvoiceMiniList(client HttpCaller, nextPagePath string) *InvoiceMiniList {
+func NewInvoiceMiniList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *InvoiceMiniList {
 	return &InvoiceMiniList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *InvoiceMiniList) Fetch() error {
+func (list *InvoiceMiniList) FetchWithContext(ctx context.Context) error {
 	resources := &invoiceMiniList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -85,13 +88,23 @@ func (list *InvoiceMiniList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *InvoiceMiniList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *InvoiceMiniList) Count() (*int64, error) {
+func (list *InvoiceMiniList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &invoiceMiniList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *InvoiceMiniList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/item.go
+++ b/item.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -96,25 +97,27 @@ func (resource *itemList) setResponse(res *ResponseMetadata) {
 
 // ItemList allows you to paginate Item objects
 type ItemList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []Item
 }
 
-func NewItemList(client HttpCaller, nextPagePath string) *ItemList {
+func NewItemList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *ItemList {
 	return &ItemList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *ItemList) Fetch() error {
+func (list *ItemList) FetchWithContext(ctx context.Context) error {
 	resources := &itemList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -125,13 +128,23 @@ func (list *ItemList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *ItemList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *ItemList) Count() (*int64, error) {
+func (list *ItemList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &itemList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *ItemList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/item_mini.go
+++ b/item_mini.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -59,25 +60,27 @@ func (resource *itemMiniList) setResponse(res *ResponseMetadata) {
 
 // ItemMiniList allows you to paginate ItemMini objects
 type ItemMiniList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []ItemMini
 }
 
-func NewItemMiniList(client HttpCaller, nextPagePath string) *ItemMiniList {
+func NewItemMiniList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *ItemMiniList {
 	return &ItemMiniList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *ItemMiniList) Fetch() error {
+func (list *ItemMiniList) FetchWithContext(ctx context.Context) error {
 	resources := &itemMiniList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -88,13 +91,23 @@ func (list *ItemMiniList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *ItemMiniList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *ItemMiniList) Count() (*int64, error) {
+func (list *ItemMiniList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &itemMiniList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *ItemMiniList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/line_item.go
+++ b/line_item.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -186,25 +187,27 @@ func (resource *lineItemList) setResponse(res *ResponseMetadata) {
 
 // LineItemList allows you to paginate LineItem objects
 type LineItemList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []LineItem
 }
 
-func NewLineItemList(client HttpCaller, nextPagePath string) *LineItemList {
+func NewLineItemList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *LineItemList {
 	return &LineItemList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *LineItemList) Fetch() error {
+func (list *LineItemList) FetchWithContext(ctx context.Context) error {
 	resources := &lineItemList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -215,13 +218,23 @@ func (list *LineItemList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *LineItemList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *LineItemList) Count() (*int64, error) {
+func (list *LineItemList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &lineItemList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *LineItemList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/measured_unit.go
+++ b/measured_unit.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -69,25 +70,27 @@ func (resource *measuredUnitList) setResponse(res *ResponseMetadata) {
 
 // MeasuredUnitList allows you to paginate MeasuredUnit objects
 type MeasuredUnitList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []MeasuredUnit
 }
 
-func NewMeasuredUnitList(client HttpCaller, nextPagePath string) *MeasuredUnitList {
+func NewMeasuredUnitList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *MeasuredUnitList {
 	return &MeasuredUnitList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *MeasuredUnitList) Fetch() error {
+func (list *MeasuredUnitList) FetchWithContext(ctx context.Context) error {
 	resources := &measuredUnitList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -98,13 +101,23 @@ func (list *MeasuredUnitList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *MeasuredUnitList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *MeasuredUnitList) Count() (*int64, error) {
+func (list *MeasuredUnitList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &measuredUnitList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *MeasuredUnitList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/payment_method.go
+++ b/payment_method.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -82,25 +83,27 @@ func (resource *paymentMethodList) setResponse(res *ResponseMetadata) {
 
 // PaymentMethodList allows you to paginate PaymentMethod objects
 type PaymentMethodList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []PaymentMethod
 }
 
-func NewPaymentMethodList(client HttpCaller, nextPagePath string) *PaymentMethodList {
+func NewPaymentMethodList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PaymentMethodList {
 	return &PaymentMethodList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *PaymentMethodList) Fetch() error {
+func (list *PaymentMethodList) FetchWithContext(ctx context.Context) error {
 	resources := &paymentMethodList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -111,13 +114,23 @@ func (list *PaymentMethodList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *PaymentMethodList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *PaymentMethodList) Count() (*int64, error) {
+func (list *PaymentMethodList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &paymentMethodList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *PaymentMethodList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/plan.go
+++ b/plan.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -125,25 +126,27 @@ func (resource *planList) setResponse(res *ResponseMetadata) {
 
 // PlanList allows you to paginate Plan objects
 type PlanList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []Plan
 }
 
-func NewPlanList(client HttpCaller, nextPagePath string) *PlanList {
+func NewPlanList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PlanList {
 	return &PlanList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *PlanList) Fetch() error {
+func (list *PlanList) FetchWithContext(ctx context.Context) error {
 	resources := &planList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -154,13 +157,23 @@ func (list *PlanList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *PlanList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *PlanList) Count() (*int64, error) {
+func (list *PlanList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &planList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *PlanList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/plan_hosted_pages.go
+++ b/plan_hosted_pages.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -53,25 +54,27 @@ func (resource *planHostedPagesList) setResponse(res *ResponseMetadata) {
 
 // PlanHostedPagesList allows you to paginate PlanHostedPages objects
 type PlanHostedPagesList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []PlanHostedPages
 }
 
-func NewPlanHostedPagesList(client HttpCaller, nextPagePath string) *PlanHostedPagesList {
+func NewPlanHostedPagesList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PlanHostedPagesList {
 	return &PlanHostedPagesList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *PlanHostedPagesList) Fetch() error {
+func (list *PlanHostedPagesList) FetchWithContext(ctx context.Context) error {
 	resources := &planHostedPagesList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -82,13 +85,23 @@ func (list *PlanHostedPagesList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *PlanHostedPagesList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *PlanHostedPagesList) Count() (*int64, error) {
+func (list *PlanHostedPagesList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &planHostedPagesList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *PlanHostedPagesList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/plan_mini.go
+++ b/plan_mini.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -53,25 +54,27 @@ func (resource *planMiniList) setResponse(res *ResponseMetadata) {
 
 // PlanMiniList allows you to paginate PlanMini objects
 type PlanMiniList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []PlanMini
 }
 
-func NewPlanMiniList(client HttpCaller, nextPagePath string) *PlanMiniList {
+func NewPlanMiniList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PlanMiniList {
 	return &PlanMiniList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *PlanMiniList) Fetch() error {
+func (list *PlanMiniList) FetchWithContext(ctx context.Context) error {
 	resources := &planMiniList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -82,13 +85,23 @@ func (list *PlanMiniList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *PlanMiniList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *PlanMiniList) Count() (*int64, error) {
+func (list *PlanMiniList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &planMiniList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *PlanMiniList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/plan_pricing.go
+++ b/plan_pricing.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -50,25 +51,27 @@ func (resource *planPricingList) setResponse(res *ResponseMetadata) {
 
 // PlanPricingList allows you to paginate PlanPricing objects
 type PlanPricingList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []PlanPricing
 }
 
-func NewPlanPricingList(client HttpCaller, nextPagePath string) *PlanPricingList {
+func NewPlanPricingList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PlanPricingList {
 	return &PlanPricingList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *PlanPricingList) Fetch() error {
+func (list *PlanPricingList) FetchWithContext(ctx context.Context) error {
 	resources := &planPricingList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -79,13 +82,23 @@ func (list *PlanPricingList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *PlanPricingList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *PlanPricingList) Count() (*int64, error) {
+func (list *PlanPricingList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &planPricingList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *PlanPricingList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/pricing.go
+++ b/pricing.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -47,25 +48,27 @@ func (resource *pricingList) setResponse(res *ResponseMetadata) {
 
 // PricingList allows you to paginate Pricing objects
 type PricingList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []Pricing
 }
 
-func NewPricingList(client HttpCaller, nextPagePath string) *PricingList {
+func NewPricingList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PricingList {
 	return &PricingList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *PricingList) Fetch() error {
+func (list *PricingList) FetchWithContext(ctx context.Context) error {
 	resources := &pricingList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -76,13 +79,23 @@ func (list *PricingList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *PricingList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *PricingList) Count() (*int64, error) {
+func (list *PricingList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &pricingList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *PricingList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/recurly_test.go
+++ b/recurly_test.go
@@ -152,30 +152,33 @@ func (attr *ResourceCreate) toParams() *Params {
 
 // We also implement fake CRUD operations for these fake resources
 // We want to use the Client from the consuming code's perspective
-func (c *Client) GetResource(resourceId string) (*RecurlyResource, error) {
+func (c *Client) GetResource(resourceId string, opts ...Option) (*RecurlyResource, error) {
 	path, err := c.InterpolatePath("/resources/{resource_id}", resourceId)
+	requestOptions := NewRequestOptions(opts...)
 	result := &RecurlyResource{}
-	err = c.Call(http.MethodGet, path, nil, result)
+	err = c.Call(http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-func (c *Client) CreateResource(body *ResourceCreate) (*RecurlyResource, error) {
+func (c *Client) CreateResource(body *ResourceCreate, opts ...Option) (*RecurlyResource, error) {
 	path, err := c.InterpolatePath("/resources")
+	requestOptions := NewRequestOptions(opts...)
 	result := &RecurlyResource{}
-	err = c.Call(http.MethodPost, path, body, result)
+	err = c.Call(http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
 	return result, err
 }
 
-func (c *Client) DeleteResource(resourceId string) (*Empty, error) {
+func (c *Client) DeleteResource(resourceId string, opts ...Option) (*Empty, error) {
 	path, err := c.InterpolatePath("/resources")
+	requestOptions := NewRequestOptions(opts...)
 	result := &Empty{}
-	err = c.Call(http.MethodDelete, path, nil, result)
+	err = c.Call(http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -183,10 +186,11 @@ func (c *Client) DeleteResource(resourceId string) (*Empty, error) {
 }
 
 // ResourceMetada calls the HEAD endpoint and returns the response metadata
-func (c *Client) GetResourceMetadata(resourceId string) (*ResponseMetadata, error) {
+func (c *Client) GetResourceMetadata(resourceId string, opts ...Option) (*ResponseMetadata, error) {
 	path, err := c.InterpolatePath("/resources")
+	requestOptions := NewRequestOptions(opts...)
 	result := &Empty{}
-	err = c.Call(http.MethodHead, path, nil, result)
+	err = c.Call(http.MethodHead, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}

--- a/recurly_test.go
+++ b/recurly_test.go
@@ -2,6 +2,7 @@ package recurly
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -156,7 +157,7 @@ func (c *Client) GetResource(resourceId string, opts ...Option) (*RecurlyResourc
 	path, err := c.InterpolatePath("/resources/{resource_id}", resourceId)
 	requestOptions := NewRequestOptions(opts...)
 	result := &RecurlyResource{}
-	err = c.Call(http.MethodGet, path, nil, nil, requestOptions, result)
+	err = c.Call(context.Background(), http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +168,7 @@ func (c *Client) CreateResource(body *ResourceCreate, opts ...Option) (*RecurlyR
 	path, err := c.InterpolatePath("/resources")
 	requestOptions := NewRequestOptions(opts...)
 	result := &RecurlyResource{}
-	err = c.Call(http.MethodPost, path, body, nil, requestOptions, result)
+	err = c.Call(context.Background(), http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +179,7 @@ func (c *Client) DeleteResource(resourceId string, opts ...Option) (*Empty, erro
 	path, err := c.InterpolatePath("/resources")
 	requestOptions := NewRequestOptions(opts...)
 	result := &Empty{}
-	err = c.Call(http.MethodDelete, path, nil, nil, requestOptions, result)
+	err = c.Call(context.Background(), http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +191,7 @@ func (c *Client) GetResourceMetadata(resourceId string, opts ...Option) (*Respon
 	path, err := c.InterpolatePath("/resources")
 	requestOptions := NewRequestOptions(opts...)
 	result := &Empty{}
-	err = c.Call(http.MethodHead, path, nil, nil, requestOptions, result)
+	err = c.Call(context.Background(), http.MethodHead, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}

--- a/request_options.go
+++ b/request_options.go
@@ -1,7 +1,6 @@
 package recurly
 
 import (
-	"context"
 	"net/http"
 )
 
@@ -11,15 +10,12 @@ type RequestOptions struct {
 	IdempotencyKey string `json:"-"`
 	// Header contains additional request headers for unique requests
 	Header http.Header `json:"-"`
-	// Context passed to the HTTP request for cancelling requests
-	Context context.Context `json:"-"`
 }
 
 func (o *RequestOptions) clone() *RequestOptions {
 	clone := &RequestOptions{}
 	clone.Header = o.Header.Clone()
 	clone.IdempotencyKey = o.IdempotencyKey
-	clone.Context = o.Context
 
 	return clone
 }
@@ -38,7 +34,6 @@ func RequestOptionsFromParams(p Params, opts ...Option) *RequestOptions {
 	o := &RequestOptions{}
 	o.Header = p.Header.Clone()
 	o.IdempotencyKey = p.IdempotencyKey
-	o.Context = p.Context
 
 	return o.ApplyOptions(opts...)
 }
@@ -50,13 +45,6 @@ func (o *RequestOptions) ApplyOptions(opts ...Option) *RequestOptions {
 		opt(cOpts)
 	}
 	return cOpts
-}
-
-// WithContext provides the capability to add a Context to an operation.
-func WithContext(ctx context.Context) Option {
-	return func(o *RequestOptions) {
-		o.Context = ctx
-	}
 }
 
 // WithHeader provides the capability to add custom headers to an operation.
@@ -88,8 +76,5 @@ func (o *RequestOptions) applyOptions(req *http.Request) *http.Request {
 		req.Header.Add("Idempotency-Key", o.IdempotencyKey)
 	}
 
-	if o.Context != nil {
-		req = req.WithContext(o.Context)
-	}
 	return req
 }

--- a/request_options.go
+++ b/request_options.go
@@ -1,0 +1,95 @@
+package recurly
+
+import (
+	"context"
+	"net/http"
+)
+
+// RequestOptions contains additional request parameters for the API client
+type RequestOptions struct {
+	// IdempotencyKey used to prevent duplicate requests
+	IdempotencyKey string `json:"-"`
+	// Header contains additional request headers for unique requests
+	Header http.Header `json:"-"`
+	// Context passed to the HTTP request for cancelling requests
+	Context context.Context `json:"-"`
+}
+
+func (o *RequestOptions) clone() *RequestOptions {
+	clone := &RequestOptions{}
+	clone.Header = o.Header.Clone()
+	clone.IdempotencyKey = o.IdempotencyKey
+	clone.Context = o.Context
+
+	return clone
+}
+
+// Option allows for customizations to a request.
+type Option func(o *RequestOptions)
+
+// NewRequestOptions will create a new RequestOptions with the passed Options applied to it.
+func NewRequestOptions(opts ...Option) *RequestOptions {
+	o := &RequestOptions{}
+	return o.ApplyOptions(opts...)
+}
+
+// RequestOptionsFromParams will create a RequestOptions from a Params
+func RequestOptionsFromParams(p Params, opts ...Option) *RequestOptions {
+	o := &RequestOptions{}
+	o.Header = p.Header.Clone()
+	o.IdempotencyKey = p.IdempotencyKey
+	o.Context = p.Context
+
+	return o.ApplyOptions(opts...)
+}
+
+// ApplyOptions will apply the passed Options to the RequestOptions.
+func (o *RequestOptions) ApplyOptions(opts ...Option) *RequestOptions {
+	cOpts := o.clone()
+	for _, opt := range opts {
+		opt(cOpts)
+	}
+	return cOpts
+}
+
+// WithContext provides the capability to add a Context to an operation.
+func WithContext(ctx context.Context) Option {
+	return func(o *RequestOptions) {
+		o.Context = ctx
+	}
+}
+
+// WithHeader provides the capability to add custom headers to an operation.
+func WithHeader(h http.Header) Option {
+	return func(o *RequestOptions) {
+		o.Header = h
+	}
+}
+
+// WithIdempotencyKey provides the capability to add an Idempotency Key to an operation.
+func WithIdempotencyKey(k string) Option {
+	return func(o *RequestOptions) {
+		o.IdempotencyKey = k
+	}
+}
+
+type optionsApplier interface {
+	applyOptions(req *http.Request) *http.Request
+}
+
+func (o *RequestOptions) applyOptions(req *http.Request) *http.Request {
+	for key, v := range o.Header {
+		for _, value := range v {
+			req.Header.Set(key, value)
+		}
+	}
+	// TODO: generate an idempotency key if missing?
+	if o.IdempotencyKey != "" {
+		req.Header.Add("Idempotency-Key", o.IdempotencyKey)
+	}
+
+	if o.Context != nil {
+		req = req.WithContext(o.Context)
+	}
+	return req
+}

--- a/request_options_test.go
+++ b/request_options_test.go
@@ -1,0 +1,133 @@
+package recurly
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestWithOption(test *testing.T) {
+	type testCase struct {
+		name           string
+		idempotencyKey string
+		context        context.Context
+		header         http.Header
+	}
+
+	testCases := [...]testCase{
+		{
+			name:           "WithIdempotencyKey()",
+			idempotencyKey: "special-key",
+		},
+		{
+			name:    "WithContext()",
+			context: context.Background(),
+		},
+		{
+			name:   "WithHeader()",
+			header: http.Header{"Doug": []string{"Miller"}},
+		},
+	}
+
+	for _, tCase := range testCases {
+		test.Run(tCase.name, func(test *testing.T) {
+			t := &T{test}
+			o := NewRequestOptions(
+				WithIdempotencyKey(tCase.idempotencyKey),
+				WithContext(tCase.context),
+				WithHeader(tCase.header))
+			t.Assert(o.IdempotencyKey, tCase.idempotencyKey, tCase.name)
+			t.Assert(o.Context, tCase.context, tCase.name)
+			for key, v := range tCase.header {
+				for _, value := range v {
+					t.Assert(o.Header.Get(key), value, tCase.name)
+				}
+			}
+		})
+	}
+}
+
+func TestRequestOptionsClone(test *testing.T) {
+	t := &T{test}
+
+	ctx := context.Background()
+	iKey := "special-key"
+	header := http.Header{"Doug": []string{"Miller"}}
+
+	o := &RequestOptions{
+		IdempotencyKey: iKey,
+		Context:        ctx,
+		Header:         header,
+	}
+	oClone := o.clone()
+
+	// Changing original RequestOptions shouldn't impact the clone
+	o.IdempotencyKey = "different-key"
+	o.Header = http.Header{}
+	o.Context = context.TODO()
+
+	t.Assert(oClone.IdempotencyKey, iKey, "RequestOptions.clone()")
+	t.Assert(oClone.Context, ctx, "RequestOptions.clone()")
+	for key, v := range header {
+		for _, value := range v {
+			t.Assert(oClone.Header.Get(key), value, "RequestOptions.clone()")
+		}
+	}
+}
+
+func TestRequestOptionsFromParams(test *testing.T) {
+	t := &T{test}
+
+	ctx := context.Background()
+	iKey := "special-key"
+	header := http.Header{"Doug": []string{"Miller"}}
+
+	p := Params{
+		IdempotencyKey: iKey,
+		Context:        ctx,
+		Header:         header,
+	}
+	o := RequestOptionsFromParams(p)
+
+	// Changing original RequestOptions shouldn't impact the clone
+	p.IdempotencyKey = "different-key"
+	p.Header = http.Header{}
+	p.Context = context.TODO()
+
+	t.Assert(o.IdempotencyKey, iKey, "RequestOptionsFromParams()")
+	t.Assert(o.Context, ctx, "RequestOptionsFromParams()")
+	for key, v := range header {
+		for _, value := range v {
+			t.Assert(o.Header.Get(key), value, "RequestOptionsFromParams()")
+		}
+	}
+}
+
+func TestApplyOptions(test *testing.T) {
+	t := &T{test}
+
+	ctx := context.TODO()
+	iKey := "special-key"
+	header := http.Header{"Doug": []string{"Miller"}}
+
+	o := &RequestOptions{
+		IdempotencyKey: iKey,
+		Context:        ctx,
+		Header:         header,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "/resources", nil)
+	if err != nil {
+		t.Fail()
+	}
+
+	req = o.applyOptions(req)
+
+	t.Assert(req.Context(), ctx, "RequestOptions.applyOptions()")
+	for key, v := range header {
+		for _, value := range v {
+			t.Assert(req.Header.Get(key), value, "RequestOptions.applyOptions()")
+		}
+	}
+	t.Assert(req.Header.Get("Idempotency-Key"), iKey, "RequestOptions.applyOptions()")
+}

--- a/request_options_test.go
+++ b/request_options_test.go
@@ -1,7 +1,6 @@
 package recurly
 
 import (
-	"context"
 	"net/http"
 	"testing"
 )
@@ -10,7 +9,6 @@ func TestWithOption(test *testing.T) {
 	type testCase struct {
 		name           string
 		idempotencyKey string
-		context        context.Context
 		header         http.Header
 	}
 
@@ -18,10 +16,6 @@ func TestWithOption(test *testing.T) {
 		{
 			name:           "WithIdempotencyKey()",
 			idempotencyKey: "special-key",
-		},
-		{
-			name:    "WithContext()",
-			context: context.Background(),
 		},
 		{
 			name:   "WithHeader()",
@@ -34,10 +28,8 @@ func TestWithOption(test *testing.T) {
 			t := &T{test}
 			o := NewRequestOptions(
 				WithIdempotencyKey(tCase.idempotencyKey),
-				WithContext(tCase.context),
 				WithHeader(tCase.header))
 			t.Assert(o.IdempotencyKey, tCase.idempotencyKey, tCase.name)
-			t.Assert(o.Context, tCase.context, tCase.name)
 			for key, v := range tCase.header {
 				for _, value := range v {
 					t.Assert(o.Header.Get(key), value, tCase.name)
@@ -50,13 +42,11 @@ func TestWithOption(test *testing.T) {
 func TestRequestOptionsClone(test *testing.T) {
 	t := &T{test}
 
-	ctx := context.Background()
 	iKey := "special-key"
 	header := http.Header{"Doug": []string{"Miller"}}
 
 	o := &RequestOptions{
 		IdempotencyKey: iKey,
-		Context:        ctx,
 		Header:         header,
 	}
 	oClone := o.clone()
@@ -64,10 +54,8 @@ func TestRequestOptionsClone(test *testing.T) {
 	// Changing original RequestOptions shouldn't impact the clone
 	o.IdempotencyKey = "different-key"
 	o.Header = http.Header{}
-	o.Context = context.TODO()
 
 	t.Assert(oClone.IdempotencyKey, iKey, "RequestOptions.clone()")
-	t.Assert(oClone.Context, ctx, "RequestOptions.clone()")
 	for key, v := range header {
 		for _, value := range v {
 			t.Assert(oClone.Header.Get(key), value, "RequestOptions.clone()")
@@ -78,13 +66,11 @@ func TestRequestOptionsClone(test *testing.T) {
 func TestRequestOptionsFromParams(test *testing.T) {
 	t := &T{test}
 
-	ctx := context.Background()
 	iKey := "special-key"
 	header := http.Header{"Doug": []string{"Miller"}}
 
 	p := Params{
 		IdempotencyKey: iKey,
-		Context:        ctx,
 		Header:         header,
 	}
 	o := RequestOptionsFromParams(p)
@@ -92,10 +78,8 @@ func TestRequestOptionsFromParams(test *testing.T) {
 	// Changing original RequestOptions shouldn't impact the clone
 	p.IdempotencyKey = "different-key"
 	p.Header = http.Header{}
-	p.Context = context.TODO()
 
 	t.Assert(o.IdempotencyKey, iKey, "RequestOptionsFromParams()")
-	t.Assert(o.Context, ctx, "RequestOptionsFromParams()")
 	for key, v := range header {
 		for _, value := range v {
 			t.Assert(o.Header.Get(key), value, "RequestOptionsFromParams()")
@@ -106,13 +90,11 @@ func TestRequestOptionsFromParams(test *testing.T) {
 func TestApplyOptions(test *testing.T) {
 	t := &T{test}
 
-	ctx := context.TODO()
 	iKey := "special-key"
 	header := http.Header{"Doug": []string{"Miller"}}
 
 	o := &RequestOptions{
 		IdempotencyKey: iKey,
-		Context:        ctx,
 		Header:         header,
 	}
 
@@ -123,7 +105,6 @@ func TestApplyOptions(test *testing.T) {
 
 	req = o.applyOptions(req)
 
-	t.Assert(req.Context(), ctx, "RequestOptions.applyOptions()")
 	for key, v := range header {
 		for _, value := range v {
 			t.Assert(req.Header.Get(key), value, "RequestOptions.applyOptions()")

--- a/shipping_address.go
+++ b/shipping_address.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -86,25 +87,27 @@ func (resource *shippingAddressList) setResponse(res *ResponseMetadata) {
 
 // ShippingAddressList allows you to paginate ShippingAddress objects
 type ShippingAddressList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []ShippingAddress
 }
 
-func NewShippingAddressList(client HttpCaller, nextPagePath string) *ShippingAddressList {
+func NewShippingAddressList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *ShippingAddressList {
 	return &ShippingAddressList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *ShippingAddressList) Fetch() error {
+func (list *ShippingAddressList) FetchWithContext(ctx context.Context) error {
 	resources := &shippingAddressList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -115,13 +118,23 @@ func (list *ShippingAddressList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *ShippingAddressList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *ShippingAddressList) Count() (*int64, error) {
+func (list *ShippingAddressList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &shippingAddressList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *ShippingAddressList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/shipping_method_mini.go
+++ b/shipping_method_mini.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -53,25 +54,27 @@ func (resource *shippingMethodMiniList) setResponse(res *ResponseMetadata) {
 
 // ShippingMethodMiniList allows you to paginate ShippingMethodMini objects
 type ShippingMethodMiniList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []ShippingMethodMini
 }
 
-func NewShippingMethodMiniList(client HttpCaller, nextPagePath string) *ShippingMethodMiniList {
+func NewShippingMethodMiniList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *ShippingMethodMiniList {
 	return &ShippingMethodMiniList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *ShippingMethodMiniList) Fetch() error {
+func (list *ShippingMethodMiniList) FetchWithContext(ctx context.Context) error {
 	resources := &shippingMethodMiniList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -82,13 +85,23 @@ func (list *ShippingMethodMiniList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *ShippingMethodMiniList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *ShippingMethodMiniList) Count() (*int64, error) {
+func (list *ShippingMethodMiniList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &shippingMethodMiniList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *ShippingMethodMiniList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/site.go
+++ b/site.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -72,25 +73,27 @@ func (resource *siteList) setResponse(res *ResponseMetadata) {
 
 // SiteList allows you to paginate Site objects
 type SiteList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []Site
 }
 
-func NewSiteList(client HttpCaller, nextPagePath string) *SiteList {
+func NewSiteList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *SiteList {
 	return &SiteList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *SiteList) Fetch() error {
+func (list *SiteList) FetchWithContext(ctx context.Context) error {
 	resources := &siteList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -101,13 +104,23 @@ func (list *SiteList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *SiteList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *SiteList) Count() (*int64, error) {
+func (list *SiteList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &siteList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *SiteList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/subscription.go
+++ b/subscription.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -168,25 +169,27 @@ func (resource *subscriptionList) setResponse(res *ResponseMetadata) {
 
 // SubscriptionList allows you to paginate Subscription objects
 type SubscriptionList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []Subscription
 }
 
-func NewSubscriptionList(client HttpCaller, nextPagePath string) *SubscriptionList {
+func NewSubscriptionList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *SubscriptionList {
 	return &SubscriptionList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *SubscriptionList) Fetch() error {
+func (list *SubscriptionList) FetchWithContext(ctx context.Context) error {
 	resources := &subscriptionList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -197,13 +200,23 @@ func (list *SubscriptionList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *SubscriptionList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *SubscriptionList) Count() (*int64, error) {
+func (list *SubscriptionList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &subscriptionList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *SubscriptionList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/subscription_add_on.go
+++ b/subscription_add_on.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -88,25 +89,27 @@ func (resource *subscriptionAddOnList) setResponse(res *ResponseMetadata) {
 
 // SubscriptionAddOnList allows you to paginate SubscriptionAddOn objects
 type SubscriptionAddOnList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []SubscriptionAddOn
 }
 
-func NewSubscriptionAddOnList(client HttpCaller, nextPagePath string) *SubscriptionAddOnList {
+func NewSubscriptionAddOnList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *SubscriptionAddOnList {
 	return &SubscriptionAddOnList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *SubscriptionAddOnList) Fetch() error {
+func (list *SubscriptionAddOnList) FetchWithContext(ctx context.Context) error {
 	resources := &subscriptionAddOnList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -117,13 +120,23 @@ func (list *SubscriptionAddOnList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *SubscriptionAddOnList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *SubscriptionAddOnList) Count() (*int64, error) {
+func (list *SubscriptionAddOnList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &subscriptionAddOnList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *SubscriptionAddOnList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/subscription_add_on_tier.go
+++ b/subscription_add_on_tier.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -47,25 +48,27 @@ func (resource *subscriptionAddOnTierList) setResponse(res *ResponseMetadata) {
 
 // SubscriptionAddOnTierList allows you to paginate SubscriptionAddOnTier objects
 type SubscriptionAddOnTierList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []SubscriptionAddOnTier
 }
 
-func NewSubscriptionAddOnTierList(client HttpCaller, nextPagePath string) *SubscriptionAddOnTierList {
+func NewSubscriptionAddOnTierList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *SubscriptionAddOnTierList {
 	return &SubscriptionAddOnTierList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *SubscriptionAddOnTierList) Fetch() error {
+func (list *SubscriptionAddOnTierList) FetchWithContext(ctx context.Context) error {
 	resources := &subscriptionAddOnTierList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -76,13 +79,23 @@ func (list *SubscriptionAddOnTierList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *SubscriptionAddOnTierList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *SubscriptionAddOnTierList) Count() (*int64, error) {
+func (list *SubscriptionAddOnTierList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &subscriptionAddOnTierList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *SubscriptionAddOnTierList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/subscription_change.go
+++ b/subscription_change.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -93,25 +94,27 @@ func (resource *subscriptionChangeList) setResponse(res *ResponseMetadata) {
 
 // SubscriptionChangeList allows you to paginate SubscriptionChange objects
 type SubscriptionChangeList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []SubscriptionChange
 }
 
-func NewSubscriptionChangeList(client HttpCaller, nextPagePath string) *SubscriptionChangeList {
+func NewSubscriptionChangeList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *SubscriptionChangeList {
 	return &SubscriptionChangeList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *SubscriptionChangeList) Fetch() error {
+func (list *SubscriptionChangeList) FetchWithContext(ctx context.Context) error {
 	resources := &subscriptionChangeList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -122,13 +125,23 @@ func (list *SubscriptionChangeList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *SubscriptionChangeList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *SubscriptionChangeList) Count() (*int64, error) {
+func (list *SubscriptionChangeList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &subscriptionChangeList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *SubscriptionChangeList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/subscription_change_preview.go
+++ b/subscription_change_preview.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -93,25 +94,27 @@ func (resource *subscriptionChangePreviewList) setResponse(res *ResponseMetadata
 
 // SubscriptionChangePreviewList allows you to paginate SubscriptionChangePreview objects
 type SubscriptionChangePreviewList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []SubscriptionChangePreview
 }
 
-func NewSubscriptionChangePreviewList(client HttpCaller, nextPagePath string) *SubscriptionChangePreviewList {
+func NewSubscriptionChangePreviewList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *SubscriptionChangePreviewList {
 	return &SubscriptionChangePreviewList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *SubscriptionChangePreviewList) Fetch() error {
+func (list *SubscriptionChangePreviewList) FetchWithContext(ctx context.Context) error {
 	resources := &subscriptionChangePreviewList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -122,13 +125,23 @@ func (list *SubscriptionChangePreviewList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *SubscriptionChangePreviewList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *SubscriptionChangePreviewList) Count() (*int64, error) {
+func (list *SubscriptionChangePreviewList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &subscriptionChangePreviewList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *SubscriptionChangePreviewList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/subscription_shipping.go
+++ b/subscription_shipping.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -51,25 +52,27 @@ func (resource *subscriptionShippingList) setResponse(res *ResponseMetadata) {
 
 // SubscriptionShippingList allows you to paginate SubscriptionShipping objects
 type SubscriptionShippingList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []SubscriptionShipping
 }
 
-func NewSubscriptionShippingList(client HttpCaller, nextPagePath string) *SubscriptionShippingList {
+func NewSubscriptionShippingList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *SubscriptionShippingList {
 	return &SubscriptionShippingList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *SubscriptionShippingList) Fetch() error {
+func (list *SubscriptionShippingList) FetchWithContext(ctx context.Context) error {
 	resources := &subscriptionShippingList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -80,13 +83,23 @@ func (list *SubscriptionShippingList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *SubscriptionShippingList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *SubscriptionShippingList) Count() (*int64, error) {
+func (list *SubscriptionShippingList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &subscriptionShippingList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *SubscriptionShippingList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/tax_info.go
+++ b/tax_info.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -50,25 +51,27 @@ func (resource *taxInfoList) setResponse(res *ResponseMetadata) {
 
 // TaxInfoList allows you to paginate TaxInfo objects
 type TaxInfoList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []TaxInfo
 }
 
-func NewTaxInfoList(client HttpCaller, nextPagePath string) *TaxInfoList {
+func NewTaxInfoList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *TaxInfoList {
 	return &TaxInfoList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *TaxInfoList) Fetch() error {
+func (list *TaxInfoList) FetchWithContext(ctx context.Context) error {
 	resources := &taxInfoList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -79,13 +82,23 @@ func (list *TaxInfoList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *TaxInfoList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *TaxInfoList) Count() (*int64, error) {
+func (list *TaxInfoList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &taxInfoList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *TaxInfoList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/tier.go
+++ b/tier.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -47,25 +48,27 @@ func (resource *tierList) setResponse(res *ResponseMetadata) {
 
 // TierList allows you to paginate Tier objects
 type TierList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []Tier
 }
 
-func NewTierList(client HttpCaller, nextPagePath string) *TierList {
+func NewTierList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *TierList {
 	return &TierList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *TierList) Fetch() error {
+func (list *TierList) FetchWithContext(ctx context.Context) error {
 	resources := &tierList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -76,13 +79,23 @@ func (list *TierList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *TierList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *TierList) Count() (*int64, error) {
+func (list *TierList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &tierList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *TierList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/transaction_payment_gateway.go
+++ b/transaction_payment_gateway.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -50,25 +51,27 @@ func (resource *transactionPaymentGatewayList) setResponse(res *ResponseMetadata
 
 // TransactionPaymentGatewayList allows you to paginate TransactionPaymentGateway objects
 type TransactionPaymentGatewayList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []TransactionPaymentGateway
 }
 
-func NewTransactionPaymentGatewayList(client HttpCaller, nextPagePath string) *TransactionPaymentGatewayList {
+func NewTransactionPaymentGatewayList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *TransactionPaymentGatewayList {
 	return &TransactionPaymentGatewayList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *TransactionPaymentGatewayList) Fetch() error {
+func (list *TransactionPaymentGatewayList) FetchWithContext(ctx context.Context) error {
 	resources := &transactionPaymentGatewayList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -79,13 +82,23 @@ func (list *TransactionPaymentGatewayList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *TransactionPaymentGatewayList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *TransactionPaymentGatewayList) Count() (*int64, error) {
+func (list *TransactionPaymentGatewayList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &transactionPaymentGatewayList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *TransactionPaymentGatewayList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/unique_coupon_code.go
+++ b/unique_coupon_code.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -72,25 +73,27 @@ func (resource *uniqueCouponCodeList) setResponse(res *ResponseMetadata) {
 
 // UniqueCouponCodeList allows you to paginate UniqueCouponCode objects
 type UniqueCouponCodeList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []UniqueCouponCode
 }
 
-func NewUniqueCouponCodeList(client HttpCaller, nextPagePath string) *UniqueCouponCodeList {
+func NewUniqueCouponCodeList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *UniqueCouponCodeList {
 	return &UniqueCouponCodeList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *UniqueCouponCodeList) Fetch() error {
+func (list *UniqueCouponCodeList) FetchWithContext(ctx context.Context) error {
 	resources := &uniqueCouponCodeList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -101,13 +104,23 @@ func (list *UniqueCouponCodeList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *UniqueCouponCodeList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *UniqueCouponCodeList) Count() (*int64, error) {
+func (list *UniqueCouponCodeList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &uniqueCouponCodeList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *UniqueCouponCodeList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }

--- a/usage.go
+++ b/usage.go
@@ -5,6 +5,7 @@
 package recurly
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -87,25 +88,27 @@ func (resource *usageList) setResponse(res *ResponseMetadata) {
 
 // UsageList allows you to paginate Usage objects
 type UsageList struct {
-	client       HttpCaller
-	nextPagePath string
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
 
 	HasMore bool
 	Data    []Usage
 }
 
-func NewUsageList(client HttpCaller, nextPagePath string) *UsageList {
+func NewUsageList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *UsageList {
 	return &UsageList{
-		client:       client,
-		nextPagePath: nextPagePath,
-		HasMore:      true,
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
 	}
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *UsageList) Fetch() error {
+func (list *UsageList) FetchWithContext(ctx context.Context) error {
 	resources := &usageList{}
-	err := list.client.Call(http.MethodGet, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
 	}
@@ -116,13 +119,23 @@ func (list *UsageList) Fetch() error {
 	return nil
 }
 
+// Fetch fetches the next page of data into the `Data` property
+func (list *UsageList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
 // Count returns the count of items on the server that match this pager
-func (list *UsageList) Count() (*int64, error) {
+func (list *UsageList) CountWithContext(ctx context.Context) (*int64, error) {
 	resources := &usageList{}
-	err := list.client.Call(http.MethodHead, list.nextPagePath, nil, resources)
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
 	}
 	resp := resources.GetResponse()
 	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *UsageList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
 }


### PR DESCRIPTION
# Using a context with operations

Each non-list operation has had a *WithContext version of the same operation added to the client.

**Note**: Some operations allow the `Context` to be passed in the `Params` of the request. This method is still supported, and the context passed in via `Params` will continue to be used for operations that do not accept the context as the first parameter (operations that end in `WithContext`)

```go
ctx, _ := context.WithTimeout(context.Background(), 20*time.Second)

accountReq := &recurly.AccountCreate{
	...
}

account, err := client.CreateAccountWithContext(ctx, accountReq)
```

Each list operation has had a `FetchWithContext()` and `CountWithContext()` function added in addition to their original non-context based versions.

```go
listParams := &recurly.ListAccountsParams{
	...
}
accounts, err := client.ListAccounts(listParams)

// A single context that applies to all Fetch() calls
ctx, _ := context.WithTimeout(context.Background(), 20*time.Second)
for accounts.HasMore {
	err := accounts.FetchWithContext(ctx)
	if e, ok := err.(*recurly.Error); ok {
		fmt.Printf("Failed to retrieve next page: %v", e)
		break
	}
	for i, account := range accounts.Data {
		fmt.Printf("Account %s fetched\n", account.Code)
	}
}
```

# RequestOptions

Updates client operations to be variadic functions that accept additional request configurations.

Currently there are 2 request options that are supported:
- `WithIdempotencyKey(string)`: Sets the `Idempotency-Key` header to the http request's headers.
- `WithHeader(http.Header)`: Sets additional custom headers to the http request's headers.

**Note**: Some operations allow the `IdempotencyKey` and `Header` values to be passed in the `Params` of the request. This method is still supported, and any values passed in via `Params` will continue to be used. The `With*` values will overwrite existing values provided in `Params`.

**Using `Params`:**
```go
headers := http.Header{"Accept-Language": []string{"fr"}}

accountReq := &recurly.AccountCreate{
	...
	Params: recurly.Params{
		Header: headers,
	},
}

account, err := client.CreateAccount(accountReq)
```

**Using `WithHeader` request option:**
```go
headers := http.Header{"Accept-Language": []string{"fr"}}

accountReq := &recurly.AccountCreate{
	...
}

account, err := client.CreateAccount(accountReq, recurly.WithHeader(headers))
```
