### PR TITLE
Generated Latest Changes for v2019-10-10 (Tax Inclusive Pricing)

### DIFF
--- a/add_on_pricing.go
+++ b/add_on_pricing.go
@@ -17,6 +17,9 @@ type AddOnPricing struct {
 
 	// Unit price
 	UnitAmount float64 `json:"unit_amount,omitempty"`
+
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive bool `json:"tax_inclusive,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/add_on_pricing_create.go
+++ b/add_on_pricing_create.go
@@ -14,6 +14,9 @@ type AddOnPricingCreate struct {
 
 	// Unit price
 	UnitAmount *float64 `json:"unit_amount,omitempty"`
+
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive *bool `json:"tax_inclusive,omitempty"`
 }
 
 func (attr *AddOnPricingCreate) toParams() *Params {

--- a/invoice.go
+++ b/invoice.go
@@ -31,7 +31,7 @@ type Invoice struct {
 	// Account mini details
 	Account AccountMini `json:"account,omitempty"`
 
-	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
 	BillingInfoId string `json:"billing_info_id,omitempty"`
 
 	// If the invoice is charging or refunding for one or more subscriptions, these are their IDs.

--- a/invoice_collect.go
+++ b/invoice_collect.go
@@ -15,7 +15,7 @@ type InvoiceCollect struct {
 	// An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
 	TransactionType *string `json:"transaction_type,omitempty"`
 
-	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
 	BillingInfoId *string `json:"billing_info_id,omitempty"`
 }
 

--- a/line_item_create.go
+++ b/line_item_create.go
@@ -20,6 +20,9 @@ type LineItemCreate struct {
 	// `unit_amount`. If `item_code`/`item_id` is not present then `unit_amount` is required.
 	UnitAmount *float64 `json:"unit_amount,omitempty"`
 
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive *bool `json:"tax_inclusive,omitempty"`
+
 	// This number will be multiplied by the unit amount to compute the subtotal before any discounts or taxes.
 	Quantity *int `json:"quantity,omitempty"`
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -14525,7 +14525,8 @@ components:
     billing_info_id:
       name: billing_info_id
       in: path
-      description: Billing Info ID.
+      description: Billing Info ID. Can ONLY be used for sites utilizing the Wallet
+        feature.
       required: true
       schema:
         type: string
@@ -17683,7 +17684,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         subscription_ids:
           type: array
           title: Subscription IDs
@@ -17939,7 +17941,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
     InvoiceCollection:
       type: object
       title: Invoice collection
@@ -18551,6 +18554,13 @@ components:
             A positive or negative amount with `type=credit` will result in a negative `unit_amount`.
             If `item_code`/`item_id` is present, `unit_amount` can be passed in, to override the `Item`'s
             `unit_amount`. If `item_code`/`item_id` is not present then `unit_amount` is required.
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -19113,6 +19123,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
     PlanUpdate:
       type: object
       properties:
@@ -19274,6 +19291,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
       required:
       - currency
       - unit_amount
@@ -19291,6 +19315,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
       required:
       - currency
       - unit_amount
@@ -20248,6 +20279,13 @@ components:
           type: number
           format: float
           title: Unit amount
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Subscription quantity
@@ -20353,6 +20391,13 @@ components:
             be used.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20485,7 +20530,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         shipping:
           title: Shipping address
           description: Create a shipping address on the account and assign it to the
@@ -20512,6 +20558,13 @@ components:
             the subscription plan for the provided currency.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20649,6 +20702,13 @@ components:
             the subscription plan for the provided currency.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20792,6 +20852,13 @@ components:
             at 31 days exactly.
           minimum: 0
           default: 0
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"
         billing_info_id:
@@ -20800,7 +20867,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
     SubscriptionPause:
       type: object
       properties:
@@ -21469,7 +21537,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         collection_method:
           type: string
           title: Collection method

--- a/plan_pricing.go
+++ b/plan_pricing.go
@@ -20,6 +20,9 @@ type PlanPricing struct {
 
 	// Unit price
 	UnitAmount float64 `json:"unit_amount,omitempty"`
+
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive bool `json:"tax_inclusive,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/plan_pricing_create.go
+++ b/plan_pricing_create.go
@@ -17,6 +17,9 @@ type PlanPricingCreate struct {
 
 	// Unit price
 	UnitAmount *float64 `json:"unit_amount,omitempty"`
+
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive *bool `json:"tax_inclusive,omitempty"`
 }
 
 func (attr *PlanPricingCreate) toParams() *Params {

--- a/pricing.go
+++ b/pricing.go
@@ -17,6 +17,9 @@ type Pricing struct {
 
 	// Unit price
 	UnitAmount float64 `json:"unit_amount,omitempty"`
+
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive bool `json:"tax_inclusive,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/pricing_create.go
+++ b/pricing_create.go
@@ -14,6 +14,9 @@ type PricingCreate struct {
 
 	// Unit price
 	UnitAmount *float64 `json:"unit_amount,omitempty"`
+
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive *bool `json:"tax_inclusive,omitempty"`
 }
 
 func (attr *PricingCreate) toParams() *Params {

--- a/purchase_create.go
+++ b/purchase_create.go
@@ -14,7 +14,7 @@ type PurchaseCreate struct {
 
 	Account *AccountPurchase `json:"account,omitempty"`
 
-	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
 	BillingInfoId *string `json:"billing_info_id,omitempty"`
 
 	// Must be set to manual in order to preview a purchase for an Account that does not have payment information associated with the Billing Info.

--- a/subscription_change.go
+++ b/subscription_change.go
@@ -31,6 +31,9 @@ type SubscriptionChange struct {
 	// Unit amount
 	UnitAmount float64 `json:"unit_amount,omitempty"`
 
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive bool `json:"tax_inclusive,omitempty"`
+
 	// Subscription quantity
 	Quantity int `json:"quantity,omitempty"`
 

--- a/subscription_change_create.go
+++ b/subscription_change_create.go
@@ -21,6 +21,9 @@ type SubscriptionChangeCreate struct {
 	// Optionally, sets custom pricing for the subscription, overriding the plan's default unit amount. The subscription's current currency will be used.
 	UnitAmount *float64 `json:"unit_amount,omitempty"`
 
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive *bool `json:"tax_inclusive,omitempty"`
+
 	// Optionally override the default quantity of 1.
 	Quantity *int `json:"quantity,omitempty"`
 

--- a/subscription_change_preview.go
+++ b/subscription_change_preview.go
@@ -31,6 +31,9 @@ type SubscriptionChangePreview struct {
 	// Unit amount
 	UnitAmount float64 `json:"unit_amount,omitempty"`
 
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive bool `json:"tax_inclusive,omitempty"`
+
 	// Subscription quantity
 	Quantity int `json:"quantity,omitempty"`
 

--- a/subscription_create.go
+++ b/subscription_create.go
@@ -19,7 +19,7 @@ type SubscriptionCreate struct {
 
 	Account *AccountCreate `json:"account,omitempty"`
 
-	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
 	BillingInfoId *string `json:"billing_info_id,omitempty"`
 
 	// Create a shipping address on the account and assign it to the subscription.
@@ -33,6 +33,9 @@ type SubscriptionCreate struct {
 
 	// Override the unit amount of the subscription plan by setting this value. If not provided, the subscription will inherit the price from the subscription plan for the provided currency.
 	UnitAmount *float64 `json:"unit_amount,omitempty"`
+
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive *bool `json:"tax_inclusive,omitempty"`
 
 	// Optionally override the default quantity of 1.
 	Quantity *int `json:"quantity,omitempty"`

--- a/subscription_purchase.go
+++ b/subscription_purchase.go
@@ -20,6 +20,9 @@ type SubscriptionPurchase struct {
 	// Override the unit amount of the subscription plan by setting this value. If not provided, the subscription will inherit the price from the subscription plan for the provided currency.
 	UnitAmount *float64 `json:"unit_amount,omitempty"`
 
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive *bool `json:"tax_inclusive,omitempty"`
+
 	// Optionally override the default quantity of 1.
 	Quantity *int `json:"quantity,omitempty"`
 

--- a/subscription_update.go
+++ b/subscription_update.go
@@ -44,10 +44,13 @@ type SubscriptionUpdate struct {
 	// Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
 	NetTerms *int `json:"net_terms,omitempty"`
 
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive *bool `json:"tax_inclusive,omitempty"`
+
 	// Subscription shipping details
 	Shipping *SubscriptionShippingUpdate `json:"shipping,omitempty"`
 
-	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
 	BillingInfoId *string `json:"billing_info_id,omitempty"`
 }
 


### PR DESCRIPTION
Adds to description of `billing_info_id`.
Adds support for **Tax Inclusive Pricing** feature of Recurly API.

Adds `TaxInclusive` bool to the following:
- add_on_pricing
- add_on_pricing_create
- line_item_create
- plan_pricing
- plan_pricing_create
- pricing
- pricing_create
- purchase_create
- subscription_change
- subscription_change_create
- subscription_change_create_preview
- subscription_create
- subscription_purchase
- subscription_update