### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/account.go
+++ b/account.go
@@ -99,6 +99,9 @@ type Account struct {
 
 	// The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
 	CustomFields []CustomField `json:"custom_fields,omitempty"`
+
+	// Invoice template associated to the account. Available when invoice customization flag is enabled.
+	InvoiceTemplate AccountInvoiceTemplate `json:"invoice_template,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/account_invoice_template.go
+++ b/account_invoice_template.go
@@ -1,0 +1,122 @@
+// This file is automatically created by Recurly's OpenAPI generation process
+// and thus any edits you make by hand will be lost. If you wish to make a
+// change to this file, please create a Github issue explaining the changes you
+// need and we will usher them to the appropriate places.
+package recurly
+
+import (
+	"context"
+	"net/http"
+)
+
+type AccountInvoiceTemplate struct {
+	recurlyResponse *ResponseMetadata
+
+	// Unique ID to identify the invoice template.
+	Id string `json:"id,omitempty"`
+
+	// Template name
+	Name string `json:"name,omitempty"`
+}
+
+// GetResponse returns the ResponseMetadata that generated this resource
+func (resource *AccountInvoiceTemplate) GetResponse() *ResponseMetadata {
+	return resource.recurlyResponse
+}
+
+// setResponse sets the ResponseMetadata that generated this resource
+func (resource *AccountInvoiceTemplate) setResponse(res *ResponseMetadata) {
+	resource.recurlyResponse = res
+}
+
+// internal struct for deserializing accounts
+type accountInvoiceTemplateList struct {
+	ListMetadata
+	Data            []AccountInvoiceTemplate `json:"data"`
+	recurlyResponse *ResponseMetadata
+}
+
+// GetResponse returns the ResponseMetadata that generated this resource
+func (resource *accountInvoiceTemplateList) GetResponse() *ResponseMetadata {
+	return resource.recurlyResponse
+}
+
+// setResponse sets the ResponseMetadata that generated this resource
+func (resource *accountInvoiceTemplateList) setResponse(res *ResponseMetadata) {
+	resource.recurlyResponse = res
+}
+
+// AccountInvoiceTemplateList allows you to paginate AccountInvoiceTemplate objects
+type AccountInvoiceTemplateList struct {
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
+	hasMore        bool
+	data           []AccountInvoiceTemplate
+}
+
+func NewAccountInvoiceTemplateList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *AccountInvoiceTemplateList {
+	return &AccountInvoiceTemplateList{
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		hasMore:        true,
+	}
+}
+
+type AccountInvoiceTemplateLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []AccountInvoiceTemplate
+	HasMore() bool
+	Next() string
+}
+
+func (list *AccountInvoiceTemplateList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *AccountInvoiceTemplateList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *AccountInvoiceTemplateList) Data() []AccountInvoiceTemplate {
+	return list.data
+}
+
+// Fetch fetches the next page of data into the `Data` property
+func (list *AccountInvoiceTemplateList) FetchWithContext(ctx context.Context) error {
+	resources := &accountInvoiceTemplateList{}
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
+	if err != nil {
+		return err
+	}
+	// copy over properties from the response
+	list.nextPagePath = resources.Next
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
+	return nil
+}
+
+// Fetch fetches the next page of data into the `Data` property
+func (list *AccountInvoiceTemplateList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *AccountInvoiceTemplateList) CountWithContext(ctx context.Context) (*int64, error) {
+	resources := &accountInvoiceTemplateList{}
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
+	if err != nil {
+		return nil, err
+	}
+	resp := resources.GetResponse()
+	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *AccountInvoiceTemplateList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
+}

--- a/add_on_create.go
+++ b/add_on_create.go
@@ -8,10 +8,10 @@ import ()
 
 type AddOnCreate struct {
 
-	// Unique code to identify an item. Available when the `Credit Invoices` and `Subscription Billing Terms` features are enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
+	// Unique code to identify an item. Available when the `Credit Invoices` feature are enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
 	ItemCode *string `json:"item_code,omitempty"`
 
-	// System-generated unique identifier for an item. Available when the `Credit Invoices` and `Subscription Billing Terms` features are enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
+	// System-generated unique identifier for an item. Available when the `Credit Invoices` feature is enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
 	ItemId *string `json:"item_id,omitempty"`
 
 	// The unique identifier for the add-on within its plan. If `item_code`/`item_id` is part of the request then `code` must be absent. If `item_code`/`item_id` is not present `code` is required.

--- a/billing_info_create.go
+++ b/billing_info_create.go
@@ -76,7 +76,7 @@ type BillingInfoCreate struct {
 	// Bank identifier code for UK based banks. Required for Bacs based billing infos. (Bacs only)
 	SortCode *string `json:"sort_code,omitempty"`
 
-	// The payment method type for a non-credit card based billing info. The value of `bacs` is the only accepted value (Bacs only)
+	// The payment method type for a non-credit card based billing info. `bacs` and `becs` are the only accepted values.
 	Type *string `json:"type,omitempty"`
 
 	// The bank account type. (ACH only)

--- a/line_item.go
+++ b/line_item.go
@@ -25,13 +25,13 @@ type LineItem struct {
 	// Charges are positive line items that debit the account. Credits are negative line items that credit the account.
 	Type string `json:"type,omitempty"`
 
-	// Unique code to identify an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
+	// Unique code to identify an item. Available when the Credit Invoices feature is enabled.
 	ItemCode string `json:"item_code,omitempty"`
 
-	// System-generated unique identifier for an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
+	// System-generated unique identifier for an item. Available when the Credit Invoices feature is enabled.
 	ItemId string `json:"item_id,omitempty"`
 
-	// Optional Stock Keeping Unit assigned to an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
+	// Optional Stock Keeping Unit assigned to an item. Available when the Credit Invoices feature is enabled.
 	ExternalSku string `json:"external_sku,omitempty"`
 
 	// Revenue schedule type

--- a/line_item_create.go
+++ b/line_item_create.go
@@ -28,10 +28,10 @@ type LineItemCreate struct {
 	// Description that appears on the invoice. If `item_code`/`item_id` is part of the request then `description` must be absent.
 	Description *string `json:"description,omitempty"`
 
-	// Unique code to identify an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
+	// Unique code to identify an item. Available when the Credit Invoices feature is enabled.
 	ItemCode *string `json:"item_code,omitempty"`
 
-	// System-generated unique identifier for an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
+	// System-generated unique identifier for an item. Available when the Credit Invoices feature is enabled.
 	ItemId *string `json:"item_id,omitempty"`
 
 	// Revenue schedule type

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -232,7 +232,7 @@ tags:
   description: |-
     For merchants who sell the same things to many customers, documenting those offerings in a catalog allows for faster charge creation, easier management of offerings, and analytics about your offerings across all sales channels. Because your offerings can be physical, digital, or service-oriented, Recurly collectively calls these offerings "Items".
 
-    Recurly's item catalog requires the Credit Invoices and Subscription Billing Terms features to be enabled.
+    Recurly's item catalog requires the Credit Invoices features to be enabled.
 - name: plan
   x-displayName: Plan
   description: A plan tells Recurly how often and how much to charge your customers.
@@ -15540,6 +15540,8 @@ components:
           "$ref": "#/components/schemas/BillingInfo"
         custom_fields:
           "$ref": "#/components/schemas/CustomFields"
+        invoice_template:
+          "$ref": "#/components/schemas/AccountInvoiceTemplate"
     AccountNote:
       type: object
       required:
@@ -15636,6 +15638,20 @@ components:
           format: float
           title: Amount
           description: Total amount the account is past due.
+    AccountInvoiceTemplate:
+      type: object
+      title: Invoice Template
+      description: Invoice template associated to the account. Available when invoice
+        customization flag is enabled.
+      properties:
+        id:
+          type: string
+          title: ID
+          description: Unique ID to identify the invoice template.
+        name:
+          type: string
+          title: Name
+          description: Template name
     InvoiceAddress:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -15900,16 +15916,16 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the `Credit
-            Invoices` and `Subscription Billing Terms` features are enabled. If `item_id`
-            and `item_code` are both present, `item_id` will be used.
+            Invoices` feature are enabled. If `item_id` and `item_code` are both present,
+            `item_id` will be used.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
         item_id:
           type: string
           title: Item ID
           description: System-generated unique identifier for an item. Available when
-            the `Credit Invoices` and `Subscription Billing Terms` features are enabled.
-            If `item_id` and `item_code` are both present, `item_id` will be used.
+            the `Credit Invoices` feature is enabled. If `item_id` and `item_code`
+            are both present, `item_id` will be used.
           maxLength: 13
         code:
           type: string
@@ -17888,20 +17904,20 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the Credit
-            Invoices and Subscription Billing Terms features are enabled.
+            Invoices feature is enabled.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
         item_id:
           type: string
           title: Item ID
           description: System-generated unique identifier for an item. Available when
-            the Credit Invoices and Subscription Billing Terms features are enabled.
+            the Credit Invoices feature is enabled.
           maxLength: 13
         external_sku:
           type: string
           title: External SKU
           description: Optional Stock Keeping Unit assigned to an item. Available
-            when the Credit Invoices and Subscription Billing Terms features are enabled.
+            when the Credit Invoices feature is enabled.
           maxLength: 50
         revenue_schedule_type:
           title: Revenue schedule type
@@ -18204,14 +18220,14 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the Credit
-            Invoices and Subscription Billing Terms features are enabled.
+            Invoices feature is enabled.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
         item_id:
           type: string
           title: Item ID
           description: System-generated unique identifier for an item. Available when
-            the Credit Invoices and Subscription Billing Terms features are enabled.
+            the Credit Invoices feature is enabled.
           maxLength: 13
         revenue_schedule_type:
           title: Revenue schedule type
@@ -22160,9 +22176,10 @@ components:
     AchTypeEnum:
       type: string
       description: The payment method type for a non-credit card based billing info.
-        The value of `bacs` is the only accepted value (Bacs only)
+        `bacs` and `becs` are the only accepted values.
       enum:
       - bacs
+      - becs
     AchAccountTypeEnum:
       type: string
       description: The bank account type. (ACH only)

--- a/scripts/clean
+++ b/scripts/clean
@@ -11,6 +11,7 @@ rm -f payment_method.go
 rm -f fraud_info.go
 rm -f billing_info_updated_by.go
 rm -f custom_field.go
+rm -f account_invoice_template.go
 rm -f error_may_have_transaction.go
 rm -f account_acquisition.go
 rm -f account_acquisition_cost.go


### PR DESCRIPTION
Support `becs` as a payment method type for non-credit card based billing info.
- Added `becs` as a valid non-credit card payment method type.

Support `invoice_template` in account when invoice customization feature is enabled.
- Added `invoice_template` to Account.

Updated documentation for the removal of the `Subscription Billing Terms` feature flag as the feature is now fully accessible on all sites.