### PR TITLE
Latest Changes for 2019-10-10

### DIFF
--- a/client_operations.go
+++ b/client_operations.go
@@ -864,6 +864,9 @@ type ListAccountCouponRedemptionsParams struct {
 	// EndTime - Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
 	// **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 	EndTime *time.Time
+
+	// State - Filter by state.
+	State *string
 }
 
 func (list *ListAccountCouponRedemptionsParams) toParams() *Params {
@@ -892,6 +895,10 @@ func (list *ListAccountCouponRedemptionsParams) URLParams() []KeyValue {
 
 	if list.EndTime != nil {
 		options = append(options, KeyValue{Key: "end_time", Value: formatTime(*list.EndTime)})
+	}
+
+	if list.State != nil {
+		options = append(options, KeyValue{Key: "state", Value: *list.State})
 	}
 
 	return options
@@ -4110,6 +4117,9 @@ type TerminateSubscriptionParams struct {
 	// In the event that the most recent invoice is a $0 invoice paid entirely by credit, Recurly will apply the credit back to the customer’s account.
 	// You may also terminate a subscription with no refund and then manually refund specific invoices.
 	Refund *string
+
+	// Charge - Applicable only if the subscription has usage based add-ons and unbilled usage logged for the current billing cycle. If true, current billing cycle unbilled usage is billed on the final invoice. If false, Recurly will create a negative usage record for current billing cycle usage that will zero out the final invoice line items.
+	Charge *bool
 }
 
 func (list *TerminateSubscriptionParams) toParams() *Params {
@@ -4126,6 +4136,10 @@ func (list *TerminateSubscriptionParams) URLParams() []KeyValue {
 
 	if list.Refund != nil {
 		options = append(options, KeyValue{Key: "refund", Value: *list.Refund})
+	}
+
+	if list.Charge != nil {
+		options = append(options, KeyValue{Key: "charge", Value: strconv.FormatBool(*list.Charge)})
 	}
 
 	return options

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -10043,7 +10043,7 @@ paths:
           }
       - lang: Go
         source: "addOnReq := &recurly.AddOnCreate{\n\tCode: &addOnCode,\n\tName: recurly.String(\"Fresh
-          beans shipped monthly\"),\n\tCurrencies: []recurly.PricingCreate{\n\t\t{\n\t\t\tCurrency:
+          beans shipped monthly\"),\n\tCurrencies: []recurly.AddOnPricingCreate{\n\t\t{\n\t\t\tCurrency:
           \  recurly.String(\"USD\"),\n\t\t\tUnitAmount: recurly.Float(10),\n\t\t},\n\t},\n}\n\nplanAddOn,
           err := client.CreatePlanAddOn(planID, addOnReq)\nif e, ok := err.(*recurly.Error);
           ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -2481,6 +2481,7 @@ paths:
       - "$ref": "#/components/parameters/sort_dates"
       - "$ref": "#/components/parameters/filter_begin_time"
       - "$ref": "#/components/parameters/filter_end_time"
+      - "$ref": "#/components/parameters/filter_state"
       responses:
         '200':
           description: A list of the the coupon redemptions on an account.
@@ -10042,7 +10043,7 @@ paths:
           }
       - lang: Go
         source: "addOnReq := &recurly.AddOnCreate{\n\tCode: &addOnCode,\n\tName: recurly.String(\"Fresh
-          beans shipped monthly\"),\n\tCurrencies: []recurly.AddOnPricingCreate{\n\t\t{\n\t\t\tCurrency:
+          beans shipped monthly\"),\n\tCurrencies: []recurly.PricingCreate{\n\t\t{\n\t\t\tCurrency:
           \  recurly.String(\"USD\"),\n\t\t\tUnitAmount: recurly.Float(10),\n\t\t},\n\t},\n}\n\nplanAddOn,
           err := client.CreatePlanAddOn(planID, addOnReq)\nif e, ok := err.(*recurly.Error);
           ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
@@ -11451,6 +11452,16 @@ paths:
           - partial
           - none
           default: none
+      - name: charge
+        in: query
+        description: Applicable only if the subscription has usage based add-ons and
+          unbilled usage logged for the current billing cycle. If true, current billing
+          cycle unbilled usage is billed on the final invoice. If false, Recurly will
+          create a negative usage record for current billing cycle usage that will
+          zero out the final invoice line items.
+        schema:
+          default: true
+          type: boolean
       responses:
         '200':
           description: An expired subscription.
@@ -19310,6 +19321,8 @@ components:
         coupon_redemptions:
           type: array
           title: Coupon redemptions
+          description: Returns subscription level coupon redemptions that are tied
+            to this subscription.
           items:
             "$ref": "#/components/schemas/CouponRedemptionMini"
         pending_change:

--- a/subscription.go
+++ b/subscription.go
@@ -33,7 +33,7 @@ type Subscription struct {
 	// Subscription shipping details
 	Shipping SubscriptionShipping `json:"shipping,omitempty"`
 
-	// Coupon redemptions
+	// Returns subscription level coupon redemptions that are tied to this subscription.
 	CouponRedemptions []CouponRedemptionMini `json:"coupon_redemptions,omitempty"`
 
 	// Subscription Change


### PR DESCRIPTION
- Adds the `state` parameter to the `ListAccountCouponRedemptions` operation.
- Adds the `charge` parameter to the `TerminateSubscription` operation so that a merchant can choose to not bill a customer for un-billed usage when terminating a subscription 