### PR TITLE
Export optionsApplier as OptionsApplier

### DIFF
--- a/client.go
+++ b/client.go
@@ -111,14 +111,14 @@ func (c *Client) InterpolatePath(path string, params ...string) (string, error) 
 
 // HTTPCaller is the generic http interface used by the Client
 type HTTPCaller interface {
-	Call(ctx context.Context, method string, path string, body GenericParams, queryParams GenericParams, requestOptions optionsApplier, v interface{}) error
+	Call(ctx context.Context, method string, path string, body GenericParams, queryParams GenericParams, requestOptions OptionsApplier, v interface{}) error
 }
 
 // Call sends a request to Recurly and parses the JSON response for the expected response type.
 // The RequestOptions have been added to replace the common features of the Params struct
 // (which is returned by genericParams.toParams()) to seperate concerns with payload/URL params
 // from configurations of the HTTP request (RequestOptions).
-func (c *Client) Call(ctx context.Context, method string, path string, body GenericParams, queryParams GenericParams, requestOptions optionsApplier, v interface{}) error {
+func (c *Client) Call(ctx context.Context, method string, path string, body GenericParams, queryParams GenericParams, requestOptions OptionsApplier, v interface{}) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -175,7 +175,7 @@ func BuildURL(requestURL string, genericParams GenericParams) string {
 // The RequestOptions have been added to replace the common features of the Params struct in
 // an attempt to seperate request payload information (Params.Data) from configurations of the
 // HTTP request (RequestOptions).
-func (c *Client) NewRequest(ctx context.Context, method string, requestURL string, params *Params, requestOptions optionsApplier) (*http.Request, error) {
+func (c *Client) NewRequest(ctx context.Context, method string, requestURL string, params *Params, requestOptions OptionsApplier) (*http.Request, error) {
 	req, err := http.NewRequestWithContext(ctx, method, requestURL, nil)
 	if err != nil {
 		return nil, err

--- a/request_options.go
+++ b/request_options.go
@@ -61,7 +61,7 @@ func WithIdempotencyKey(k string) Option {
 	}
 }
 
-type optionsApplier interface {
+type OptionsApplier interface {
 	applyOptions(req *http.Request) *http.Request
 }
 


### PR DESCRIPTION
As mentioned in #79 -- export `optionsApplier` as `OptionsApplier` to ease mocking. I believe this is safe to merge back into v3-v2019-10-10, but if not, I will rebase on v3-v2021-02-25.