### PR TITLE
Generated Latest Changes for v2019-10-10 (Account Hierarchy Invoice Rollup)

### DIFF
--- a/line_item.go
+++ b/line_item.go
@@ -50,6 +50,9 @@ type LineItem struct {
 	// Account mini details
 	Account AccountMini `json:"account,omitempty"`
 
+	// The UUID of the account responsible for originating the line item.
+	BillForAccountId string `json:"bill_for_account_id,omitempty"`
+
 	// If the line item is a charge or credit for a subscription, this is its ID.
 	SubscriptionId string `json:"subscription_id,omitempty"`
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -18279,6 +18279,12 @@ components:
           - carryforward
         account:
           "$ref": "#/components/schemas/AccountMini"
+        bill_for_account_id:
+          type: string
+          title: Bill For Account ID
+          maxLength: 13
+          description: The UUID of the account responsible for originating the line
+            item.
         subscription_id:
           type: string
           title: Subscription ID
@@ -21916,6 +21922,8 @@ components:
                 - batch_processing_error
                 - billing_agreement_already_accepted
                 - billing_agreement_not_accepted
+                - billing_agreement_not_found
+                - billing_agreement_replaced
                 - call_issuer
                 - call_issuer_update_cardholder_data
                 - cannot_refund_unsettled_transactions


### PR DESCRIPTION
Add `BillForAccountId` field -- the UUID of the account responsible for originating the line item -- to `LineItem` struct.