### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/billing_info_create.go
+++ b/billing_info_create.go
@@ -64,6 +64,24 @@ type BillingInfoCreate struct {
 	// The International Bank Account Number, up to 34 alphanumeric characters comprising a country code; two check digits; and a number that includes the domestic bank account number, branch identifier, and potential routing information
 	Iban *string `json:"iban,omitempty"`
 
+	// The name associated with the bank account (ACH, SEPA, Bacs only)
+	NameOnAccount *string `json:"name_on_account,omitempty"`
+
+	// The bank account number. (ACH, Bacs only)
+	AccountNumber *string `json:"account_number,omitempty"`
+
+	// The bank's rounting number. (ACH only)
+	RoutingNumber *string `json:"routing_number,omitempty"`
+
+	// Bank identifier code for UK based banks. Required for Bacs based billing infos. (Bacs only)
+	SortCode *string `json:"sort_code,omitempty"`
+
+	// The payment method type for a non-credit card based billing info. The value of `bacs` is the only accepted value (Bacs only)
+	Type *string `json:"type,omitempty"`
+
+	// The bank account type. (ACH only)
+	AccountType *string `json:"account_type,omitempty"`
+
 	// Tax identifier is required if adding a billing info that is a consumer card in Brazil or in Argentina. This would be the customer's CPF (Brazil) and CUIT (Argentina). CPF and CUIT are tax identifiers for all residents who pay taxes in Brazil and Argentina respectively.
 	TaxIdentifier *string `json:"tax_identifier,omitempty"`
 

--- a/line_item.go
+++ b/line_item.go
@@ -50,6 +50,9 @@ type LineItem struct {
 	// Account mini details
 	Account AccountMini `json:"account,omitempty"`
 
+	// The UUID of the account responsible for originating the line item.
+	BillForAccountId string `json:"bill_for_account_id,omitempty"`
+
 	// If the line item is a charge or credit for a subscription, this is its ID.
 	SubscriptionId string `json:"subscription_id,omitempty"`
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16345,6 +16345,28 @@ components:
             characters comprising a country code; two check digits; and a number that
             includes the domestic bank account number, branch identifier, and potential
             routing information
+        name_on_account:
+          type: string
+          maxLength: 255
+          description: The name associated with the bank account (ACH, SEPA, Bacs
+            only)
+        account_number:
+          type: string
+          maxLength: 255
+          description: The bank account number. (ACH, Bacs only)
+        routing_number:
+          type: string
+          maxLength: 15
+          description: The bank's rounting number. (ACH only)
+        sort_code:
+          type: string
+          maxLength: 15
+          description: Bank identifier code for UK based banks. Required for Bacs
+            based billing infos. (Bacs only)
+        type:
+          "$ref": "#/components/schemas/AchTypeEnum"
+        account_type:
+          "$ref": "#/components/schemas/AchAccountTypeEnum"
         tax_identifier:
           type: string
           description: Tax identifier is required if adding a billing info that is
@@ -17898,6 +17920,12 @@ components:
           "$ref": "#/components/schemas/LegacyCategoryEnum"
         account:
           "$ref": "#/components/schemas/AccountMini"
+        bill_for_account_id:
+          type: string
+          title: Bill For Account ID
+          maxLength: 13
+          description: The UUID of the account responsible for originating the line
+            item.
         subscription_id:
           type: string
           title: Subscription ID
@@ -21885,6 +21913,7 @@ components:
       - billing_agreement_already_accepted
       - billing_agreement_not_accepted
       - billing_agreement_not_found
+      - billing_agreement_replaced
       - call_issuer
       - call_issuer_update_cardholder_data
       - cancelled
@@ -22058,3 +22087,15 @@ components:
       - automatic
       - manual
       - trial
+    AchTypeEnum:
+      type: string
+      description: The payment method type for a non-credit card based billing info.
+        The value of `bacs` is the only accepted value (Bacs only)
+      enum:
+      - bacs
+    AchAccountTypeEnum:
+      type: string
+      description: The bank account type. (ACH only)
+      enum:
+      - checking
+      - savings


### PR DESCRIPTION
Support for Account Hierarchy Invoice Rollup:
- Add `BillForAccountId` field -- the UUID of the account responsible for originating the line item -- to `LineItem` struct.

BillingInfoCreate request format has changed:
- Added `name_on_account`
- Added `account_number`
- Added `routing_number`
- Added `sort_code`
- Added `type`
- Added `account_type`