### PR TITLE
Generated Latest Changes for v2021-02-25 (Tax Inclusive Pricing)

### DIFF
--- a/add_on_pricing.go
+++ b/add_on_pricing.go
@@ -21,6 +21,9 @@ type AddOnPricing struct {
 	// Allows up to 9 decimal places. Only supported when `add_on_type` = `usage`.
 	// If `unit_amount_decimal` is provided, `unit_amount` cannot be provided.
 	UnitAmountDecimal string `json:"unit_amount_decimal,omitempty"`
+
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive bool `json:"tax_inclusive,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/add_on_pricing_create.go
+++ b/add_on_pricing_create.go
@@ -17,4 +17,7 @@ type AddOnPricingCreate struct {
 	// Allows up to 9 decimal places. Only supported when `add_on_type` = `usage`.
 	// If `unit_amount_decimal` is provided, `unit_amount` cannot be provided.
 	UnitAmountDecimal *string `json:"unit_amount_decimal,omitempty"`
+
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive *bool `json:"tax_inclusive,omitempty"`
 }

--- a/invoice.go
+++ b/invoice.go
@@ -31,7 +31,7 @@ type Invoice struct {
 	// Account mini details
 	Account AccountMini `json:"account,omitempty"`
 
-	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
 	BillingInfoId string `json:"billing_info_id,omitempty"`
 
 	// If the invoice is charging or refunding for one or more subscriptions, these are their IDs.

--- a/invoice_collect.go
+++ b/invoice_collect.go
@@ -14,6 +14,6 @@ type InvoiceCollect struct {
 	// An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
 	TransactionType *string `json:"transaction_type,omitempty"`
 
-	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
 	BillingInfoId *string `json:"billing_info_id,omitempty"`
 }

--- a/line_item_create.go
+++ b/line_item_create.go
@@ -19,6 +19,9 @@ type LineItemCreate struct {
 	// `Item`'s `unit_amount`. If `item_code`/`item_id` is not present then `unit_amount` is required.
 	UnitAmount *float64 `json:"unit_amount,omitempty"`
 
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive *bool `json:"tax_inclusive,omitempty"`
+
 	// This number will be multiplied by the unit amount to compute the subtotal before any discounts or taxes.
 	Quantity *int `json:"quantity,omitempty"`
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -14579,7 +14579,8 @@ components:
     billing_info_id:
       name: billing_info_id
       in: path
-      description: Billing Info ID.
+      description: Billing Info ID. Can ONLY be used for sites utilizing the Wallet
+        feature.
       required: true
       schema:
         type: string
@@ -17377,7 +17378,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         subscription_ids:
           type: array
           title: Subscription IDs
@@ -17634,7 +17636,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
     InvoiceCollection:
       type: object
       title: Invoice collection
@@ -18178,6 +18181,13 @@ components:
             A positive or negative amount with `type=credit` will result in a negative `unit_amount`.
             If `item_code`/`item_id` is present, `unit_amount` can be passed in, to override the
             `Item`'s `unit_amount`. If `item_code`/`item_id` is not present then `unit_amount` is required.
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -18691,6 +18701,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
     PlanUpdate:
       type: object
       properties:
@@ -18849,6 +18866,13 @@ components:
           description: |
             Allows up to 9 decimal places. Only supported when `add_on_type` = `usage`.
             If `unit_amount_decimal` is provided, `unit_amount` cannot be provided.
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
       required:
       - currency
     TierPricing:
@@ -18891,6 +18915,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
       required:
       - currency
       - unit_amount
@@ -19828,6 +19859,13 @@ components:
           type: number
           format: float
           title: Unit amount
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Subscription quantity
@@ -19915,6 +19953,13 @@ components:
             be used.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20043,7 +20088,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         shipping:
           title: Shipping address
           description: Create a shipping address on the account and assign it to the
@@ -20067,6 +20113,13 @@ components:
             the subscription plan for the provided currency.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20198,6 +20251,13 @@ components:
             the subscription plan for the provided currency.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20334,6 +20394,13 @@ components:
           description: If present, this subscription's transactions will use the payment
             gateway with this code.
           maxLength: 13
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"
         billing_info_id:
@@ -20342,7 +20409,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
     SubscriptionPause:
       type: object
       properties:
@@ -20940,7 +21008,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         collection_method:
           title: Collection method
           description: Must be set to manual in order to preview a purchase for an
@@ -22017,6 +22086,7 @@ components:
       - three_d_secure_action_result_token_mismatch
       - three_d_secure_authentication
       - three_d_secure_connection_error
+      - three_d_secure_credential_error
       - three_d_secure_not_supported
       - too_many_attempts
       - total_credit_exceeds_capture

--- a/plan_pricing.go
+++ b/plan_pricing.go
@@ -20,6 +20,9 @@ type PlanPricing struct {
 
 	// Unit price
 	UnitAmount float64 `json:"unit_amount,omitempty"`
+
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive bool `json:"tax_inclusive,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/plan_pricing_create.go
+++ b/plan_pricing_create.go
@@ -16,4 +16,7 @@ type PlanPricingCreate struct {
 
 	// Unit price
 	UnitAmount *float64 `json:"unit_amount,omitempty"`
+
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive *bool `json:"tax_inclusive,omitempty"`
 }

--- a/pricing.go
+++ b/pricing.go
@@ -17,6 +17,9 @@ type Pricing struct {
 
 	// Unit price
 	UnitAmount float64 `json:"unit_amount,omitempty"`
+
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive bool `json:"tax_inclusive,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/pricing_create.go
+++ b/pricing_create.go
@@ -13,4 +13,7 @@ type PricingCreate struct {
 
 	// Unit price
 	UnitAmount *float64 `json:"unit_amount,omitempty"`
+
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive *bool `json:"tax_inclusive,omitempty"`
 }

--- a/purchase_create.go
+++ b/purchase_create.go
@@ -13,7 +13,7 @@ type PurchaseCreate struct {
 
 	Account *AccountPurchase `json:"account,omitempty"`
 
-	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
 	BillingInfoId *string `json:"billing_info_id,omitempty"`
 
 	// Must be set to manual in order to preview a purchase for an Account that does not have payment information associated with the Billing Info.

--- a/subscription_change.go
+++ b/subscription_change.go
@@ -31,6 +31,9 @@ type SubscriptionChange struct {
 	// Unit amount
 	UnitAmount float64 `json:"unit_amount,omitempty"`
 
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive bool `json:"tax_inclusive,omitempty"`
+
 	// Subscription quantity
 	Quantity int `json:"quantity,omitempty"`
 

--- a/subscription_change_create.go
+++ b/subscription_change_create.go
@@ -20,6 +20,9 @@ type SubscriptionChangeCreate struct {
 	// Optionally, sets custom pricing for the subscription, overriding the plan's default unit amount. The subscription's current currency will be used.
 	UnitAmount *float64 `json:"unit_amount,omitempty"`
 
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive *bool `json:"tax_inclusive,omitempty"`
+
 	// Optionally override the default quantity of 1.
 	Quantity *int `json:"quantity,omitempty"`
 

--- a/subscription_create.go
+++ b/subscription_create.go
@@ -18,7 +18,7 @@ type SubscriptionCreate struct {
 
 	Account *AccountCreate `json:"account,omitempty"`
 
-	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
 	BillingInfoId *string `json:"billing_info_id,omitempty"`
 
 	// Create a shipping address on the account and assign it to the subscription.
@@ -32,6 +32,9 @@ type SubscriptionCreate struct {
 
 	// Override the unit amount of the subscription plan by setting this value. If not provided, the subscription will inherit the price from the subscription plan for the provided currency.
 	UnitAmount *float64 `json:"unit_amount,omitempty"`
+
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive *bool `json:"tax_inclusive,omitempty"`
 
 	// Optionally override the default quantity of 1.
 	Quantity *int `json:"quantity,omitempty"`

--- a/subscription_purchase.go
+++ b/subscription_purchase.go
@@ -19,6 +19,9 @@ type SubscriptionPurchase struct {
 	// Override the unit amount of the subscription plan by setting this value. If not provided, the subscription will inherit the price from the subscription plan for the provided currency.
 	UnitAmount *float64 `json:"unit_amount,omitempty"`
 
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive *bool `json:"tax_inclusive,omitempty"`
+
 	// Optionally override the default quantity of 1.
 	Quantity *int `json:"quantity,omitempty"`
 

--- a/subscription_update.go
+++ b/subscription_update.go
@@ -46,9 +46,12 @@ type SubscriptionUpdate struct {
 	// If present, this subscription's transactions will use the payment gateway with this code.
 	GatewayCode *string `json:"gateway_code,omitempty"`
 
+	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+	TaxInclusive *bool `json:"tax_inclusive,omitempty"`
+
 	// Subscription shipping details
 	Shipping *SubscriptionShippingUpdate `json:"shipping,omitempty"`
 
-	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+	// The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
 	BillingInfoId *string `json:"billing_info_id,omitempty"`
 }


### PR DESCRIPTION
Adds to description of `billing_info_id`.
Adds support for **Tax Inclusive Pricing** feature of Recurly API.

Adds `TaxInclusive` bool to the following:
- add_on_pricing
- add_on_pricing_create
- line_item_create
- plan_pricing
- plan_pricing_create
- pricing
- pricing_create
- purchase_create
- subscription_change
- subscription_change_create
- subscription_change_create_preview
- subscription_create
- subscription_purchase
- subscription_update