### PR TITLE
Latest Changes for 2019-10-10

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -15154,7 +15154,7 @@ components:
           maxLength: 255
         company:
           type: string
-          maxLength: 50
+          maxLength: 100
         vat_number:
           type: string
           description: The VAT number of the account (to avoid having the VAT applied).
@@ -20079,6 +20079,13 @@ components:
             are provided the `plan_id` will be used.
         account:
           "$ref": "#/components/schemas/AccountCreate"
+        billing_info_id:
+          type: string
+          title: Billing Info ID
+          description: The `billing_info_id` is the value that represents a specific
+            billing info for an end customer. When `billing_info_id` is used to assign
+            billing info to the subscription, all future billing events for the subscription
+            will bill to the specified billing info.
         shipping:
           title: Shipping address
           description: Create a shipping address on the account and assign it to the
@@ -21012,6 +21019,13 @@ components:
           maxLength: 3
         account:
           "$ref": "#/components/schemas/AccountPurchase"
+        billing_info_id:
+          type: string
+          title: Billing info ID
+          description: The `billing_info_id` is the value that represents a specific
+            billing info for an end customer. When `billing_info_id` is used to assign
+            billing info to the subscription, all future billing events for the subscription
+            will bill to the specified billing info.
         collection_method:
           type: string
           title: Collection method

--- a/purchase_create.go
+++ b/purchase_create.go
@@ -14,6 +14,9 @@ type PurchaseCreate struct {
 
 	Account *AccountPurchase `json:"account,omitempty"`
 
+	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+	BillingInfoId *string `json:"billing_info_id,omitempty"`
+
 	// Must be set to manual in order to preview a purchase for an Account that does not have payment information associated with the Billing Info.
 	CollectionMethod *string `json:"collection_method,omitempty"`
 

--- a/subscription_create.go
+++ b/subscription_create.go
@@ -19,6 +19,9 @@ type SubscriptionCreate struct {
 
 	Account *AccountCreate `json:"account,omitempty"`
 
+	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+	BillingInfoId *string `json:"billing_info_id,omitempty"`
+
 	// Create a shipping address on the account and assign it to the subscription.
 	Shipping *SubscriptionShippingCreate `json:"shipping,omitempty"`
 


### PR DESCRIPTION
- Adds `BillingInfoId` to `PurchaseCreate` and `SubscriptionCreate` request structs.