### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/add_on.go
+++ b/add_on.go
@@ -79,6 +79,9 @@ type AddOn struct {
 	// to configure quantity-based pricing models.
 	TierType string `json:"tier_type,omitempty"`
 
+	// The time at which usage totals are reset for billing purposes.
+	UsageTimeframe string `json:"usage_timeframe,omitempty"`
+
 	// Tiers
 	Tiers []Tier `json:"tiers,omitempty"`
 

--- a/add_on_create.go
+++ b/add_on_create.go
@@ -79,6 +79,11 @@ type AddOnCreate struct {
 	// to configure quantity-based pricing models.
 	TierType *string `json:"tier_type,omitempty"`
 
+	// The time at which usage totals are reset for billing purposes.
+	// Allows for `tiered` add-ons to accumulate usage over the course of multiple
+	// billing periods.
+	UsageTimeframe *string `json:"usage_timeframe,omitempty"`
+
 	// If the tier_type is `flat`, then `tiers` must be absent. The `tiers` object
 	// must include one to many tiers with `ending_quantity` and `unit_amount` for
 	// the desired `currencies`. There must be one tier without an `ending_quantity` value

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16265,6 +16265,8 @@ components:
           readOnly: true
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeEnum"
         tiers:
           type: array
           title: Tiers
@@ -16443,6 +16445,8 @@ components:
             * Must be absent if `add_on_type` is `usage` and `usage_type` is `percentage`.
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeCreateEnum"
         tiers:
           type: array
           title: Tiers
@@ -20059,6 +20063,13 @@ components:
           type: string
           title: Billing Info ID
           description: Billing Info ID.
+        active_invoice_id:
+          type: string
+          title: Active invoice ID
+          description: The invoice ID of the latest invoice created for an active
+            subscription.
+          maxLength: 13
+          readOnly: true
     SubscriptionAddOn:
       type: object
       title: Subscription Add-on
@@ -20098,6 +20109,8 @@ components:
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeEnum"
         tiers:
           type: array
           title: Tiers
@@ -22176,6 +22189,25 @@ components:
       - tiered
       - stairstep
       - volume
+    UsageTimeframeEnum:
+      type: string
+      title: Usage Timeframe
+      description: The time at which usage totals are reset for billing purposes.
+      enum:
+      - billing_period
+      - subscription_term
+      default: billing_period
+    UsageTimeframeCreateEnum:
+      type: string
+      title: Usage Timeframe
+      description: |
+        The time at which usage totals are reset for billing purposes.
+        Allows for `tiered` add-ons to accumulate usage over the course of multiple
+        billing periods.
+      enum:
+      - billing_period
+      - subscription_term
+      default: billing_period
     CreditPaymentActionEnum:
       type: string
       enum:

--- a/subscription.go
+++ b/subscription.go
@@ -150,6 +150,9 @@ type Subscription struct {
 
 	// Billing Info ID.
 	BillingInfoId string `json:"billing_info_id,omitempty"`
+
+	// The invoice ID of the latest invoice created for an active subscription.
+	ActiveInvoiceId string `json:"active_invoice_id,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/subscription_add_on.go
+++ b/subscription_add_on.go
@@ -49,6 +49,9 @@ type SubscriptionAddOn struct {
 	// to configure quantity-based pricing models.
 	TierType string `json:"tier_type,omitempty"`
 
+	// The time at which usage totals are reset for billing purposes.
+	UsageTimeframe string `json:"usage_timeframe,omitempty"`
+
 	// If tiers are provided in the request, all existing tiers on the Subscription Add-on will be
 	// removed and replaced by the tiers in the request. If add_on.tier_type is tiered or volume and
 	// add_on.usage_type is percentage use percentage_tiers instead.


### PR DESCRIPTION
Adds `active_invoice_id` to `subscription` response. It contains the invoice ID of the latest invoice created for an active subscription. It is `null` if the subscription is `future` or `expired`.

Adds `usage_timeframe` to the add-on create request and responses. It represents the time at which usage totals are reset for billing purposes. Allows for `tiered` add-ons to accumulate usage over the course of multiple billing periods.  The valid values are `billing_period` or `subscription_term` with `billing_period` being the default value.