### PR TITLE
feat: add Idempotency-Prior to ResponseMetadata

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -128,6 +128,7 @@ func TestClientInjectsResponseMetadataIntoResource(test *testing.T) {
 	t.Assert(resp.RateLimit.Limit, 2000, "resp.RateLimit.Limit")
 	t.Assert(resp.RateLimit.Remaining, 1999, "resp.RateLimit.Remaining")
 	t.Assert(resp.Version, "recurly."+APIVersion, "resp.Version")
+	t.Assert(resp.IdempotencyPrior, true, "resp.IdempotencyPrior")
 
 	// check that the we inject the metadata into the Empty resource as well
 	scenario = &Scenario{

--- a/recurly_test.go
+++ b/recurly_test.go
@@ -84,6 +84,7 @@ func mockResponse(req *http.Request, statusCode int, body *string) *http.Respons
 	headers.Add("X-RateLimit-Reset", "1586203320")
 	headers.Add("X-Request-Id", "msy-1234")
 	headers.Add("Recurly-Total-Records", "100")
+	headers.Add("Idempotency-Prior", "true")
 	return &http.Response{
 		StatusCode: statusCode,
 		Body:       bodyReader(body),


### PR DESCRIPTION
Its useful to know whether a response has the Idempotency-Prior header.

This change simply catches that header and adds it to the ResponseMetadata.

Please let me know if this PR is to the wrong branch.