### PR TITLE
Add pager interface

### DIFF
--- a/account.go
+++ b/account.go
@@ -130,9 +130,18 @@ type AccountList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []Account
+}
 
-	HasMore bool
-	Data    []Account
+type AccountLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []Account
+	HasMore() bool
+	Next() string
 }
 
 func NewAccountList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *AccountList {
@@ -140,8 +149,20 @@ func NewAccountList(client HTTPCaller, nextPagePath string, requestOptions *Requ
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *AccountList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *AccountList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *AccountList) Data() []Account {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -153,8 +174,8 @@ func (list *AccountList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/account_acquisition.go
+++ b/account_acquisition.go
@@ -72,9 +72,18 @@ type AccountAcquisitionList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []AccountAcquisition
+}
 
-	HasMore bool
-	Data    []AccountAcquisition
+type AccountAcquisitionLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []AccountAcquisition
+	HasMore() bool
+	Next() string
 }
 
 func NewAccountAcquisitionList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *AccountAcquisitionList {
@@ -82,8 +91,20 @@ func NewAccountAcquisitionList(client HTTPCaller, nextPagePath string, requestOp
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *AccountAcquisitionList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *AccountAcquisitionList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *AccountAcquisitionList) Data() []AccountAcquisition {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -95,8 +116,8 @@ func (list *AccountAcquisitionList) FetchWithContext(ctx context.Context) error 
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/account_acquisition_cost.go
+++ b/account_acquisition_cost.go
@@ -51,9 +51,18 @@ type AccountAcquisitionCostList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []AccountAcquisitionCost
+}
 
-	HasMore bool
-	Data    []AccountAcquisitionCost
+type AccountAcquisitionCostLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []AccountAcquisitionCost
+	HasMore() bool
+	Next() string
 }
 
 func NewAccountAcquisitionCostList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *AccountAcquisitionCostList {
@@ -61,8 +70,20 @@ func NewAccountAcquisitionCostList(client HTTPCaller, nextPagePath string, reque
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *AccountAcquisitionCostList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *AccountAcquisitionCostList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *AccountAcquisitionCostList) Data() []AccountAcquisitionCost {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -74,8 +95,8 @@ func (list *AccountAcquisitionCostList) FetchWithContext(ctx context.Context) er
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/account_balance.go
+++ b/account_balance.go
@@ -55,9 +55,18 @@ type AccountBalanceList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []AccountBalance
+}
 
-	HasMore bool
-	Data    []AccountBalance
+type AccountBalanceLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []AccountBalance
+	HasMore() bool
+	Next() string
 }
 
 func NewAccountBalanceList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *AccountBalanceList {
@@ -65,8 +74,20 @@ func NewAccountBalanceList(client HTTPCaller, nextPagePath string, requestOption
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *AccountBalanceList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *AccountBalanceList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *AccountBalanceList) Data() []AccountBalance {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -78,8 +99,8 @@ func (list *AccountBalanceList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/account_balance_amount.go
+++ b/account_balance_amount.go
@@ -51,9 +51,18 @@ type AccountBalanceAmountList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []AccountBalanceAmount
+}
 
-	HasMore bool
-	Data    []AccountBalanceAmount
+type AccountBalanceAmountLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []AccountBalanceAmount
+	HasMore() bool
+	Next() string
 }
 
 func NewAccountBalanceAmountList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *AccountBalanceAmountList {
@@ -61,8 +70,20 @@ func NewAccountBalanceAmountList(client HTTPCaller, nextPagePath string, request
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *AccountBalanceAmountList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *AccountBalanceAmountList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *AccountBalanceAmountList) Data() []AccountBalanceAmount {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -74,8 +95,8 @@ func (list *AccountBalanceAmountList) FetchWithContext(ctx context.Context) erro
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/account_mini.go
+++ b/account_mini.go
@@ -66,9 +66,18 @@ type AccountMiniList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []AccountMini
+}
 
-	HasMore bool
-	Data    []AccountMini
+type AccountMiniLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []AccountMini
+	HasMore() bool
+	Next() string
 }
 
 func NewAccountMiniList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *AccountMiniList {
@@ -76,8 +85,20 @@ func NewAccountMiniList(client HTTPCaller, nextPagePath string, requestOptions *
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *AccountMiniList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *AccountMiniList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *AccountMiniList) Data() []AccountMini {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -89,8 +110,8 @@ func (list *AccountMiniList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/account_note.go
+++ b/account_note.go
@@ -59,9 +59,18 @@ type AccountNoteList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []AccountNote
+}
 
-	HasMore bool
-	Data    []AccountNote
+type AccountNoteLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []AccountNote
+	HasMore() bool
+	Next() string
 }
 
 func NewAccountNoteList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *AccountNoteList {
@@ -69,8 +78,20 @@ func NewAccountNoteList(client HTTPCaller, nextPagePath string, requestOptions *
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *AccountNoteList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *AccountNoteList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *AccountNoteList) Data() []AccountNote {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -82,8 +103,8 @@ func (list *AccountNoteList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/add_on.go
+++ b/add_on.go
@@ -127,9 +127,18 @@ type AddOnList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []AddOn
+}
 
-	HasMore bool
-	Data    []AddOn
+type AddOnLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []AddOn
+	HasMore() bool
+	Next() string
 }
 
 func NewAddOnList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *AddOnList {
@@ -137,8 +146,20 @@ func NewAddOnList(client HTTPCaller, nextPagePath string, requestOptions *Reques
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *AddOnList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *AddOnList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *AddOnList) Data() []AddOn {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -150,8 +171,8 @@ func (list *AddOnList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/add_on_mini.go
+++ b/add_on_mini.go
@@ -78,9 +78,18 @@ type AddOnMiniList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []AddOnMini
+}
 
-	HasMore bool
-	Data    []AddOnMini
+type AddOnMiniLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []AddOnMini
+	HasMore() bool
+	Next() string
 }
 
 func NewAddOnMiniList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *AddOnMiniList {
@@ -88,8 +97,20 @@ func NewAddOnMiniList(client HTTPCaller, nextPagePath string, requestOptions *Re
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *AddOnMiniList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *AddOnMiniList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *AddOnMiniList) Data() []AddOnMini {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -101,8 +122,8 @@ func (list *AddOnMiniList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/address.go
+++ b/address.go
@@ -72,9 +72,18 @@ type AddressList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []Address
+}
 
-	HasMore bool
-	Data    []Address
+type AddressLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []Address
+	HasMore() bool
+	Next() string
 }
 
 func NewAddressList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *AddressList {
@@ -82,8 +91,20 @@ func NewAddressList(client HTTPCaller, nextPagePath string, requestOptions *Requ
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *AddressList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *AddressList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *AddressList) Data() []Address {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -95,8 +116,8 @@ func (list *AddressList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/billing_info.go
+++ b/billing_info.go
@@ -82,9 +82,18 @@ type BillingInfoList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []BillingInfo
+}
 
-	HasMore bool
-	Data    []BillingInfo
+type BillingInfoLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []BillingInfo
+	HasMore() bool
+	Next() string
 }
 
 func NewBillingInfoList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *BillingInfoList {
@@ -92,8 +101,20 @@ func NewBillingInfoList(client HTTPCaller, nextPagePath string, requestOptions *
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *BillingInfoList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *BillingInfoList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *BillingInfoList) Data() []BillingInfo {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -105,8 +126,8 @@ func (list *BillingInfoList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/billing_info_updated_by.go
+++ b/billing_info_updated_by.go
@@ -51,9 +51,18 @@ type BillingInfoUpdatedByList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []BillingInfoUpdatedBy
+}
 
-	HasMore bool
-	Data    []BillingInfoUpdatedBy
+type BillingInfoUpdatedByLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []BillingInfoUpdatedBy
+	HasMore() bool
+	Next() string
 }
 
 func NewBillingInfoUpdatedByList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *BillingInfoUpdatedByList {
@@ -61,8 +70,20 @@ func NewBillingInfoUpdatedByList(client HTTPCaller, nextPagePath string, request
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *BillingInfoUpdatedByList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *BillingInfoUpdatedByList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *BillingInfoUpdatedByList) Data() []BillingInfoUpdatedBy {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -74,8 +95,8 @@ func (list *BillingInfoUpdatedByList) FetchWithContext(ctx context.Context) erro
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/binary_file.go
+++ b/binary_file.go
@@ -47,9 +47,18 @@ type BinaryFileList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []BinaryFile
+}
 
-	HasMore bool
-	Data    []BinaryFile
+type BinaryFileLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []BinaryFile
+	HasMore() bool
+	Next() string
 }
 
 func NewBinaryFileList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *BinaryFileList {
@@ -57,8 +66,20 @@ func NewBinaryFileList(client HTTPCaller, nextPagePath string, requestOptions *R
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *BinaryFileList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *BinaryFileList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *BinaryFileList) Data() []BinaryFile {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -70,8 +91,8 @@ func (list *BinaryFileList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/client_operations.go
+++ b/client_operations.go
@@ -18,12 +18,12 @@ const (
 )
 
 type ClientInterface interface {
-	ListSites(params *ListSitesParams, opts ...Option) (*SiteList, error)
+	ListSites(params *ListSitesParams, opts ...Option) (SiteLister, error)
 
 	GetSite(siteId string, opts ...Option) (*Site, error)
 	GetSiteWithContext(ctx context.Context, siteId string, opts ...Option) (*Site, error)
 
-	ListAccounts(params *ListAccountsParams, opts ...Option) (*AccountList, error)
+	ListAccounts(params *ListAccountsParams, opts ...Option) (AccountLister, error)
 
 	CreateAccount(body *AccountCreate, opts ...Option) (*Account, error)
 	CreateAccountWithContext(ctx context.Context, body *AccountCreate, opts ...Option) (*Account, error)
@@ -61,7 +61,7 @@ type ClientInterface interface {
 	RemoveBillingInfo(accountId string, opts ...Option) (*Empty, error)
 	RemoveBillingInfoWithContext(ctx context.Context, accountId string, opts ...Option) (*Empty, error)
 
-	ListBillingInfos(accountId string, params *ListBillingInfosParams, opts ...Option) (*BillingInfoList, error)
+	ListBillingInfos(accountId string, params *ListBillingInfosParams, opts ...Option) (BillingInfoLister, error)
 
 	CreateBillingInfo(accountId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error)
 	CreateBillingInfoWithContext(ctx context.Context, accountId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error)
@@ -75,9 +75,9 @@ type ClientInterface interface {
 	RemoveABillingInfo(accountId string, billingInfoId string, opts ...Option) (*Empty, error)
 	RemoveABillingInfoWithContext(ctx context.Context, accountId string, billingInfoId string, opts ...Option) (*Empty, error)
 
-	ListAccountCouponRedemptions(accountId string, params *ListAccountCouponRedemptionsParams, opts ...Option) (*CouponRedemptionList, error)
+	ListAccountCouponRedemptions(accountId string, params *ListAccountCouponRedemptionsParams, opts ...Option) (CouponRedemptionLister, error)
 
-	ListActiveCouponRedemptions(accountId string, opts ...Option) (*CouponRedemptionList, error)
+	ListActiveCouponRedemptions(accountId string, opts ...Option) (CouponRedemptionLister, error)
 
 	CreateCouponRedemption(accountId string, body *CouponRedemptionCreate, opts ...Option) (*CouponRedemption, error)
 	CreateCouponRedemptionWithContext(ctx context.Context, accountId string, body *CouponRedemptionCreate, opts ...Option) (*CouponRedemption, error)
@@ -85,9 +85,9 @@ type ClientInterface interface {
 	RemoveCouponRedemption(accountId string, opts ...Option) (*CouponRedemption, error)
 	RemoveCouponRedemptionWithContext(ctx context.Context, accountId string, opts ...Option) (*CouponRedemption, error)
 
-	ListAccountCreditPayments(accountId string, params *ListAccountCreditPaymentsParams, opts ...Option) (*CreditPaymentList, error)
+	ListAccountCreditPayments(accountId string, params *ListAccountCreditPaymentsParams, opts ...Option) (CreditPaymentLister, error)
 
-	ListAccountInvoices(accountId string, params *ListAccountInvoicesParams, opts ...Option) (*InvoiceList, error)
+	ListAccountInvoices(accountId string, params *ListAccountInvoicesParams, opts ...Option) (InvoiceLister, error)
 
 	CreateInvoice(accountId string, body *InvoiceCreate, opts ...Option) (*InvoiceCollection, error)
 	CreateInvoiceWithContext(ctx context.Context, accountId string, body *InvoiceCreate, opts ...Option) (*InvoiceCollection, error)
@@ -95,17 +95,17 @@ type ClientInterface interface {
 	PreviewInvoice(accountId string, body *InvoiceCreate, opts ...Option) (*InvoiceCollection, error)
 	PreviewInvoiceWithContext(ctx context.Context, accountId string, body *InvoiceCreate, opts ...Option) (*InvoiceCollection, error)
 
-	ListAccountLineItems(accountId string, params *ListAccountLineItemsParams, opts ...Option) (*LineItemList, error)
+	ListAccountLineItems(accountId string, params *ListAccountLineItemsParams, opts ...Option) (LineItemLister, error)
 
 	CreateLineItem(accountId string, body *LineItemCreate, opts ...Option) (*LineItem, error)
 	CreateLineItemWithContext(ctx context.Context, accountId string, body *LineItemCreate, opts ...Option) (*LineItem, error)
 
-	ListAccountNotes(accountId string, params *ListAccountNotesParams, opts ...Option) (*AccountNoteList, error)
+	ListAccountNotes(accountId string, params *ListAccountNotesParams, opts ...Option) (AccountNoteLister, error)
 
 	GetAccountNote(accountId string, accountNoteId string, opts ...Option) (*AccountNote, error)
 	GetAccountNoteWithContext(ctx context.Context, accountId string, accountNoteId string, opts ...Option) (*AccountNote, error)
 
-	ListShippingAddresses(accountId string, params *ListShippingAddressesParams, opts ...Option) (*ShippingAddressList, error)
+	ListShippingAddresses(accountId string, params *ListShippingAddressesParams, opts ...Option) (ShippingAddressLister, error)
 
 	CreateShippingAddress(accountId string, body *ShippingAddressCreate, opts ...Option) (*ShippingAddress, error)
 	CreateShippingAddressWithContext(ctx context.Context, accountId string, body *ShippingAddressCreate, opts ...Option) (*ShippingAddress, error)
@@ -119,15 +119,15 @@ type ClientInterface interface {
 	RemoveShippingAddress(accountId string, shippingAddressId string, opts ...Option) (*Empty, error)
 	RemoveShippingAddressWithContext(ctx context.Context, accountId string, shippingAddressId string, opts ...Option) (*Empty, error)
 
-	ListAccountSubscriptions(accountId string, params *ListAccountSubscriptionsParams, opts ...Option) (*SubscriptionList, error)
+	ListAccountSubscriptions(accountId string, params *ListAccountSubscriptionsParams, opts ...Option) (SubscriptionLister, error)
 
-	ListAccountTransactions(accountId string, params *ListAccountTransactionsParams, opts ...Option) (*TransactionList, error)
+	ListAccountTransactions(accountId string, params *ListAccountTransactionsParams, opts ...Option) (TransactionLister, error)
 
-	ListChildAccounts(accountId string, params *ListChildAccountsParams, opts ...Option) (*AccountList, error)
+	ListChildAccounts(accountId string, params *ListChildAccountsParams, opts ...Option) (AccountLister, error)
 
-	ListAccountAcquisition(params *ListAccountAcquisitionParams, opts ...Option) (*AccountAcquisitionList, error)
+	ListAccountAcquisition(params *ListAccountAcquisitionParams, opts ...Option) (AccountAcquisitionLister, error)
 
-	ListCoupons(params *ListCouponsParams, opts ...Option) (*CouponList, error)
+	ListCoupons(params *ListCouponsParams, opts ...Option) (CouponLister, error)
 
 	CreateCoupon(body *CouponCreate, opts ...Option) (*Coupon, error)
 	CreateCouponWithContext(ctx context.Context, body *CouponCreate, opts ...Option) (*Coupon, error)
@@ -144,19 +144,19 @@ type ClientInterface interface {
 	RestoreCoupon(couponId string, body *CouponUpdate, opts ...Option) (*Coupon, error)
 	RestoreCouponWithContext(ctx context.Context, couponId string, body *CouponUpdate, opts ...Option) (*Coupon, error)
 
-	ListUniqueCouponCodes(couponId string, params *ListUniqueCouponCodesParams, opts ...Option) (*UniqueCouponCodeList, error)
+	ListUniqueCouponCodes(couponId string, params *ListUniqueCouponCodesParams, opts ...Option) (UniqueCouponCodeLister, error)
 
-	ListCreditPayments(params *ListCreditPaymentsParams, opts ...Option) (*CreditPaymentList, error)
+	ListCreditPayments(params *ListCreditPaymentsParams, opts ...Option) (CreditPaymentLister, error)
 
 	GetCreditPayment(creditPaymentId string, opts ...Option) (*CreditPayment, error)
 	GetCreditPaymentWithContext(ctx context.Context, creditPaymentId string, opts ...Option) (*CreditPayment, error)
 
-	ListCustomFieldDefinitions(params *ListCustomFieldDefinitionsParams, opts ...Option) (*CustomFieldDefinitionList, error)
+	ListCustomFieldDefinitions(params *ListCustomFieldDefinitionsParams, opts ...Option) (CustomFieldDefinitionLister, error)
 
 	GetCustomFieldDefinition(customFieldDefinitionId string, opts ...Option) (*CustomFieldDefinition, error)
 	GetCustomFieldDefinitionWithContext(ctx context.Context, customFieldDefinitionId string, opts ...Option) (*CustomFieldDefinition, error)
 
-	ListItems(params *ListItemsParams, opts ...Option) (*ItemList, error)
+	ListItems(params *ListItemsParams, opts ...Option) (ItemLister, error)
 
 	CreateItem(body *ItemCreate, opts ...Option) (*Item, error)
 	CreateItemWithContext(ctx context.Context, body *ItemCreate, opts ...Option) (*Item, error)
@@ -173,7 +173,7 @@ type ClientInterface interface {
 	ReactivateItem(itemId string, opts ...Option) (*Item, error)
 	ReactivateItemWithContext(ctx context.Context, itemId string, opts ...Option) (*Item, error)
 
-	ListMeasuredUnit(params *ListMeasuredUnitParams, opts ...Option) (*MeasuredUnitList, error)
+	ListMeasuredUnit(params *ListMeasuredUnitParams, opts ...Option) (MeasuredUnitLister, error)
 
 	CreateMeasuredUnit(body *MeasuredUnitCreate, opts ...Option) (*MeasuredUnit, error)
 	CreateMeasuredUnitWithContext(ctx context.Context, body *MeasuredUnitCreate, opts ...Option) (*MeasuredUnit, error)
@@ -187,7 +187,7 @@ type ClientInterface interface {
 	RemoveMeasuredUnit(measuredUnitId string, opts ...Option) (*MeasuredUnit, error)
 	RemoveMeasuredUnitWithContext(ctx context.Context, measuredUnitId string, opts ...Option) (*MeasuredUnit, error)
 
-	ListInvoices(params *ListInvoicesParams, opts ...Option) (*InvoiceList, error)
+	ListInvoices(params *ListInvoicesParams, opts ...Option) (InvoiceLister, error)
 
 	GetInvoice(invoiceId string, opts ...Option) (*Invoice, error)
 	GetInvoiceWithContext(ctx context.Context, invoiceId string, opts ...Option) (*Invoice, error)
@@ -213,16 +213,16 @@ type ClientInterface interface {
 	RecordExternalTransaction(invoiceId string, body *ExternalTransaction, opts ...Option) (*Transaction, error)
 	RecordExternalTransactionWithContext(ctx context.Context, invoiceId string, body *ExternalTransaction, opts ...Option) (*Transaction, error)
 
-	ListInvoiceLineItems(invoiceId string, params *ListInvoiceLineItemsParams, opts ...Option) (*LineItemList, error)
+	ListInvoiceLineItems(invoiceId string, params *ListInvoiceLineItemsParams, opts ...Option) (LineItemLister, error)
 
-	ListInvoiceCouponRedemptions(invoiceId string, params *ListInvoiceCouponRedemptionsParams, opts ...Option) (*CouponRedemptionList, error)
+	ListInvoiceCouponRedemptions(invoiceId string, params *ListInvoiceCouponRedemptionsParams, opts ...Option) (CouponRedemptionLister, error)
 
-	ListRelatedInvoices(invoiceId string, opts ...Option) (*InvoiceList, error)
+	ListRelatedInvoices(invoiceId string, opts ...Option) (InvoiceLister, error)
 
 	RefundInvoice(invoiceId string, body *InvoiceRefund, opts ...Option) (*Invoice, error)
 	RefundInvoiceWithContext(ctx context.Context, invoiceId string, body *InvoiceRefund, opts ...Option) (*Invoice, error)
 
-	ListLineItems(params *ListLineItemsParams, opts ...Option) (*LineItemList, error)
+	ListLineItems(params *ListLineItemsParams, opts ...Option) (LineItemLister, error)
 
 	GetLineItem(lineItemId string, opts ...Option) (*LineItem, error)
 	GetLineItemWithContext(ctx context.Context, lineItemId string, opts ...Option) (*LineItem, error)
@@ -230,7 +230,7 @@ type ClientInterface interface {
 	RemoveLineItem(lineItemId string, opts ...Option) (*Empty, error)
 	RemoveLineItemWithContext(ctx context.Context, lineItemId string, opts ...Option) (*Empty, error)
 
-	ListPlans(params *ListPlansParams, opts ...Option) (*PlanList, error)
+	ListPlans(params *ListPlansParams, opts ...Option) (PlanLister, error)
 
 	CreatePlan(body *PlanCreate, opts ...Option) (*Plan, error)
 	CreatePlanWithContext(ctx context.Context, body *PlanCreate, opts ...Option) (*Plan, error)
@@ -244,7 +244,7 @@ type ClientInterface interface {
 	RemovePlan(planId string, opts ...Option) (*Plan, error)
 	RemovePlanWithContext(ctx context.Context, planId string, opts ...Option) (*Plan, error)
 
-	ListPlanAddOns(planId string, params *ListPlanAddOnsParams, opts ...Option) (*AddOnList, error)
+	ListPlanAddOns(planId string, params *ListPlanAddOnsParams, opts ...Option) (AddOnLister, error)
 
 	CreatePlanAddOn(planId string, body *AddOnCreate, opts ...Option) (*AddOn, error)
 	CreatePlanAddOnWithContext(ctx context.Context, planId string, body *AddOnCreate, opts ...Option) (*AddOn, error)
@@ -258,12 +258,12 @@ type ClientInterface interface {
 	RemovePlanAddOn(planId string, addOnId string, opts ...Option) (*AddOn, error)
 	RemovePlanAddOnWithContext(ctx context.Context, planId string, addOnId string, opts ...Option) (*AddOn, error)
 
-	ListAddOns(params *ListAddOnsParams, opts ...Option) (*AddOnList, error)
+	ListAddOns(params *ListAddOnsParams, opts ...Option) (AddOnLister, error)
 
 	GetAddOn(addOnId string, opts ...Option) (*AddOn, error)
 	GetAddOnWithContext(ctx context.Context, addOnId string, opts ...Option) (*AddOn, error)
 
-	ListShippingMethods(params *ListShippingMethodsParams, opts ...Option) (*ShippingMethodList, error)
+	ListShippingMethods(params *ListShippingMethodsParams, opts ...Option) (ShippingMethodLister, error)
 
 	CreateShippingMethod(body *ShippingMethodCreate, opts ...Option) (*ShippingMethod, error)
 	CreateShippingMethodWithContext(ctx context.Context, body *ShippingMethodCreate, opts ...Option) (*ShippingMethod, error)
@@ -277,7 +277,7 @@ type ClientInterface interface {
 	DeactivateShippingMethod(shippingMethodId string, opts ...Option) (*ShippingMethod, error)
 	DeactivateShippingMethodWithContext(ctx context.Context, shippingMethodId string, opts ...Option) (*ShippingMethod, error)
 
-	ListSubscriptions(params *ListSubscriptionsParams, opts ...Option) (*SubscriptionList, error)
+	ListSubscriptions(params *ListSubscriptionsParams, opts ...Option) (SubscriptionLister, error)
 
 	CreateSubscription(body *SubscriptionCreate, opts ...Option) (*Subscription, error)
 	CreateSubscriptionWithContext(ctx context.Context, body *SubscriptionCreate, opts ...Option) (*Subscription, error)
@@ -318,13 +318,13 @@ type ClientInterface interface {
 	PreviewSubscriptionChange(subscriptionId string, body *SubscriptionChangeCreate, opts ...Option) (*SubscriptionChange, error)
 	PreviewSubscriptionChangeWithContext(ctx context.Context, subscriptionId string, body *SubscriptionChangeCreate, opts ...Option) (*SubscriptionChange, error)
 
-	ListSubscriptionInvoices(subscriptionId string, params *ListSubscriptionInvoicesParams, opts ...Option) (*InvoiceList, error)
+	ListSubscriptionInvoices(subscriptionId string, params *ListSubscriptionInvoicesParams, opts ...Option) (InvoiceLister, error)
 
-	ListSubscriptionLineItems(subscriptionId string, params *ListSubscriptionLineItemsParams, opts ...Option) (*LineItemList, error)
+	ListSubscriptionLineItems(subscriptionId string, params *ListSubscriptionLineItemsParams, opts ...Option) (LineItemLister, error)
 
-	ListSubscriptionCouponRedemptions(subscriptionId string, params *ListSubscriptionCouponRedemptionsParams, opts ...Option) (*CouponRedemptionList, error)
+	ListSubscriptionCouponRedemptions(subscriptionId string, params *ListSubscriptionCouponRedemptionsParams, opts ...Option) (CouponRedemptionLister, error)
 
-	ListUsage(subscriptionId string, addOnId string, params *ListUsageParams, opts ...Option) (*UsageList, error)
+	ListUsage(subscriptionId string, addOnId string, params *ListUsageParams, opts ...Option) (UsageLister, error)
 
 	CreateUsage(subscriptionId string, addOnId string, body *UsageCreate, opts ...Option) (*Usage, error)
 	CreateUsageWithContext(ctx context.Context, subscriptionId string, addOnId string, body *UsageCreate, opts ...Option) (*Usage, error)
@@ -338,7 +338,7 @@ type ClientInterface interface {
 	RemoveUsage(usageId string, opts ...Option) (*Empty, error)
 	RemoveUsageWithContext(ctx context.Context, usageId string, opts ...Option) (*Empty, error)
 
-	ListTransactions(params *ListTransactionsParams, opts ...Option) (*TransactionList, error)
+	ListTransactions(params *ListTransactionsParams, opts ...Option) (TransactionLister, error)
 
 	GetTransaction(transactionId string, opts ...Option) (*Transaction, error)
 	GetTransactionWithContext(ctx context.Context, transactionId string, opts ...Option) (*Transaction, error)
@@ -424,7 +424,7 @@ func (list *ListSitesParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_sites
 //
 // Returns: A list of sites.
-func (c *Client) ListSites(params *ListSitesParams, opts ...Option) (*SiteList, error) {
+func (c *Client) ListSites(params *ListSitesParams, opts ...Option) (SiteLister, error) {
 	path, err := c.InterpolatePath("/sites")
 	if err != nil {
 		return nil, err
@@ -553,7 +553,7 @@ func (list *ListAccountsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_accounts
 //
 // Returns: A list of the site's accounts.
-func (c *Client) ListAccounts(params *ListAccountsParams, opts ...Option) (*AccountList, error) {
+func (c *Client) ListAccounts(params *ListAccountsParams, opts ...Option) (AccountLister, error) {
 	path, err := c.InterpolatePath("/accounts")
 	if err != nil {
 		return nil, err
@@ -965,7 +965,7 @@ func (list *ListBillingInfosParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_billing_infos
 //
 // Returns: A list of the the billing information for an account's
-func (c *Client) ListBillingInfos(accountId string, params *ListBillingInfosParams, opts ...Option) (*BillingInfoList, error) {
+func (c *Client) ListBillingInfos(accountId string, params *ListBillingInfosParams, opts ...Option) (BillingInfoLister, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/billing_infos", accountId)
 	if err != nil {
 		return nil, err
@@ -1145,7 +1145,7 @@ func (list *ListAccountCouponRedemptionsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_account_coupon_redemptions
 //
 // Returns: A list of the the coupon redemptions on an account.
-func (c *Client) ListAccountCouponRedemptions(accountId string, params *ListAccountCouponRedemptionsParams, opts ...Option) (*CouponRedemptionList, error) {
+func (c *Client) ListAccountCouponRedemptions(accountId string, params *ListAccountCouponRedemptionsParams, opts ...Option) (CouponRedemptionLister, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/coupon_redemptions", accountId)
 	if err != nil {
 		return nil, err
@@ -1160,7 +1160,7 @@ func (c *Client) ListAccountCouponRedemptions(accountId string, params *ListAcco
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_active_coupon_redemptions
 //
 // Returns: Active coupon redemptions on an account.
-func (c *Client) ListActiveCouponRedemptions(accountId string, opts ...Option) (*CouponRedemptionList, error) {
+func (c *Client) ListActiveCouponRedemptions(accountId string, opts ...Option) (CouponRedemptionLister, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/coupon_redemptions/active", accountId)
 	if err != nil {
 		return nil, err
@@ -1280,7 +1280,7 @@ func (list *ListAccountCreditPaymentsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_account_credit_payments
 //
 // Returns: A list of the account's credit payments.
-func (c *Client) ListAccountCreditPayments(accountId string, params *ListAccountCreditPaymentsParams, opts ...Option) (*CreditPaymentList, error) {
+func (c *Client) ListAccountCreditPayments(accountId string, params *ListAccountCreditPaymentsParams, opts ...Option) (CreditPaymentLister, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/credit_payments", accountId)
 	if err != nil {
 		return nil, err
@@ -1369,7 +1369,7 @@ func (list *ListAccountInvoicesParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_account_invoices
 //
 // Returns: A list of the account's invoices.
-func (c *Client) ListAccountInvoices(accountId string, params *ListAccountInvoicesParams, opts ...Option) (*InvoiceList, error) {
+func (c *Client) ListAccountInvoices(accountId string, params *ListAccountInvoicesParams, opts ...Option) (InvoiceLister, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/invoices", accountId)
 	if err != nil {
 		return nil, err
@@ -1526,7 +1526,7 @@ func (list *ListAccountLineItemsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_account_line_items
 //
 // Returns: A list of the account's line items.
-func (c *Client) ListAccountLineItems(accountId string, params *ListAccountLineItemsParams, opts ...Option) (*LineItemList, error) {
+func (c *Client) ListAccountLineItems(accountId string, params *ListAccountLineItemsParams, opts ...Option) (LineItemLister, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/line_items", accountId)
 	if err != nil {
 		return nil, err
@@ -1594,7 +1594,7 @@ func (list *ListAccountNotesParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_account_notes
 //
 // Returns: A list of an account's notes.
-func (c *Client) ListAccountNotes(accountId string, params *ListAccountNotesParams, opts ...Option) (*AccountNoteList, error) {
+func (c *Client) ListAccountNotes(accountId string, params *ListAccountNotesParams, opts ...Option) (AccountNoteLister, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/notes", accountId)
 	if err != nil {
 		return nil, err
@@ -1701,7 +1701,7 @@ func (list *ListShippingAddressesParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_shipping_addresses
 //
 // Returns: A list of an account's shipping addresses.
-func (c *Client) ListShippingAddresses(accountId string, params *ListShippingAddressesParams, opts ...Option) (*ShippingAddressList, error) {
+func (c *Client) ListShippingAddresses(accountId string, params *ListShippingAddressesParams, opts ...Option) (ShippingAddressLister, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/shipping_addresses", accountId)
 	if err != nil {
 		return nil, err
@@ -1905,7 +1905,7 @@ func (list *ListAccountSubscriptionsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_account_subscriptions
 //
 // Returns: A list of the account's subscriptions.
-func (c *Client) ListAccountSubscriptions(accountId string, params *ListAccountSubscriptionsParams, opts ...Option) (*SubscriptionList, error) {
+func (c *Client) ListAccountSubscriptions(accountId string, params *ListAccountSubscriptionsParams, opts ...Option) (SubscriptionLister, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/subscriptions", accountId)
 	if err != nil {
 		return nil, err
@@ -1997,7 +1997,7 @@ func (list *ListAccountTransactionsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_account_transactions
 //
 // Returns: A list of the account's transactions.
-func (c *Client) ListAccountTransactions(accountId string, params *ListAccountTransactionsParams, opts ...Option) (*TransactionList, error) {
+func (c *Client) ListAccountTransactions(accountId string, params *ListAccountTransactionsParams, opts ...Option) (TransactionLister, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/transactions", accountId)
 	if err != nil {
 		return nil, err
@@ -2097,7 +2097,7 @@ func (list *ListChildAccountsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_child_accounts
 //
 // Returns: A list of an account's child accounts.
-func (c *Client) ListChildAccounts(accountId string, params *ListChildAccountsParams, opts ...Option) (*AccountList, error) {
+func (c *Client) ListChildAccounts(accountId string, params *ListChildAccountsParams, opts ...Option) (AccountLister, error) {
 	path, err := c.InterpolatePath("/accounts/{account_id}/accounts", accountId)
 	if err != nil {
 		return nil, err
@@ -2175,7 +2175,7 @@ func (list *ListAccountAcquisitionParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_account_acquisition
 //
 // Returns: A list of the site's account acquisition data.
-func (c *Client) ListAccountAcquisition(params *ListAccountAcquisitionParams, opts ...Option) (*AccountAcquisitionList, error) {
+func (c *Client) ListAccountAcquisition(params *ListAccountAcquisitionParams, opts ...Option) (AccountAcquisitionLister, error) {
 	path, err := c.InterpolatePath("/acquisitions")
 	if err != nil {
 		return nil, err
@@ -2253,7 +2253,7 @@ func (list *ListCouponsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_coupons
 //
 // Returns: A list of the site's coupons.
-func (c *Client) ListCoupons(params *ListCouponsParams, opts ...Option) (*CouponList, error) {
+func (c *Client) ListCoupons(params *ListCouponsParams, opts ...Option) (CouponLister, error) {
 	path, err := c.InterpolatePath("/coupons")
 	if err != nil {
 		return nil, err
@@ -2476,7 +2476,7 @@ func (list *ListUniqueCouponCodesParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_unique_coupon_codes
 //
 // Returns: A list of unique coupon codes that were generated
-func (c *Client) ListUniqueCouponCodes(couponId string, params *ListUniqueCouponCodesParams, opts ...Option) (*UniqueCouponCodeList, error) {
+func (c *Client) ListUniqueCouponCodes(couponId string, params *ListUniqueCouponCodesParams, opts ...Option) (UniqueCouponCodeLister, error) {
 	path, err := c.InterpolatePath("/coupons/{coupon_id}/unique_coupon_codes", couponId)
 	if err != nil {
 		return nil, err
@@ -2539,7 +2539,7 @@ func (list *ListCreditPaymentsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_credit_payments
 //
 // Returns: A list of the site's credit payments.
-func (c *Client) ListCreditPayments(params *ListCreditPaymentsParams, opts ...Option) (*CreditPaymentList, error) {
+func (c *Client) ListCreditPayments(params *ListCreditPaymentsParams, opts ...Option) (CreditPaymentLister, error) {
 	path, err := c.InterpolatePath("/credit_payments")
 	if err != nil {
 		return nil, err
@@ -2653,7 +2653,7 @@ func (list *ListCustomFieldDefinitionsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_custom_field_definitions
 //
 // Returns: A list of the site's custom field definitions.
-func (c *Client) ListCustomFieldDefinitions(params *ListCustomFieldDefinitionsParams, opts ...Option) (*CustomFieldDefinitionList, error) {
+func (c *Client) ListCustomFieldDefinitions(params *ListCustomFieldDefinitionsParams, opts ...Option) (CustomFieldDefinitionLister, error) {
 	path, err := c.InterpolatePath("/custom_field_definitions")
 	if err != nil {
 		return nil, err
@@ -2767,7 +2767,7 @@ func (list *ListItemsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_items
 //
 // Returns: A list of the site's items.
-func (c *Client) ListItems(params *ListItemsParams, opts ...Option) (*ItemList, error) {
+func (c *Client) ListItems(params *ListItemsParams, opts ...Option) (ItemLister, error) {
 	path, err := c.InterpolatePath("/items")
 	if err != nil {
 		return nil, err
@@ -2997,7 +2997,7 @@ func (list *ListMeasuredUnitParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_measured_unit
 //
 // Returns: A list of the site's measured units.
-func (c *Client) ListMeasuredUnit(params *ListMeasuredUnitParams, opts ...Option) (*MeasuredUnitList, error) {
+func (c *Client) ListMeasuredUnit(params *ListMeasuredUnitParams, opts ...Option) (MeasuredUnitLister, error) {
 	path, err := c.InterpolatePath("/measured_units")
 	if err != nil {
 		return nil, err
@@ -3202,7 +3202,7 @@ func (list *ListInvoicesParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_invoices
 //
 // Returns: A list of the site's invoices.
-func (c *Client) ListInvoices(params *ListInvoicesParams, opts ...Option) (*InvoiceList, error) {
+func (c *Client) ListInvoices(params *ListInvoicesParams, opts ...Option) (InvoiceLister, error) {
 	path, err := c.InterpolatePath("/invoices")
 	if err != nil {
 		return nil, err
@@ -3545,7 +3545,7 @@ func (list *ListInvoiceLineItemsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_invoice_line_items
 //
 // Returns: A list of the invoice's line items.
-func (c *Client) ListInvoiceLineItems(invoiceId string, params *ListInvoiceLineItemsParams, opts ...Option) (*LineItemList, error) {
+func (c *Client) ListInvoiceLineItems(invoiceId string, params *ListInvoiceLineItemsParams, opts ...Option) (LineItemLister, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/line_items", invoiceId)
 	if err != nil {
 		return nil, err
@@ -3609,7 +3609,7 @@ func (list *ListInvoiceCouponRedemptionsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_invoice_coupon_redemptions
 //
 // Returns: A list of the the coupon redemptions associated with the invoice.
-func (c *Client) ListInvoiceCouponRedemptions(invoiceId string, params *ListInvoiceCouponRedemptionsParams, opts ...Option) (*CouponRedemptionList, error) {
+func (c *Client) ListInvoiceCouponRedemptions(invoiceId string, params *ListInvoiceCouponRedemptionsParams, opts ...Option) (CouponRedemptionLister, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/coupon_redemptions", invoiceId)
 	if err != nil {
 		return nil, err
@@ -3624,7 +3624,7 @@ func (c *Client) ListInvoiceCouponRedemptions(invoiceId string, params *ListInvo
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_related_invoices
 //
 // Returns: A list of the credit or charge invoices associated with the invoice.
-func (c *Client) ListRelatedInvoices(invoiceId string, opts ...Option) (*InvoiceList, error) {
+func (c *Client) ListRelatedInvoices(invoiceId string, opts ...Option) (InvoiceLister, error) {
 	path, err := c.InterpolatePath("/invoices/{invoice_id}/related_invoices", invoiceId)
 	if err != nil {
 		return nil, err
@@ -3751,7 +3751,7 @@ func (list *ListLineItemsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_line_items
 //
 // Returns: A list of the site's line items.
-func (c *Client) ListLineItems(params *ListLineItemsParams, opts ...Option) (*LineItemList, error) {
+func (c *Client) ListLineItems(params *ListLineItemsParams, opts ...Option) (LineItemLister, error) {
 	path, err := c.InterpolatePath("/line_items")
 	if err != nil {
 		return nil, err
@@ -3894,7 +3894,7 @@ func (list *ListPlansParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_plans
 //
 // Returns: A list of plans.
-func (c *Client) ListPlans(params *ListPlansParams, opts ...Option) (*PlanList, error) {
+func (c *Client) ListPlans(params *ListPlansParams, opts ...Option) (PlanLister, error) {
 	path, err := c.InterpolatePath("/plans")
 	if err != nil {
 		return nil, err
@@ -4095,7 +4095,7 @@ func (list *ListPlanAddOnsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_plan_add_ons
 //
 // Returns: A list of add-ons.
-func (c *Client) ListPlanAddOns(planId string, params *ListPlanAddOnsParams, opts ...Option) (*AddOnList, error) {
+func (c *Client) ListPlanAddOns(planId string, params *ListPlanAddOnsParams, opts ...Option) (AddOnLister, error) {
 	path, err := c.InterpolatePath("/plans/{plan_id}/add_ons", planId)
 	if err != nil {
 		return nil, err
@@ -4296,7 +4296,7 @@ func (list *ListAddOnsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_add_ons
 //
 // Returns: A list of add-ons.
-func (c *Client) ListAddOns(params *ListAddOnsParams, opts ...Option) (*AddOnList, error) {
+func (c *Client) ListAddOns(params *ListAddOnsParams, opts ...Option) (AddOnLister, error) {
 	path, err := c.InterpolatePath("/add_ons")
 	if err != nil {
 		return nil, err
@@ -4403,7 +4403,7 @@ func (list *ListShippingMethodsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_shipping_methods
 //
 // Returns: A list of the site's shipping methods.
-func (c *Client) ListShippingMethods(params *ListShippingMethodsParams, opts ...Option) (*ShippingMethodList, error) {
+func (c *Client) ListShippingMethods(params *ListShippingMethodsParams, opts ...Option) (ShippingMethodLister, error) {
 	path, err := c.InterpolatePath("/shipping_methods")
 	if err != nil {
 		return nil, err
@@ -4607,7 +4607,7 @@ func (list *ListSubscriptionsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_subscriptions
 //
 // Returns: A list of the site's subscriptions.
-func (c *Client) ListSubscriptions(params *ListSubscriptionsParams, opts ...Option) (*SubscriptionList, error) {
+func (c *Client) ListSubscriptions(params *ListSubscriptionsParams, opts ...Option) (SubscriptionLister, error) {
 	path, err := c.InterpolatePath("/subscriptions")
 	if err != nil {
 		return nil, err
@@ -5106,7 +5106,7 @@ func (list *ListSubscriptionInvoicesParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_subscription_invoices
 //
 // Returns: A list of the subscription's invoices.
-func (c *Client) ListSubscriptionInvoices(subscriptionId string, params *ListSubscriptionInvoicesParams, opts ...Option) (*InvoiceList, error) {
+func (c *Client) ListSubscriptionInvoices(subscriptionId string, params *ListSubscriptionInvoicesParams, opts ...Option) (InvoiceLister, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/invoices", subscriptionId)
 	if err != nil {
 		return nil, err
@@ -5205,7 +5205,7 @@ func (list *ListSubscriptionLineItemsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_subscription_line_items
 //
 // Returns: A list of the subscription's line items.
-func (c *Client) ListSubscriptionLineItems(subscriptionId string, params *ListSubscriptionLineItemsParams, opts ...Option) (*LineItemList, error) {
+func (c *Client) ListSubscriptionLineItems(subscriptionId string, params *ListSubscriptionLineItemsParams, opts ...Option) (LineItemLister, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/line_items", subscriptionId)
 	if err != nil {
 		return nil, err
@@ -5269,7 +5269,7 @@ func (list *ListSubscriptionCouponRedemptionsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_subscription_coupon_redemptions
 //
 // Returns: A list of the the coupon redemptions on a subscription.
-func (c *Client) ListSubscriptionCouponRedemptions(subscriptionId string, params *ListSubscriptionCouponRedemptionsParams, opts ...Option) (*CouponRedemptionList, error) {
+func (c *Client) ListSubscriptionCouponRedemptions(subscriptionId string, params *ListSubscriptionCouponRedemptionsParams, opts ...Option) (CouponRedemptionLister, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/coupon_redemptions", subscriptionId)
 	if err != nil {
 		return nil, err
@@ -5354,7 +5354,7 @@ func (list *ListUsageParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_usage
 //
 // Returns: A list of the subscription add-on's usage records.
-func (c *Client) ListUsage(subscriptionId string, addOnId string, params *ListUsageParams, opts ...Option) (*UsageList, error) {
+func (c *Client) ListUsage(subscriptionId string, addOnId string, params *ListUsageParams, opts ...Option) (UsageLister, error) {
 	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/add_ons/{add_on_id}/usage", subscriptionId, addOnId)
 	if err != nil {
 		return nil, err
@@ -5562,7 +5562,7 @@ func (list *ListTransactionsParams) URLParams() []KeyValue {
 // API Documentation: https://developers.recurly.com/api/v2020-01-01#operation/list_transactions
 //
 // Returns: A list of the site's transactions.
-func (c *Client) ListTransactions(params *ListTransactionsParams, opts ...Option) (*TransactionList, error) {
+func (c *Client) ListTransactions(params *ListTransactionsParams, opts ...Option) (TransactionLister, error) {
 	path, err := c.InterpolatePath("/transactions")
 	if err != nil {
 		return nil, err

--- a/client_operations_test.go
+++ b/client_operations_test.go
@@ -95,10 +95,10 @@ func TestListAccounts(test *testing.T) {
 	t.Assert(err, nil, "Error not expected")
 	accounts.Fetch()
 
-	t.Assert(accounts.Data[0].Id, "abcd1234", "list.Data[0].Id")
-	t.Assert(accounts.Data[1].FirstName, "juniper", "list.Data[1].FirstName")
-	t.Assert(accounts.HasMore, true, "list.HasMore")
-	t.Assert(accounts.nextPagePath, "/accounts?cursor=efgh5678%3A1588803986.0&limit=1&order=desc&sort=created_at", "accounts.nextPagePath")
+	t.Assert(accounts.Data()[0].Id, "abcd1234", "list.Data[0].Id")
+	t.Assert(accounts.Data()[1].FirstName, "juniper", "list.Data[1].FirstName")
+	t.Assert(accounts.HasMore(), true, "list.HasMore")
+	t.Assert(accounts.Next(), "/accounts?cursor=efgh5678%3A1588803986.0&limit=1&order=desc&sort=created_at", "accounts.nextPagePath")
 }
 
 func TestListAccountsWithContext(test *testing.T) {
@@ -142,10 +142,10 @@ func TestListAccountsWithContext(test *testing.T) {
 	t.Assert(err, nil, "Error not expected")
 	accounts.FetchWithContext(ctx)
 
-	t.Assert(accounts.Data[0].Id, "abcd1234", "list.Data[0].Id")
-	t.Assert(accounts.Data[1].FirstName, "juniper", "list.Data[1].FirstName")
-	t.Assert(accounts.HasMore, true, "list.HasMore")
-	t.Assert(accounts.nextPagePath, "/accounts?cursor=efgh5678%3A1588803986.0&limit=1&order=desc&sort=created_at", "accounts.nextPagePath")
+	t.Assert(accounts.Data()[0].Id, "abcd1234", "list.Data[0].Id")
+	t.Assert(accounts.Data()[1].FirstName, "juniper", "list.Data[1].FirstName")
+	t.Assert(accounts.HasMore(), true, "list.HasMore")
+	t.Assert(accounts.Next(), "/accounts?cursor=efgh5678%3A1588803986.0&limit=1&order=desc&sort=created_at", "accounts.nextPagePath")
 }
 
 func TestCreateAccountWithNilContext(test *testing.T) {

--- a/coupon.go
+++ b/coupon.go
@@ -137,9 +137,18 @@ type CouponList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []Coupon
+}
 
-	HasMore bool
-	Data    []Coupon
+type CouponLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []Coupon
+	HasMore() bool
+	Next() string
 }
 
 func NewCouponList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *CouponList {
@@ -147,8 +156,20 @@ func NewCouponList(client HTTPCaller, nextPagePath string, requestOptions *Reque
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *CouponList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *CouponList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *CouponList) Data() []Coupon {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -160,8 +181,8 @@ func (list *CouponList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/coupon_discount.go
+++ b/coupon_discount.go
@@ -56,9 +56,18 @@ type CouponDiscountList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []CouponDiscount
+}
 
-	HasMore bool
-	Data    []CouponDiscount
+type CouponDiscountLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []CouponDiscount
+	HasMore() bool
+	Next() string
 }
 
 func NewCouponDiscountList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *CouponDiscountList {
@@ -66,8 +75,20 @@ func NewCouponDiscountList(client HTTPCaller, nextPagePath string, requestOption
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *CouponDiscountList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *CouponDiscountList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *CouponDiscountList) Data() []CouponDiscount {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -79,8 +100,8 @@ func (list *CouponDiscountList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/coupon_discount_pricing.go
+++ b/coupon_discount_pricing.go
@@ -51,9 +51,18 @@ type CouponDiscountPricingList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []CouponDiscountPricing
+}
 
-	HasMore bool
-	Data    []CouponDiscountPricing
+type CouponDiscountPricingLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []CouponDiscountPricing
+	HasMore() bool
+	Next() string
 }
 
 func NewCouponDiscountPricingList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *CouponDiscountPricingList {
@@ -61,8 +70,20 @@ func NewCouponDiscountPricingList(client HTTPCaller, nextPagePath string, reques
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *CouponDiscountPricingList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *CouponDiscountPricingList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *CouponDiscountPricingList) Data() []CouponDiscountPricing {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -74,8 +95,8 @@ func (list *CouponDiscountPricingList) FetchWithContext(ctx context.Context) err
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/coupon_discount_trial.go
+++ b/coupon_discount_trial.go
@@ -51,9 +51,18 @@ type CouponDiscountTrialList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []CouponDiscountTrial
+}
 
-	HasMore bool
-	Data    []CouponDiscountTrial
+type CouponDiscountTrialLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []CouponDiscountTrial
+	HasMore() bool
+	Next() string
 }
 
 func NewCouponDiscountTrialList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *CouponDiscountTrialList {
@@ -61,8 +70,20 @@ func NewCouponDiscountTrialList(client HTTPCaller, nextPagePath string, requestO
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *CouponDiscountTrialList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *CouponDiscountTrialList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *CouponDiscountTrialList) Data() []CouponDiscountTrial {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -74,8 +95,8 @@ func (list *CouponDiscountTrialList) FetchWithContext(ctx context.Context) error
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/coupon_mini.go
+++ b/coupon_mini.go
@@ -71,9 +71,18 @@ type CouponMiniList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []CouponMini
+}
 
-	HasMore bool
-	Data    []CouponMini
+type CouponMiniLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []CouponMini
+	HasMore() bool
+	Next() string
 }
 
 func NewCouponMiniList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *CouponMiniList {
@@ -81,8 +90,20 @@ func NewCouponMiniList(client HTTPCaller, nextPagePath string, requestOptions *R
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *CouponMiniList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *CouponMiniList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *CouponMiniList) Data() []CouponMini {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -94,8 +115,8 @@ func (list *CouponMiniList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/coupon_redemption.go
+++ b/coupon_redemption.go
@@ -75,9 +75,18 @@ type CouponRedemptionList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []CouponRedemption
+}
 
-	HasMore bool
-	Data    []CouponRedemption
+type CouponRedemptionLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []CouponRedemption
+	HasMore() bool
+	Next() string
 }
 
 func NewCouponRedemptionList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *CouponRedemptionList {
@@ -85,8 +94,20 @@ func NewCouponRedemptionList(client HTTPCaller, nextPagePath string, requestOpti
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *CouponRedemptionList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *CouponRedemptionList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *CouponRedemptionList) Data() []CouponRedemption {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -98,8 +119,8 @@ func (list *CouponRedemptionList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/coupon_redemption_mini.go
+++ b/coupon_redemption_mini.go
@@ -63,9 +63,18 @@ type CouponRedemptionMiniList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []CouponRedemptionMini
+}
 
-	HasMore bool
-	Data    []CouponRedemptionMini
+type CouponRedemptionMiniLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []CouponRedemptionMini
+	HasMore() bool
+	Next() string
 }
 
 func NewCouponRedemptionMiniList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *CouponRedemptionMiniList {
@@ -73,8 +82,20 @@ func NewCouponRedemptionMiniList(client HTTPCaller, nextPagePath string, request
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *CouponRedemptionMiniList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *CouponRedemptionMiniList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *CouponRedemptionMiniList) Data() []CouponRedemptionMini {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -86,8 +107,8 @@ func (list *CouponRedemptionMiniList) FetchWithContext(ctx context.Context) erro
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/credit_payment.go
+++ b/credit_payment.go
@@ -87,9 +87,18 @@ type CreditPaymentList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []CreditPayment
+}
 
-	HasMore bool
-	Data    []CreditPayment
+type CreditPaymentLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []CreditPayment
+	HasMore() bool
+	Next() string
 }
 
 func NewCreditPaymentList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *CreditPaymentList {
@@ -97,8 +106,20 @@ func NewCreditPaymentList(client HTTPCaller, nextPagePath string, requestOptions
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *CreditPaymentList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *CreditPaymentList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *CreditPaymentList) Data() []CreditPayment {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -110,8 +131,8 @@ func (list *CreditPaymentList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/custom_field.go
+++ b/custom_field.go
@@ -51,9 +51,18 @@ type CustomFieldList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []CustomField
+}
 
-	HasMore bool
-	Data    []CustomField
+type CustomFieldLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []CustomField
+	HasMore() bool
+	Next() string
 }
 
 func NewCustomFieldList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *CustomFieldList {
@@ -61,8 +70,20 @@ func NewCustomFieldList(client HTTPCaller, nextPagePath string, requestOptions *
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *CustomFieldList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *CustomFieldList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *CustomFieldList) Data() []CustomField {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -74,8 +95,8 @@ func (list *CustomFieldList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/custom_field_definition.go
+++ b/custom_field_definition.go
@@ -80,9 +80,18 @@ type CustomFieldDefinitionList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []CustomFieldDefinition
+}
 
-	HasMore bool
-	Data    []CustomFieldDefinition
+type CustomFieldDefinitionLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []CustomFieldDefinition
+	HasMore() bool
+	Next() string
 }
 
 func NewCustomFieldDefinitionList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *CustomFieldDefinitionList {
@@ -90,8 +99,20 @@ func NewCustomFieldDefinitionList(client HTTPCaller, nextPagePath string, reques
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *CustomFieldDefinitionList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *CustomFieldDefinitionList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *CustomFieldDefinitionList) Data() []CustomFieldDefinition {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -103,8 +124,8 @@ func (list *CustomFieldDefinitionList) FetchWithContext(ctx context.Context) err
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/error_may_have_transaction.go
+++ b/error_may_have_transaction.go
@@ -57,9 +57,18 @@ type ErrorMayHaveTransactionList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []ErrorMayHaveTransaction
+}
 
-	HasMore bool
-	Data    []ErrorMayHaveTransaction
+type ErrorMayHaveTransactionLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []ErrorMayHaveTransaction
+	HasMore() bool
+	Next() string
 }
 
 func NewErrorMayHaveTransactionList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *ErrorMayHaveTransactionList {
@@ -67,8 +76,20 @@ func NewErrorMayHaveTransactionList(client HTTPCaller, nextPagePath string, requ
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *ErrorMayHaveTransactionList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *ErrorMayHaveTransactionList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *ErrorMayHaveTransactionList) Data() []ErrorMayHaveTransaction {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -80,8 +101,8 @@ func (list *ErrorMayHaveTransactionList) FetchWithContext(ctx context.Context) e
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/export_dates.go
+++ b/export_dates.go
@@ -51,9 +51,18 @@ type ExportDatesList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []ExportDates
+}
 
-	HasMore bool
-	Data    []ExportDates
+type ExportDatesLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []ExportDates
+	HasMore() bool
+	Next() string
 }
 
 func NewExportDatesList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *ExportDatesList {
@@ -61,8 +70,20 @@ func NewExportDatesList(client HTTPCaller, nextPagePath string, requestOptions *
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *ExportDatesList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *ExportDatesList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *ExportDatesList) Data() []ExportDates {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -74,8 +95,8 @@ func (list *ExportDatesList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/export_file.go
+++ b/export_file.go
@@ -54,9 +54,18 @@ type ExportFileList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []ExportFile
+}
 
-	HasMore bool
-	Data    []ExportFile
+type ExportFileLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []ExportFile
+	HasMore() bool
+	Next() string
 }
 
 func NewExportFileList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *ExportFileList {
@@ -64,8 +73,20 @@ func NewExportFileList(client HTTPCaller, nextPagePath string, requestOptions *R
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *ExportFileList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *ExportFileList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *ExportFileList) Data() []ExportFile {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -77,8 +98,8 @@ func (list *ExportFileList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/export_files.go
+++ b/export_files.go
@@ -50,9 +50,18 @@ type ExportFilesList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []ExportFiles
+}
 
-	HasMore bool
-	Data    []ExportFiles
+type ExportFilesLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []ExportFiles
+	HasMore() bool
+	Next() string
 }
 
 func NewExportFilesList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *ExportFilesList {
@@ -60,8 +69,20 @@ func NewExportFilesList(client HTTPCaller, nextPagePath string, requestOptions *
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *ExportFilesList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *ExportFilesList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *ExportFilesList) Data() []ExportFiles {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -73,8 +94,8 @@ func (list *ExportFilesList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/fraud_info.go
+++ b/fraud_info.go
@@ -54,9 +54,18 @@ type FraudInfoList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []FraudInfo
+}
 
-	HasMore bool
-	Data    []FraudInfo
+type FraudInfoLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []FraudInfo
+	HasMore() bool
+	Next() string
 }
 
 func NewFraudInfoList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *FraudInfoList {
@@ -64,8 +73,20 @@ func NewFraudInfoList(client HTTPCaller, nextPagePath string, requestOptions *Re
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *FraudInfoList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *FraudInfoList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *FraudInfoList) Data() []FraudInfo {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -77,8 +98,8 @@ func (list *FraudInfoList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/invoice_address.go
+++ b/invoice_address.go
@@ -78,9 +78,18 @@ type InvoiceAddressList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []InvoiceAddress
+}
 
-	HasMore bool
-	Data    []InvoiceAddress
+type InvoiceAddressLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []InvoiceAddress
+	HasMore() bool
+	Next() string
 }
 
 func NewInvoiceAddressList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *InvoiceAddressList {
@@ -88,8 +97,20 @@ func NewInvoiceAddressList(client HTTPCaller, nextPagePath string, requestOption
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *InvoiceAddressList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *InvoiceAddressList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *InvoiceAddressList) Data() []InvoiceAddress {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -101,8 +122,8 @@ func (list *InvoiceAddressList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/invoice_collection.go
+++ b/invoice_collection.go
@@ -53,9 +53,18 @@ type InvoiceCollectionList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []InvoiceCollection
+}
 
-	HasMore bool
-	Data    []InvoiceCollection
+type InvoiceCollectionLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []InvoiceCollection
+	HasMore() bool
+	Next() string
 }
 
 func NewInvoiceCollectionList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *InvoiceCollectionList {
@@ -63,8 +72,20 @@ func NewInvoiceCollectionList(client HTTPCaller, nextPagePath string, requestOpt
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *InvoiceCollectionList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *InvoiceCollectionList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *InvoiceCollectionList) Data() []InvoiceCollection {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -76,8 +97,8 @@ func (list *InvoiceCollectionList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/invoice_mini.go
+++ b/invoice_mini.go
@@ -60,9 +60,18 @@ type InvoiceMiniList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []InvoiceMini
+}
 
-	HasMore bool
-	Data    []InvoiceMini
+type InvoiceMiniLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []InvoiceMini
+	HasMore() bool
+	Next() string
 }
 
 func NewInvoiceMiniList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *InvoiceMiniList {
@@ -70,8 +79,20 @@ func NewInvoiceMiniList(client HTTPCaller, nextPagePath string, requestOptions *
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *InvoiceMiniList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *InvoiceMiniList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *InvoiceMiniList) Data() []InvoiceMini {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -83,8 +104,8 @@ func (list *InvoiceMiniList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/item.go
+++ b/item.go
@@ -100,9 +100,18 @@ type ItemList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []Item
+}
 
-	HasMore bool
-	Data    []Item
+type ItemLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []Item
+	HasMore() bool
+	Next() string
 }
 
 func NewItemList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *ItemList {
@@ -110,8 +119,20 @@ func NewItemList(client HTTPCaller, nextPagePath string, requestOptions *Request
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *ItemList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *ItemList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *ItemList) Data() []Item {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -123,8 +144,8 @@ func (list *ItemList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/item_mini.go
+++ b/item_mini.go
@@ -63,9 +63,18 @@ type ItemMiniList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []ItemMini
+}
 
-	HasMore bool
-	Data    []ItemMini
+type ItemMiniLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []ItemMini
+	HasMore() bool
+	Next() string
 }
 
 func NewItemMiniList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *ItemMiniList {
@@ -73,8 +82,20 @@ func NewItemMiniList(client HTTPCaller, nextPagePath string, requestOptions *Req
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *ItemMiniList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *ItemMiniList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *ItemMiniList) Data() []ItemMini {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -86,8 +107,8 @@ func (list *ItemMiniList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/line_item.go
+++ b/line_item.go
@@ -190,9 +190,18 @@ type LineItemList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []LineItem
+}
 
-	HasMore bool
-	Data    []LineItem
+type LineItemLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []LineItem
+	HasMore() bool
+	Next() string
 }
 
 func NewLineItemList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *LineItemList {
@@ -200,8 +209,20 @@ func NewLineItemList(client HTTPCaller, nextPagePath string, requestOptions *Req
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *LineItemList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *LineItemList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *LineItemList) Data() []LineItem {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -213,8 +234,8 @@ func (list *LineItemList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/measured_unit.go
+++ b/measured_unit.go
@@ -73,9 +73,18 @@ type MeasuredUnitList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []MeasuredUnit
+}
 
-	HasMore bool
-	Data    []MeasuredUnit
+type MeasuredUnitLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []MeasuredUnit
+	HasMore() bool
+	Next() string
 }
 
 func NewMeasuredUnitList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *MeasuredUnitList {
@@ -83,8 +92,20 @@ func NewMeasuredUnitList(client HTTPCaller, nextPagePath string, requestOptions 
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *MeasuredUnitList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *MeasuredUnitList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *MeasuredUnitList) Data() []MeasuredUnit {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -96,8 +117,8 @@ func (list *MeasuredUnitList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/payment_method.go
+++ b/payment_method.go
@@ -86,9 +86,18 @@ type PaymentMethodList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []PaymentMethod
+}
 
-	HasMore bool
-	Data    []PaymentMethod
+type PaymentMethodLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []PaymentMethod
+	HasMore() bool
+	Next() string
 }
 
 func NewPaymentMethodList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PaymentMethodList {
@@ -96,8 +105,20 @@ func NewPaymentMethodList(client HTTPCaller, nextPagePath string, requestOptions
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *PaymentMethodList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *PaymentMethodList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *PaymentMethodList) Data() []PaymentMethod {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -109,8 +130,8 @@ func (list *PaymentMethodList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/plan.go
+++ b/plan.go
@@ -129,9 +129,18 @@ type PlanList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []Plan
+}
 
-	HasMore bool
-	Data    []Plan
+type PlanLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []Plan
+	HasMore() bool
+	Next() string
 }
 
 func NewPlanList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PlanList {
@@ -139,8 +148,20 @@ func NewPlanList(client HTTPCaller, nextPagePath string, requestOptions *Request
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *PlanList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *PlanList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *PlanList) Data() []Plan {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -152,8 +173,8 @@ func (list *PlanList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/plan_hosted_pages.go
+++ b/plan_hosted_pages.go
@@ -57,9 +57,18 @@ type PlanHostedPagesList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []PlanHostedPages
+}
 
-	HasMore bool
-	Data    []PlanHostedPages
+type PlanHostedPagesLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []PlanHostedPages
+	HasMore() bool
+	Next() string
 }
 
 func NewPlanHostedPagesList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PlanHostedPagesList {
@@ -67,8 +76,20 @@ func NewPlanHostedPagesList(client HTTPCaller, nextPagePath string, requestOptio
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *PlanHostedPagesList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *PlanHostedPagesList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *PlanHostedPagesList) Data() []PlanHostedPages {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -80,8 +101,8 @@ func (list *PlanHostedPagesList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/plan_mini.go
+++ b/plan_mini.go
@@ -57,9 +57,18 @@ type PlanMiniList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []PlanMini
+}
 
-	HasMore bool
-	Data    []PlanMini
+type PlanMiniLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []PlanMini
+	HasMore() bool
+	Next() string
 }
 
 func NewPlanMiniList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PlanMiniList {
@@ -67,8 +76,20 @@ func NewPlanMiniList(client HTTPCaller, nextPagePath string, requestOptions *Req
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *PlanMiniList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *PlanMiniList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *PlanMiniList) Data() []PlanMini {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -80,8 +101,8 @@ func (list *PlanMiniList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/plan_pricing.go
+++ b/plan_pricing.go
@@ -54,9 +54,18 @@ type PlanPricingList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []PlanPricing
+}
 
-	HasMore bool
-	Data    []PlanPricing
+type PlanPricingLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []PlanPricing
+	HasMore() bool
+	Next() string
 }
 
 func NewPlanPricingList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PlanPricingList {
@@ -64,8 +73,20 @@ func NewPlanPricingList(client HTTPCaller, nextPagePath string, requestOptions *
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *PlanPricingList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *PlanPricingList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *PlanPricingList) Data() []PlanPricing {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -77,8 +98,8 @@ func (list *PlanPricingList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/pricing.go
+++ b/pricing.go
@@ -51,9 +51,18 @@ type PricingList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []Pricing
+}
 
-	HasMore bool
-	Data    []Pricing
+type PricingLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []Pricing
+	HasMore() bool
+	Next() string
 }
 
 func NewPricingList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PricingList {
@@ -61,8 +70,20 @@ func NewPricingList(client HTTPCaller, nextPagePath string, requestOptions *Requ
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *PricingList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *PricingList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *PricingList) Data() []Pricing {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -74,8 +95,8 @@ func (list *PricingList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/settings.go
+++ b/settings.go
@@ -56,9 +56,18 @@ type SettingsList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []Settings
+}
 
-	HasMore bool
-	Data    []Settings
+type SettingsLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []Settings
+	HasMore() bool
+	Next() string
 }
 
 func NewSettingsList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *SettingsList {
@@ -66,8 +75,20 @@ func NewSettingsList(client HTTPCaller, nextPagePath string, requestOptions *Req
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *SettingsList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *SettingsList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *SettingsList) Data() []Settings {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -79,8 +100,8 @@ func (list *SettingsList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/shipping_address.go
+++ b/shipping_address.go
@@ -90,9 +90,18 @@ type ShippingAddressList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []ShippingAddress
+}
 
-	HasMore bool
-	Data    []ShippingAddress
+type ShippingAddressLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []ShippingAddress
+	HasMore() bool
+	Next() string
 }
 
 func NewShippingAddressList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *ShippingAddressList {
@@ -100,8 +109,20 @@ func NewShippingAddressList(client HTTPCaller, nextPagePath string, requestOptio
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *ShippingAddressList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *ShippingAddressList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *ShippingAddressList) Data() []ShippingAddress {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -113,8 +134,8 @@ func (list *ShippingAddressList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/shipping_method.go
+++ b/shipping_method.go
@@ -82,9 +82,18 @@ type ShippingMethodList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []ShippingMethod
+}
 
-	HasMore bool
-	Data    []ShippingMethod
+type ShippingMethodLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []ShippingMethod
+	HasMore() bool
+	Next() string
 }
 
 func NewShippingMethodList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *ShippingMethodList {
@@ -92,8 +101,20 @@ func NewShippingMethodList(client HTTPCaller, nextPagePath string, requestOption
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *ShippingMethodList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *ShippingMethodList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *ShippingMethodList) Data() []ShippingMethod {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -105,8 +126,8 @@ func (list *ShippingMethodList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/shipping_method_mini.go
+++ b/shipping_method_mini.go
@@ -57,9 +57,18 @@ type ShippingMethodMiniList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []ShippingMethodMini
+}
 
-	HasMore bool
-	Data    []ShippingMethodMini
+type ShippingMethodMiniLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []ShippingMethodMini
+	HasMore() bool
+	Next() string
 }
 
 func NewShippingMethodMiniList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *ShippingMethodMiniList {
@@ -67,8 +76,20 @@ func NewShippingMethodMiniList(client HTTPCaller, nextPagePath string, requestOp
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *ShippingMethodMiniList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *ShippingMethodMiniList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *ShippingMethodMiniList) Data() []ShippingMethodMini {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -80,8 +101,8 @@ func (list *ShippingMethodMiniList) FetchWithContext(ctx context.Context) error 
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/site.go
+++ b/site.go
@@ -76,9 +76,18 @@ type SiteList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []Site
+}
 
-	HasMore bool
-	Data    []Site
+type SiteLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []Site
+	HasMore() bool
+	Next() string
 }
 
 func NewSiteList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *SiteList {
@@ -86,8 +95,20 @@ func NewSiteList(client HTTPCaller, nextPagePath string, requestOptions *Request
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *SiteList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *SiteList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *SiteList) Data() []Site {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -99,8 +120,8 @@ func (list *SiteList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/subscription.go
+++ b/subscription.go
@@ -172,9 +172,18 @@ type SubscriptionList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []Subscription
+}
 
-	HasMore bool
-	Data    []Subscription
+type SubscriptionLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []Subscription
+	HasMore() bool
+	Next() string
 }
 
 func NewSubscriptionList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *SubscriptionList {
@@ -182,8 +191,20 @@ func NewSubscriptionList(client HTTPCaller, nextPagePath string, requestOptions 
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *SubscriptionList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *SubscriptionList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *SubscriptionList) Data() []Subscription {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -195,8 +216,8 @@ func (list *SubscriptionList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/subscription_add_on.go
+++ b/subscription_add_on.go
@@ -95,9 +95,18 @@ type SubscriptionAddOnList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []SubscriptionAddOn
+}
 
-	HasMore bool
-	Data    []SubscriptionAddOn
+type SubscriptionAddOnLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []SubscriptionAddOn
+	HasMore() bool
+	Next() string
 }
 
 func NewSubscriptionAddOnList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *SubscriptionAddOnList {
@@ -105,8 +114,20 @@ func NewSubscriptionAddOnList(client HTTPCaller, nextPagePath string, requestOpt
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *SubscriptionAddOnList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *SubscriptionAddOnList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *SubscriptionAddOnList) Data() []SubscriptionAddOn {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -118,8 +139,8 @@ func (list *SubscriptionAddOnList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/subscription_add_on_tier.go
+++ b/subscription_add_on_tier.go
@@ -51,9 +51,18 @@ type SubscriptionAddOnTierList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []SubscriptionAddOnTier
+}
 
-	HasMore bool
-	Data    []SubscriptionAddOnTier
+type SubscriptionAddOnTierLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []SubscriptionAddOnTier
+	HasMore() bool
+	Next() string
 }
 
 func NewSubscriptionAddOnTierList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *SubscriptionAddOnTierList {
@@ -61,8 +70,20 @@ func NewSubscriptionAddOnTierList(client HTTPCaller, nextPagePath string, reques
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *SubscriptionAddOnTierList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *SubscriptionAddOnTierList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *SubscriptionAddOnTierList) Data() []SubscriptionAddOnTier {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -74,8 +95,8 @@ func (list *SubscriptionAddOnTierList) FetchWithContext(ctx context.Context) err
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/subscription_change.go
+++ b/subscription_change.go
@@ -94,9 +94,18 @@ type SubscriptionChangeList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []SubscriptionChange
+}
 
-	HasMore bool
-	Data    []SubscriptionChange
+type SubscriptionChangeLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []SubscriptionChange
+	HasMore() bool
+	Next() string
 }
 
 func NewSubscriptionChangeList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *SubscriptionChangeList {
@@ -104,8 +113,20 @@ func NewSubscriptionChangeList(client HTTPCaller, nextPagePath string, requestOp
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *SubscriptionChangeList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *SubscriptionChangeList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *SubscriptionChangeList) Data() []SubscriptionChange {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -117,8 +138,8 @@ func (list *SubscriptionChangeList) FetchWithContext(ctx context.Context) error 
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/subscription_shipping.go
+++ b/subscription_shipping.go
@@ -55,9 +55,18 @@ type SubscriptionShippingList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []SubscriptionShipping
+}
 
-	HasMore bool
-	Data    []SubscriptionShipping
+type SubscriptionShippingLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []SubscriptionShipping
+	HasMore() bool
+	Next() string
 }
 
 func NewSubscriptionShippingList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *SubscriptionShippingList {
@@ -65,8 +74,20 @@ func NewSubscriptionShippingList(client HTTPCaller, nextPagePath string, request
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *SubscriptionShippingList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *SubscriptionShippingList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *SubscriptionShippingList) Data() []SubscriptionShipping {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -78,8 +99,8 @@ func (list *SubscriptionShippingList) FetchWithContext(ctx context.Context) erro
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/tax_info.go
+++ b/tax_info.go
@@ -54,9 +54,18 @@ type TaxInfoList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []TaxInfo
+}
 
-	HasMore bool
-	Data    []TaxInfo
+type TaxInfoLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []TaxInfo
+	HasMore() bool
+	Next() string
 }
 
 func NewTaxInfoList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *TaxInfoList {
@@ -64,8 +73,20 @@ func NewTaxInfoList(client HTTPCaller, nextPagePath string, requestOptions *Requ
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *TaxInfoList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *TaxInfoList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *TaxInfoList) Data() []TaxInfo {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -77,8 +98,8 @@ func (list *TaxInfoList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/tier.go
+++ b/tier.go
@@ -51,9 +51,18 @@ type TierList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []Tier
+}
 
-	HasMore bool
-	Data    []Tier
+type TierLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []Tier
+	HasMore() bool
+	Next() string
 }
 
 func NewTierList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *TierList {
@@ -61,8 +70,20 @@ func NewTierList(client HTTPCaller, nextPagePath string, requestOptions *Request
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *TierList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *TierList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *TierList) Data() []Tier {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -74,8 +95,8 @@ func (list *TierList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/transaction.go
+++ b/transaction.go
@@ -161,9 +161,18 @@ type TransactionList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []Transaction
+}
 
-	HasMore bool
-	Data    []Transaction
+type TransactionLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []Transaction
+	HasMore() bool
+	Next() string
 }
 
 func NewTransactionList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *TransactionList {
@@ -171,8 +180,20 @@ func NewTransactionList(client HTTPCaller, nextPagePath string, requestOptions *
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *TransactionList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *TransactionList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *TransactionList) Data() []Transaction {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -184,8 +205,8 @@ func (list *TransactionList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/transaction_payment_gateway.go
+++ b/transaction_payment_gateway.go
@@ -54,9 +54,18 @@ type TransactionPaymentGatewayList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []TransactionPaymentGateway
+}
 
-	HasMore bool
-	Data    []TransactionPaymentGateway
+type TransactionPaymentGatewayLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []TransactionPaymentGateway
+	HasMore() bool
+	Next() string
 }
 
 func NewTransactionPaymentGatewayList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *TransactionPaymentGatewayList {
@@ -64,8 +73,20 @@ func NewTransactionPaymentGatewayList(client HTTPCaller, nextPagePath string, re
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *TransactionPaymentGatewayList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *TransactionPaymentGatewayList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *TransactionPaymentGatewayList) Data() []TransactionPaymentGateway {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -77,8 +98,8 @@ func (list *TransactionPaymentGatewayList) FetchWithContext(ctx context.Context)
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/unique_coupon_code.go
+++ b/unique_coupon_code.go
@@ -76,9 +76,18 @@ type UniqueCouponCodeList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []UniqueCouponCode
+}
 
-	HasMore bool
-	Data    []UniqueCouponCode
+type UniqueCouponCodeLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []UniqueCouponCode
+	HasMore() bool
+	Next() string
 }
 
 func NewUniqueCouponCodeList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *UniqueCouponCodeList {
@@ -86,8 +95,20 @@ func NewUniqueCouponCodeList(client HTTPCaller, nextPagePath string, requestOpti
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *UniqueCouponCodeList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *UniqueCouponCodeList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *UniqueCouponCodeList) Data() []UniqueCouponCode {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -99,8 +120,8 @@ func (list *UniqueCouponCodeList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/usage.go
+++ b/usage.go
@@ -93,9 +93,18 @@ type UsageList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []Usage
+}
 
-	HasMore bool
-	Data    []Usage
+type UsageLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []Usage
+	HasMore() bool
+	Next() string
 }
 
 func NewUsageList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *UsageList {
@@ -103,8 +112,20 @@ func NewUsageList(client HTTPCaller, nextPagePath string, requestOptions *Reques
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *UsageList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *UsageList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *UsageList) Data() []Usage {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -116,8 +137,8 @@ func (list *UsageList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 

--- a/user.go
+++ b/user.go
@@ -63,9 +63,18 @@ type UserList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
+	hasMore        bool
+	data           []User
+}
 
-	HasMore bool
-	Data    []User
+type UserLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []User
+	HasMore() bool
+	Next() string
 }
 
 func NewUserList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *UserList {
@@ -73,8 +82,20 @@ func NewUserList(client HTTPCaller, nextPagePath string, requestOptions *Request
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
-		HasMore:        true,
+		hasMore:        true,
 	}
+}
+
+func (list *UserList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *UserList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *UserList) Data() []User {
+	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
@@ -86,8 +107,8 @@ func (list *UserList) FetchWithContext(ctx context.Context) error {
 	}
 	// copy over properties from the response
 	list.nextPagePath = resources.Next
-	list.HasMore = resources.HasMore
-	list.Data = resources.Data
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
 	return nil
 }
 


### PR DESCRIPTION
Incorporate the feedback on #77 and return pager interfaces e.g. `UsageLister`, `AccountLister` from list operations. This should ease mocking away our client calls when testing. From a usage standpoint, this changes `HasMore` and `Data` from struct fields to methods i.e. `Data[0]` becomes `Data()[0]`.