### PR TITLE
Generated Latest Changes for v2021-02-25 (get_preview_renewal)

### DIFF
--- a/client_operations.go
+++ b/client_operations.go
@@ -312,6 +312,9 @@ type ClientInterface interface {
 	ConvertTrial(subscriptionId string, opts ...Option) (*Subscription, error)
 	ConvertTrialWithContext(ctx context.Context, subscriptionId string, opts ...Option) (*Subscription, error)
 
+	GetPreviewRenewal(subscriptionId string, opts ...Option) (*InvoiceCollection, error)
+	GetPreviewRenewalWithContext(ctx context.Context, subscriptionId string, opts ...Option) (*InvoiceCollection, error)
+
 	GetSubscriptionChange(subscriptionId string, opts ...Option) (*SubscriptionChange, error)
 	GetSubscriptionChangeWithContext(ctx context.Context, subscriptionId string, opts ...Option) (*SubscriptionChange, error)
 
@@ -4995,6 +4998,35 @@ func (c *Client) convertTrial(ctx context.Context, subscriptionId string, opts .
 	requestOptions := NewRequestOptions(opts...)
 	result := &Subscription{}
 	err = c.Call(ctx, http.MethodPut, path, nil, nil, requestOptions, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, err
+}
+
+// GetPreviewRenewal wraps GetPreviewRenewalWithContext using the background context
+func (c *Client) GetPreviewRenewal(subscriptionId string, opts ...Option) (*InvoiceCollection, error) {
+	ctx := context.Background()
+	return c.getPreviewRenewal(ctx, subscriptionId, opts...)
+}
+
+// GetPreviewRenewalWithContext Fetch a preview of a subscription's renewal invoice(s)
+//
+// API Documentation: https://developers.recurly.com/api/v2021-02-25#operation/get_preview_renewal
+//
+// Returns: A preview of the subscription's renewal invoice(s).
+func (c *Client) GetPreviewRenewalWithContext(ctx context.Context, subscriptionId string, opts ...Option) (*InvoiceCollection, error) {
+	return c.getPreviewRenewal(ctx, subscriptionId, opts...)
+}
+
+func (c *Client) getPreviewRenewal(ctx context.Context, subscriptionId string, opts ...Option) (*InvoiceCollection, error) {
+	path, err := c.InterpolatePath("/subscriptions/{subscription_id}/preview_renewal", subscriptionId)
+	if err != nil {
+		return nil, err
+	}
+	requestOptions := NewRequestOptions(opts...)
+	result := &InvoiceCollection{}
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -12434,6 +12434,43 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
+  "/subscriptions/{subscription_id}/preview_renewal":
+    get:
+      tags:
+      - subscription
+      operationId: get_preview_renewal
+      summary: Fetch a preview of a subscription's renewal invoice(s)
+      description: The subscriptions's renewal invoice(s) will be returned if they
+        exist; if they don't (for example, if the subscription is not set to renew),
+        it will return an result with no invoices.
+      parameters:
+      - "$ref": "#/components/parameters/subscription_id"
+      responses:
+        '200':
+          description: A preview of the subscription's renewal invoice(s).
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/InvoiceCollection"
+        '400':
+          description: Invalid or unpermitted parameter.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Incorrect site ID or subscription ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/subscriptions/{subscription_id}/change":
     get:
       tags:
@@ -20075,7 +20112,8 @@ components:
         remaining_pause_cycles:
           type: integer
           title: Remaining pause cycles
-          description: Number of billing cycles to pause the subscriptions.
+          description: Number of billing cycles to pause the subscriptions. A value
+            of 0 will cancel any pending pauses on the subscription.
       required:
       - remaining_pause_cycles
     SubscriptionShipping:

--- a/subscription_pause.go
+++ b/subscription_pause.go
@@ -8,6 +8,6 @@ import ()
 
 type SubscriptionPause struct {
 
-	// Number of billing cycles to pause the subscriptions.
+	// Number of billing cycles to pause the subscriptions. A value of 0 will cancel any pending pauses on the subscription.
 	RemainingPauseCycles *int `json:"remaining_pause_cycles,omitempty"`
 }


### PR DESCRIPTION
* Adds new endpoint GET /sites/:site_id/subscriptions/:id/preview_renewal which returns a preview of the subscription's renewal invoice(s)