### PR TITLE
Generated Latest Changes for v2021-02-25 (Support to new subscription fields and response)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -12611,7 +12611,16 @@ paths:
       - subscription_change
       operationId: create_subscription_change
       summary: Create a new subscription change
-      description: Calling this will overwrite an existing, pending subscription change.
+      description: |
+        Calling this will overwrite an existing, pending subscription change.
+
+        If a subscription has a pending change, and a change is submitted which matches
+        the subscription as it currently exists, the pending change will be deleted,
+        and you will receive a 204 No Content response.
+
+        If a subscription has no pending
+        change, and a change is submitted which matches the subscription as it currently
+        exists, a 422 Unprocessable Entity validation error will be returned.
       parameters:
       - "$ref": "#/components/parameters/subscription_id"
       requestBody:
@@ -12627,6 +12636,8 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/SubscriptionChange"
+        '204':
+          description: The previous pending change was reverted.
         '404':
           description: Incorrect site ID.
           content:
@@ -19443,6 +19454,16 @@ components:
           format: float
           title: Estimated total, before tax.
           minimum: 0
+        tax:
+          type: number
+          format: float
+          title: Estimated tax
+        tax_info:
+          "$ref": "#/components/schemas/TaxInfo"
+        total:
+          type: number
+          format: float
+          title: Estimated total
         collection_method:
           title: Collection method
           default: automatic
@@ -19502,6 +19523,12 @@ components:
             set. This timestamp is used for alerting customers to reauthorize in 3
             years in accordance with NACHA rules. If a subscription becomes inactive
             or the billing info is no longer a bank account, this timestamp is cleared.
+        gateway_code:
+          type: string
+          title: Gateway Code
+          description: If present, this subscription's transactions will use the payment
+            gateway with this code.
+          maxLength: 13
         billing_info_id:
           type: string
           title: Billing Info ID
@@ -19956,6 +19983,13 @@ components:
           format: float
           title: Assigns the subscription's shipping cost. If this is greater than
             zero then a `method_id` or `method_code` is required.
+        address_id:
+          type: string
+          titpe: Shipping address ID
+          description: Assign a shipping address from the account's existing shipping
+            addresses. If this and address are both present, address will take precedence.
+        address:
+          "$ref": "#/components/schemas/ShippingAddressCreate"
     SubscriptionCreate:
       type: object
       properties:
@@ -20264,6 +20298,12 @@ components:
             at 31 days exactly.
           minimum: 0
           default: 0
+        gateway_code:
+          type: string
+          title: Gateway Code
+          description: If present, this subscription's transactions will use the payment
+            gateway with this code.
+          maxLength: 13
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"
         billing_info_id:

--- a/subscription.go
+++ b/subscription.go
@@ -97,6 +97,15 @@ type Subscription struct {
 	// Estimated total, before tax.
 	Subtotal float64 `json:"subtotal,omitempty"`
 
+	// Estimated tax
+	Tax float64 `json:"tax,omitempty"`
+
+	// Tax info
+	TaxInfo TaxInfo `json:"tax_info,omitempty"`
+
+	// Estimated total
+	Total float64 `json:"total,omitempty"`
+
 	// Collection method
 	CollectionMethod string `json:"collection_method,omitempty"`
 
@@ -135,6 +144,9 @@ type Subscription struct {
 
 	// Recurring subscriptions paid with ACH will have this attribute set. This timestamp is used for alerting customers to reauthorize in 3 years in accordance with NACHA rules. If a subscription becomes inactive or the billing info is no longer a bank account, this timestamp is cleared.
 	BankAccountAuthorizedAt time.Time `json:"bank_account_authorized_at,omitempty"`
+
+	// If present, this subscription's transactions will use the payment gateway with this code.
+	GatewayCode string `json:"gateway_code,omitempty"`
 
 	// Billing Info ID.
 	BillingInfoId string `json:"billing_info_id,omitempty"`

--- a/subscription_change_shipping_create.go
+++ b/subscription_change_shipping_create.go
@@ -16,4 +16,9 @@ type SubscriptionChangeShippingCreate struct {
 
 	// Assigns the subscription's shipping cost. If this is greater than zero then a `method_id` or `method_code` is required.
 	Amount *float64 `json:"amount,omitempty"`
+
+	// Assign a shipping address from the account's existing shipping addresses. If this and address are both present, address will take precedence.
+	AddressId *string `json:"address_id,omitempty"`
+
+	Address *ShippingAddressCreate `json:"address,omitempty"`
 }

--- a/subscription_update.go
+++ b/subscription_update.go
@@ -43,6 +43,9 @@ type SubscriptionUpdate struct {
 	// Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
 	NetTerms *int `json:"net_terms,omitempty"`
 
+	// If present, this subscription's transactions will use the payment gateway with this code.
+	GatewayCode *string `json:"gateway_code,omitempty"`
+
 	// Subscription shipping details
 	Shipping *SubscriptionShippingUpdate `json:"shipping,omitempty"`
 


### PR DESCRIPTION
Generated Latest Changes for v2021-02-25

SubscriptionCreate request format has changed:
* Added `gateway_code`.

SubscriptionUpdate request format has changed:
* Added `gateway_code`.

Subscription response format has changed:
* Added `gateway_code`.

SubscriptionChangeShippingCreate request format has changed:
* Added `address`.
* Added `address_id`.

Added tax information to `Subscription` response
* Added the fields `tax`, `tax_info` and `total`.

Updated the response for `POST /subscriptions/{subscription_id}/change`.
* Responding with `204 No Content` when the subscription has a pending change, and a change is submitted which matches the subscription as it currently exists.