### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -19999,6 +19999,13 @@ components:
           type: string
           title: Billing Info ID
           description: Billing Info ID.
+        active_invoice_id:
+          type: string
+          title: Active invoice ID
+          description: The invoice ID of the latest invoice created for an active
+            subscription.
+          maxLength: 13
+          readOnly: true
     SubscriptionAddOn:
       type: object
       title: Subscription Add-on

--- a/subscription.go
+++ b/subscription.go
@@ -138,6 +138,9 @@ type Subscription struct {
 
 	// Billing Info ID.
 	BillingInfoId string `json:"billing_info_id,omitempty"`
+
+	// The invoice ID of the latest invoice created for an active subscription.
+	ActiveInvoiceId string `json:"active_invoice_id,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource


### PR DESCRIPTION
Adds `active_invoice_id` to `subscription` response. It contains the invoice ID of the latest invoice created for an active subscription. It is `null` if the subscription is `future` or `expired`.