### PR TITLE
Generated Latest Changes for v2022-01-01(Ramp Pricing)

### DIFF
--- a/account.go
+++ b/account.go
@@ -93,7 +93,7 @@ type Account struct {
 	// Unique ID to identify a dunning campaign. Used to specify if a non-default dunning campaign should be assigned to this account. For sites without multiple dunning campaigns enabled, the default dunning campaign will always be used.
 	DunningCampaignId string `json:"dunning_campaign_id,omitempty"`
 
-	// Unique ID to identify an invoice template. Available when the Invoice Customization feature is enabled. Used to specify if a non-default invoice template will be used to generate invoices for the account. For sites without multiple invoice templates enabled, the default template will always be used.
+	// Unique ID to identify an invoice template. Available when the site is on a Pro or Enterprise plan. Used to specify if a non-default invoice template will be used to generate invoices for the account. For sites without multiple invoice templates enabled, the default template will always be used.
 	InvoiceTemplateId string `json:"invoice_template_id,omitempty"`
 
 	Address Address `json:"address,omitempty"`

--- a/account_create.go
+++ b/account_create.go
@@ -57,7 +57,7 @@ type AccountCreate struct {
 	// Unique ID to identify a dunning campaign. Used to specify if a non-default dunning campaign should be assigned to this account. For sites without multiple dunning campaigns enabled, the default dunning campaign will always be used.
 	DunningCampaignId *string `json:"dunning_campaign_id,omitempty"`
 
-	// Unique ID to identify an invoice template.  Available when the Invoice Customization feature is enabled.  Used to specify which invoice template, if any, should be used to generate invoices for the account.
+	// Unique ID to identify an invoice template.  Available when the site is on a Pro or Enterprise plan.  Used to specify which invoice template, if any, should be used to generate invoices for the account.
 	InvoiceTemplateId *string `json:"invoice_template_id,omitempty"`
 
 	Address *AddressCreate `json:"address,omitempty"`

--- a/account_purchase.go
+++ b/account_purchase.go
@@ -58,7 +58,7 @@ type AccountPurchase struct {
 	// Unique ID to identify a dunning campaign. Used to specify if a non-default dunning campaign should be assigned to this account. For sites without multiple dunning campaigns enabled, the default dunning campaign will always be used.
 	DunningCampaignId *string `json:"dunning_campaign_id,omitempty"`
 
-	// Unique ID to identify an invoice template.  Available when the Invoice Customization feature is enabled.  Used to specify which invoice template, if any, should be used to generate invoices for the account.
+	// Unique ID to identify an invoice template.  Available when the site is on a Pro or Enterprise plan.  Used to specify which invoice template, if any, should be used to generate invoices for the account.
 	InvoiceTemplateId *string `json:"invoice_template_id,omitempty"`
 
 	Address *AddressCreate `json:"address,omitempty"`

--- a/account_update.go
+++ b/account_update.go
@@ -50,7 +50,7 @@ type AccountUpdate struct {
 	// Unique ID to identify a dunning campaign. Used to specify if a non-default dunning campaign should be assigned to this account. For sites without multiple dunning campaigns enabled, the default dunning campaign will always be used.
 	DunningCampaignId *string `json:"dunning_campaign_id,omitempty"`
 
-	// Unique ID to identify an invoice template.  Available when the Invoice Customization feature is enabled.  Used to specify which invoice template, if any, should be used to generate invoices for the account.
+	// Unique ID to identify an invoice template.  Available when the site is on a Pro or Enterprise plan.  Used to specify which invoice template, if any, should be used to generate invoices for the account.
 	InvoiceTemplateId *string `json:"invoice_template_id,omitempty"`
 
 	Address *AddressCreate `json:"address,omitempty"`

--- a/add_on.go
+++ b/add_on.go
@@ -79,6 +79,9 @@ type AddOn struct {
 	// to configure quantity-based pricing models.
 	TierType string `json:"tier_type,omitempty"`
 
+	// The time at which usage totals are reset for billing purposes.
+	UsageTimeframe string `json:"usage_timeframe,omitempty"`
+
 	// Tiers
 	Tiers []Tier `json:"tiers,omitempty"`
 

--- a/add_on_create.go
+++ b/add_on_create.go
@@ -79,14 +79,20 @@ type AddOnCreate struct {
 	// to configure quantity-based pricing models.
 	TierType *string `json:"tier_type,omitempty"`
 
+	// The time at which usage totals are reset for billing purposes.
+	// Allows for `tiered` add-ons to accumulate usage over the course of multiple
+	// billing periods.
+	UsageTimeframe *string `json:"usage_timeframe,omitempty"`
+
 	// If the tier_type is `flat`, then `tiers` must be absent. The `tiers` object
 	// must include one to many tiers with `ending_quantity` and `unit_amount` for
-	// the desired `currencies`. There must be one tier with an `ending_quantity`
-	// of 999999999 which is the default if not provided.
+	// the desired `currencies`. There must be one tier without an `ending_quantity` value
+	// which represents the final tier.
 	Tiers []TierCreate `json:"tiers,omitempty"`
 
 	// Array of objects which must have at least one set of tiers
 	// per currency and the currency code. The tier_type must be `volume` or `tiered`,
-	// if not, it must be absent. There must be one tier without ending_amount value.
+	// if not, it must be absent. There must be one tier without an `ending_amount` value
+	// which represents the final tier.
 	PercentageTiers []PercentageTiersByCurrencyCreate `json:"percentage_tiers,omitempty"`
 }

--- a/add_on_pricing.go
+++ b/add_on_pricing.go
@@ -21,9 +21,6 @@ type AddOnPricing struct {
 	// Allows up to 9 decimal places. Only supported when `add_on_type` = `usage`.
 	// If `unit_amount_decimal` is provided, `unit_amount` cannot be provided.
 	UnitAmountDecimal string `json:"unit_amount_decimal,omitempty"`
-
-	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-	TaxInclusive bool `json:"tax_inclusive,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/add_on_update.go
+++ b/add_on_update.go
@@ -58,11 +58,12 @@ type AddOnUpdate struct {
 	// If the tier_type is `flat`, then `tiers` must be absent. The `tiers` object
 	// must include one to many tiers with `ending_quantity` and `unit_amount` for
 	// the desired `currencies`. There must be one tier without an `ending_quantity` value
-	// that represents the final tier.
+	// which represents the final tier.
 	Tiers []TierCreate `json:"tiers,omitempty"`
 
 	// `percentage_tiers` is an array of objects, which must have the set of tiers
 	// per currency and the currency code. The tier_type must be `volume` or `tiered`,
-	// if not, it must be absent.
+	// if not, it must be absent. There must be one tier without an `ending_amount` value
+	// which represents the final tier.
 	PercentageTiers []PercentageTiersByCurrencyCreate `json:"percentage_tiers,omitempty"`
 }

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -6378,7 +6378,7 @@ components:
           type: string
           title: Invoice Template ID
           description: Unique ID to identify an invoice template.  Available when
-            the Invoice Customization feature is enabled.  Used to specify which invoice
+            the site is on a Pro or Enterprise plan.  Used to specify which invoice
             template, if any, should be used to generate invoices for the account.
         address:
           "$ref": "#/components/schemas/Address"
@@ -6461,7 +6461,7 @@ components:
           type: string
           title: Invoice Template ID
           description: Unique ID to identify an invoice template. Available when the
-            Invoice Customization feature is enabled. Used to specify if a non-default
+            site is on a Pro or Enterprise plan. Used to specify if a non-default
             invoice template will be used to generate invoices for the account. For
             sites without multiple invoice templates enabled, the default template
             will always be used.
@@ -6791,6 +6791,8 @@ components:
           readOnly: true
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeEnum"
         tiers:
           type: array
           title: Tiers
@@ -6968,6 +6970,8 @@ components:
             * Must be absent if `add_on_type` is `usage` and `usage_type` is `percentage`.
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeCreateEnum"
         tiers:
           type: array
           title: Tiers
@@ -6976,8 +6980,8 @@ components:
           description: |
             If the tier_type is `flat`, then `tiers` must be absent. The `tiers` object
             must include one to many tiers with `ending_quantity` and `unit_amount` for
-            the desired `currencies`. There must be one tier with an `ending_quantity`
-            of 999999999 which is the default if not provided.
+            the desired `currencies`. There must be one tier without an `ending_quantity` value
+            which represents the final tier.
         percentage_tiers:
           type: array
           title: Percentage Tiers By Currency
@@ -6986,7 +6990,8 @@ components:
           description: |
             Array of objects which must have at least one set of tiers
             per currency and the currency code. The tier_type must be `volume` or `tiered`,
-            if not, it must be absent. There must be one tier without ending_amount value.
+            if not, it must be absent. There must be one tier without an `ending_amount` value
+            which represents the final tier.
       required:
       - code
       - name
@@ -7114,7 +7119,7 @@ components:
             If the tier_type is `flat`, then `tiers` must be absent. The `tiers` object
             must include one to many tiers with `ending_quantity` and `unit_amount` for
             the desired `currencies`. There must be one tier without an `ending_quantity` value
-            that represents the final tier.
+            which represents the final tier.
         percentage_tiers:
           type: array
           title: Percentage Tiers By Currency
@@ -7123,7 +7128,8 @@ components:
           description: |
             `percentage_tiers` is an array of objects, which must have the set of tiers
             per currency and the currency code. The tier_type must be `volume` or `tiered`,
-            if not, it must be absent.
+            if not, it must be absent. There must be one tier without an `ending_amount` value
+            which represents the final tier.
     BillingInfo:
       type: object
       properties:
@@ -9372,6 +9378,14 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        pricing_model:
+          title: Pricing Model
+          "$ref": "#/components/schemas/PricingModelTypeEnum"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -9534,6 +9548,14 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        pricing_model:
+          title: Pricing Model
+          "$ref": "#/components/schemas/PricingModelTypeEnum"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -9655,15 +9677,22 @@ components:
           type: number
           format: float
           title: Unit price
+          description: This field should not be sent when the pricing model is 'ramp'.
           minimum: 0
           maximum: 1000000
-        tax_inclusive:
-          type: boolean
-          title: Tax Inclusive?
-          default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+    PlanRampInterval:
+      type: object
+      title: Plan Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents the first billing cycle of a ramp.
+          default: 1
+        currencies:
+          type: array
+          description: Represents the price for the ramp interval.
+          items:
+            "$ref": "#/components/schemas/PlanRampPricing"
     PlanUpdate:
       type: object
       properties:
@@ -9730,6 +9759,11 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -9776,6 +9810,7 @@ components:
         currencies:
           type: array
           title: Pricing
+          description: Optional when the pricing model is 'ramp'.
           items:
             "$ref": "#/components/schemas/PlanPricing"
           minItems: 1
@@ -9821,13 +9856,6 @@ components:
           description: |
             Allows up to 9 decimal places. Only supported when `add_on_type` = `usage`.
             If `unit_amount_decimal` is provided, `unit_amount` cannot be provided.
-        tax_inclusive:
-          type: boolean
-          title: Tax Inclusive?
-          default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
       required:
       - currency
     TierPricing:
@@ -9856,6 +9884,24 @@ components:
             If `unit_amount_decimal` is provided, `unit_amount` cannot be provided.
       required:
       - currency
+    PlanRampPricing:
+      type: object
+      properties:
+        currency:
+          type: string
+          title: Currency
+          description: 3-letter ISO 4217 currency code.
+          maxLength: 3
+        unit_amount:
+          type: number
+          format: float
+          title: Unit price
+          description: Represents the price for the Ramp Interval.
+          minimum: 0
+          maximum: 1000000
+      required:
+      - currency
+      - unit_amount
     Pricing:
       type: object
       properties:
@@ -9870,13 +9916,6 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
-        tax_inclusive:
-          type: boolean
-          title: Tax Inclusive?
-          default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
       required:
       - currency
       - unit_amount
@@ -9886,11 +9925,11 @@ components:
         ending_quantity:
           type: integer
           title: Ending quantity
-          description: Ending quantity for the tier.  This represents a unit amount
-            for unit-priced add ons.
           minimum: 1
           maximum: 999999999
-          default: 999999999
+          default: 
+          description: Ending quantity for the tier. This represents a unit amount
+            for unit-priced add ons. Must be left empty if it is the final tier.
         currencies:
           type: array
           title: Tier pricing
@@ -9918,14 +9957,19 @@ components:
           type: number
           format: float
           title: Ending amount
-          minimum: 0.1
-          maximum: 9999999999999
+          minimum: 0.01
+          maximum: 9999999999999.99
+          default: 
           description: Ending amount for the tier. Allows up to 2 decimal places.
-            The last tier ending_amount is null.
+            Must be left empty if it is the final tier.
         usage_percentage:
           type: string
           title: Usage Percentage
-          description: Decimal usage percentage.
+          minimum: 0
+          maximum: 100
+          description: |
+            The percentage taken of the monetary amount of usage tracked.
+            This can be up to 4 decimal places represented as a string.
     Settings:
       type: object
       properties:
@@ -10571,6 +10615,13 @@ components:
           type: string
           title: Billing Info ID
           description: Billing Info ID.
+        active_invoice_id:
+          type: string
+          title: Active invoice ID
+          description: The invoice ID of the latest invoice created for an active
+            subscription.
+          maxLength: 13
+          readOnly: true
     SubscriptionAddOn:
       type: object
       title: Subscription Add-on
@@ -10610,6 +10661,8 @@ components:
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeEnum"
         tiers:
           type: array
           title: Tiers
@@ -10620,6 +10673,7 @@ components:
             If tiers are provided in the request, all existing tiers on the Subscription Add-on will be
             removed and replaced by the tiers in the request. If add_on.tier_type is tiered or volume and
             add_on.usage_type is percentage use percentage_tiers instead.
+            There must be one tier without an `ending_quantity` value which represents the final tier.
         percentage_tiers:
           type: array
           title: Percentage Tiers
@@ -10630,6 +10684,7 @@ components:
             If percentage tiers are provided in the request, all existing percentage tiers on the Subscription Add-on will be
             removed and replaced by the percentage tiers in the request. Use only if add_on.tier_type is tiered or volume and
             add_on.usage_type is percentage.
+            There must be one tier without an `ending_amount` value which represents the final tier.
         usage_percentage:
           type: number
           format: float
@@ -10695,7 +10750,7 @@ components:
           description: |
             If the plan add-on's `tier_type` is `flat`, then `tiers` must be absent. The `tiers` object
             must include one to many tiers with `ending_quantity` and `unit_amount`.
-            There must be one tier without ending_quantity value.
+            There must be one tier without an `ending_quantity` value which represents the final tier.
             See our [Guide](https://developers.recurly.com/guides/item-addon-guide.html)
             for an overview of how to configure quantity-based pricing models.
         percentage_tiers:
@@ -10706,12 +10761,14 @@ components:
           minItems: 1
           description: |
             If percentage tiers are provided in the request, all existing percentage tiers on the Subscription Add-on will be
-            removed and replaced by the percentage tiers in the request. There must be one tier without ending_amount value.
+            removed and replaced by the percentage tiers in the request. There must be one tier without ending_amount value which represents the final tier.
             Use only if add_on.tier_type is tiered or volume and add_on.usage_type is percentage.
         usage_percentage:
           type: number
           format: float
           title: Usage Percentage
+          minimum: 0
+          maximum: 100
           description: The percentage taken of the monetary amount of usage tracked.
             This can be up to 4 decimal places. A value between 0.0 and 100.0. Required
             if `add_on_type` is usage and `usage_type` is percentage. Must be omitted
@@ -10774,8 +10831,19 @@ components:
           description: |
             If the plan add-on's `tier_type` is `flat`, then `tiers` must be absent. The `tiers` object
             must include one to many tiers with `ending_quantity` and `unit_amount`.
-            There must be one tier with an `ending_quantity` of 999999999 which is the
-            default if not provided.
+            There must be one tier without an `ending_quantity` value
+            which represents the final tier.
+        percentage_tiers:
+          type: array
+          title: Percentage Tiers
+          items:
+            "$ref": "#/components/schemas/SubscriptionAddOnPercentageTier"
+          minItems: 1
+          description: |
+            If percentage tiers are provided in the request, all existing percentage tiers on the Subscription Add-on will be
+            removed and replaced by the percentage tiers in the request. Use only if add_on.tier_type is tiered or volume and
+            add_on.usage_type is percentage.
+            There must be one tier without an `ending_amount` value which represents the final tier.
         usage_percentage:
           type: number
           format: float
@@ -10795,6 +10863,8 @@ components:
           minimum: 1
           maximum: 999999999
           default: 
+          description: Ending quantity for the tier.  This represents a unit amount
+            for unit-priced add ons. Must be left empty if it is the final tier.
         unit_amount:
           type: number
           format: float
@@ -10816,16 +10886,19 @@ components:
           type: number
           format: float
           title: Ending amount
-          minimum: 1
+          minimum: 0.01
           maximum: 9999999999999.99
           default: 
+          description: Ending amount for the tier. Allows up to 2 decimal places.
+            Must be left empty if it is the final tier.
         usage_percentage:
           type: string
           title: Usage Percentage
+          minimum: 0
+          maximum: 100
           description: |
             The percentage taken of the monetary amount of usage tracked.
-            This can be up to 4 decimal places represented as a string. A value between
-            0.0 and 100.0.
+            This can be up to 4 decimal places represented as a string.
     SubscriptionCancel:
       type: object
       properties:
@@ -10866,13 +10939,6 @@ components:
           type: number
           format: float
           title: Unit amount
-        tax_inclusive:
-          type: boolean
-          title: Tax Inclusive?
-          default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Subscription quantity
@@ -10965,13 +11031,6 @@ components:
             be used.
           minimum: 0
           maximum: 1000000
-        tax_inclusive:
-          type: boolean
-          title: Tax Inclusive?
-          default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -12695,6 +12754,25 @@ components:
       - tiered
       - stairstep
       - volume
+    UsageTimeframeEnum:
+      type: string
+      title: Usage Timeframe
+      description: The time at which usage totals are reset for billing purposes.
+      enum:
+      - billing_period
+      - subscription_term
+      default: billing_period
+    UsageTimeframeCreateEnum:
+      type: string
+      title: Usage Timeframe
+      description: |
+        The time at which usage totals are reset for billing purposes.
+        Allows for `tiered` add-ons to accumulate usage over the course of multiple
+        billing periods.
+      enum:
+      - billing_period
+      - subscription_term
+      default: billing_period
     CreditPaymentActionEnum:
       type: string
       enum:
@@ -12708,6 +12786,16 @@ components:
       - api_only
       - read_only
       - write
+    PricingModelTypeEnum:
+      type: string
+      enum:
+      - fixed
+      - ramp
+      default: fixed
+      description: |
+        A fixed pricing model has the same price for each billing period.
+        A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+        a specified cadence of billing periods. The price change could be an increase or decrease.
     RevenueScheduleTypeEnum:
       type: string
       enum:
@@ -13176,6 +13264,7 @@ components:
       - three_d_secure_connection_error
       - three_d_secure_credential_error
       - three_d_secure_not_supported
+      - too_busy
       - too_many_attempts
       - total_credit_exceeds_capture
       - transaction_already_refunded

--- a/percentage_tier.go
+++ b/percentage_tier.go
@@ -12,10 +12,11 @@ import (
 type PercentageTier struct {
 	recurlyResponse *ResponseMetadata
 
-	// Ending amount for the tier. Allows up to 2 decimal places. The last tier ending_amount is null.
+	// Ending amount for the tier. Allows up to 2 decimal places. Must be left empty if it is the final tier.
 	EndingAmount float64 `json:"ending_amount,omitempty"`
 
-	// Decimal usage percentage.
+	// The percentage taken of the monetary amount of usage tracked.
+	// This can be up to 4 decimal places represented as a string.
 	UsagePercentage string `json:"usage_percentage,omitempty"`
 }
 

--- a/percentage_tier_create.go
+++ b/percentage_tier_create.go
@@ -8,9 +8,10 @@ import ()
 
 type PercentageTierCreate struct {
 
-	// Ending amount for the tier. Allows up to 2 decimal places. The last tier ending_amount is null.
+	// Ending amount for the tier. Allows up to 2 decimal places. Must be left empty if it is the final tier.
 	EndingAmount *float64 `json:"ending_amount,omitempty"`
 
-	// Decimal usage percentage.
+	// The percentage taken of the monetary amount of usage tracked.
+	// This can be up to 4 decimal places represented as a string.
 	UsagePercentage *string `json:"usage_percentage,omitempty"`
 }

--- a/plan.go
+++ b/plan.go
@@ -52,6 +52,14 @@ type Plan struct {
 	// Subscriptions will automatically inherit this value once they are active. If `auto_renew` is `true`, then a subscription will automatically renew its term at renewal. If `auto_renew` is `false`, then a subscription will expire at the end of its term. `auto_renew` can be overridden on the subscription record itself.
 	AutoRenew bool `json:"auto_renew,omitempty"`
 
+	// A fixed pricing model has the same price for each billing period.
+	// A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+	// a specified cadence of billing periods. The price change could be an increase or decrease.
+	PricingModel string `json:"pricing_model,omitempty"`
+
+	// Ramp Intervals
+	RampIntervals []PlanRampInterval `json:"ramp_intervals,omitempty"`
+
 	// Revenue schedule type
 	RevenueScheduleType string `json:"revenue_schedule_type,omitempty"`
 

--- a/plan_create.go
+++ b/plan_create.go
@@ -41,6 +41,14 @@ type PlanCreate struct {
 	// Subscriptions will automatically inherit this value once they are active. If `auto_renew` is `true`, then a subscription will automatically renew its term at renewal. If `auto_renew` is `false`, then a subscription will expire at the end of its term. `auto_renew` can be overridden on the subscription record itself.
 	AutoRenew *bool `json:"auto_renew,omitempty"`
 
+	// A fixed pricing model has the same price for each billing period.
+	// A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+	// a specified cadence of billing periods. The price change could be an increase or decrease.
+	PricingModel *string `json:"pricing_model,omitempty"`
+
+	// Ramp Intervals
+	RampIntervals []PlanRampIntervalCreate `json:"ramp_intervals,omitempty"`
+
 	// Revenue schedule type
 	RevenueScheduleType *string `json:"revenue_schedule_type,omitempty"`
 

--- a/plan_pricing.go
+++ b/plan_pricing.go
@@ -18,11 +18,8 @@ type PlanPricing struct {
 	// Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
 	SetupFee float64 `json:"setup_fee,omitempty"`
 
-	// Unit price
+	// This field should not be sent when the pricing model is 'ramp'.
 	UnitAmount float64 `json:"unit_amount,omitempty"`
-
-	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-	TaxInclusive bool `json:"tax_inclusive,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/plan_pricing_create.go
+++ b/plan_pricing_create.go
@@ -14,9 +14,6 @@ type PlanPricingCreate struct {
 	// Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
 	SetupFee *float64 `json:"setup_fee,omitempty"`
 
-	// Unit price
+	// This field should not be sent when the pricing model is 'ramp'.
 	UnitAmount *float64 `json:"unit_amount,omitempty"`
-
-	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-	TaxInclusive *bool `json:"tax_inclusive,omitempty"`
 }

--- a/plan_ramp_interval.go
+++ b/plan_ramp_interval.go
@@ -9,54 +9,54 @@ import (
 	"net/http"
 )
 
-type Pricing struct {
+type PlanRampInterval struct {
 	recurlyResponse *ResponseMetadata
 
-	// 3-letter ISO 4217 currency code.
-	Currency string `json:"currency,omitempty"`
+	// Represents the first billing cycle of a ramp.
+	StartingBillingCycle int `json:"starting_billing_cycle,omitempty"`
 
-	// Unit price
-	UnitAmount float64 `json:"unit_amount,omitempty"`
+	// Represents the price for the ramp interval.
+	Currencies []PlanRampPricing `json:"currencies,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource
-func (resource *Pricing) GetResponse() *ResponseMetadata {
+func (resource *PlanRampInterval) GetResponse() *ResponseMetadata {
 	return resource.recurlyResponse
 }
 
 // setResponse sets the ResponseMetadata that generated this resource
-func (resource *Pricing) setResponse(res *ResponseMetadata) {
+func (resource *PlanRampInterval) setResponse(res *ResponseMetadata) {
 	resource.recurlyResponse = res
 }
 
 // internal struct for deserializing accounts
-type pricingList struct {
+type planRampIntervalList struct {
 	ListMetadata
-	Data            []Pricing `json:"data"`
+	Data            []PlanRampInterval `json:"data"`
 	recurlyResponse *ResponseMetadata
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource
-func (resource *pricingList) GetResponse() *ResponseMetadata {
+func (resource *planRampIntervalList) GetResponse() *ResponseMetadata {
 	return resource.recurlyResponse
 }
 
 // setResponse sets the ResponseMetadata that generated this resource
-func (resource *pricingList) setResponse(res *ResponseMetadata) {
+func (resource *planRampIntervalList) setResponse(res *ResponseMetadata) {
 	resource.recurlyResponse = res
 }
 
-// PricingList allows you to paginate Pricing objects
-type PricingList struct {
+// PlanRampIntervalList allows you to paginate PlanRampInterval objects
+type PlanRampIntervalList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
 	hasMore        bool
-	data           []Pricing
+	data           []PlanRampInterval
 }
 
-func NewPricingList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PricingList {
-	return &PricingList{
+func NewPlanRampIntervalList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PlanRampIntervalList {
+	return &PlanRampIntervalList{
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
@@ -64,31 +64,31 @@ func NewPricingList(client HTTPCaller, nextPagePath string, requestOptions *Requ
 	}
 }
 
-type PricingLister interface {
+type PlanRampIntervalLister interface {
 	Fetch() error
 	FetchWithContext(ctx context.Context) error
 	Count() (*int64, error)
 	CountWithContext(ctx context.Context) (*int64, error)
-	Data() []Pricing
+	Data() []PlanRampInterval
 	HasMore() bool
 	Next() string
 }
 
-func (list *PricingList) HasMore() bool {
+func (list *PlanRampIntervalList) HasMore() bool {
 	return list.hasMore
 }
 
-func (list *PricingList) Next() string {
+func (list *PlanRampIntervalList) Next() string {
 	return list.nextPagePath
 }
 
-func (list *PricingList) Data() []Pricing {
+func (list *PlanRampIntervalList) Data() []PlanRampInterval {
 	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *PricingList) FetchWithContext(ctx context.Context) error {
-	resources := &pricingList{}
+func (list *PlanRampIntervalList) FetchWithContext(ctx context.Context) error {
+	resources := &planRampIntervalList{}
 	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
@@ -101,13 +101,13 @@ func (list *PricingList) FetchWithContext(ctx context.Context) error {
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *PricingList) Fetch() error {
+func (list *PlanRampIntervalList) Fetch() error {
 	return list.FetchWithContext(context.Background())
 }
 
 // Count returns the count of items on the server that match this pager
-func (list *PricingList) CountWithContext(ctx context.Context) (*int64, error) {
-	resources := &pricingList{}
+func (list *PlanRampIntervalList) CountWithContext(ctx context.Context) (*int64, error) {
+	resources := &planRampIntervalList{}
 	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
@@ -117,6 +117,6 @@ func (list *PricingList) CountWithContext(ctx context.Context) (*int64, error) {
 }
 
 // Count returns the count of items on the server that match this pager
-func (list *PricingList) Count() (*int64, error) {
+func (list *PlanRampIntervalList) Count() (*int64, error) {
 	return list.CountWithContext(context.Background())
 }

--- a/plan_ramp_interval_create.go
+++ b/plan_ramp_interval_create.go
@@ -6,11 +6,11 @@ package recurly
 
 import ()
 
-type TierCreate struct {
+type PlanRampIntervalCreate struct {
 
-	// Ending quantity for the tier. This represents a unit amount for unit-priced add ons. Must be left empty if it is the final tier.
-	EndingQuantity *int `json:"ending_quantity,omitempty"`
+	// Represents the first billing cycle of a ramp.
+	StartingBillingCycle *int `json:"starting_billing_cycle,omitempty"`
 
-	// Tier pricing
-	Currencies []TierPricingCreate `json:"currencies,omitempty"`
+	// Represents the price for the ramp interval.
+	Currencies []PlanRampPricingCreate `json:"currencies,omitempty"`
 }

--- a/plan_ramp_pricing.go
+++ b/plan_ramp_pricing.go
@@ -9,54 +9,54 @@ import (
 	"net/http"
 )
 
-type Pricing struct {
+type PlanRampPricing struct {
 	recurlyResponse *ResponseMetadata
 
 	// 3-letter ISO 4217 currency code.
 	Currency string `json:"currency,omitempty"`
 
-	// Unit price
+	// Represents the price for the Ramp Interval.
 	UnitAmount float64 `json:"unit_amount,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource
-func (resource *Pricing) GetResponse() *ResponseMetadata {
+func (resource *PlanRampPricing) GetResponse() *ResponseMetadata {
 	return resource.recurlyResponse
 }
 
 // setResponse sets the ResponseMetadata that generated this resource
-func (resource *Pricing) setResponse(res *ResponseMetadata) {
+func (resource *PlanRampPricing) setResponse(res *ResponseMetadata) {
 	resource.recurlyResponse = res
 }
 
 // internal struct for deserializing accounts
-type pricingList struct {
+type planRampPricingList struct {
 	ListMetadata
-	Data            []Pricing `json:"data"`
+	Data            []PlanRampPricing `json:"data"`
 	recurlyResponse *ResponseMetadata
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource
-func (resource *pricingList) GetResponse() *ResponseMetadata {
+func (resource *planRampPricingList) GetResponse() *ResponseMetadata {
 	return resource.recurlyResponse
 }
 
 // setResponse sets the ResponseMetadata that generated this resource
-func (resource *pricingList) setResponse(res *ResponseMetadata) {
+func (resource *planRampPricingList) setResponse(res *ResponseMetadata) {
 	resource.recurlyResponse = res
 }
 
-// PricingList allows you to paginate Pricing objects
-type PricingList struct {
+// PlanRampPricingList allows you to paginate PlanRampPricing objects
+type PlanRampPricingList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
 	hasMore        bool
-	data           []Pricing
+	data           []PlanRampPricing
 }
 
-func NewPricingList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PricingList {
-	return &PricingList{
+func NewPlanRampPricingList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PlanRampPricingList {
+	return &PlanRampPricingList{
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
@@ -64,31 +64,31 @@ func NewPricingList(client HTTPCaller, nextPagePath string, requestOptions *Requ
 	}
 }
 
-type PricingLister interface {
+type PlanRampPricingLister interface {
 	Fetch() error
 	FetchWithContext(ctx context.Context) error
 	Count() (*int64, error)
 	CountWithContext(ctx context.Context) (*int64, error)
-	Data() []Pricing
+	Data() []PlanRampPricing
 	HasMore() bool
 	Next() string
 }
 
-func (list *PricingList) HasMore() bool {
+func (list *PlanRampPricingList) HasMore() bool {
 	return list.hasMore
 }
 
-func (list *PricingList) Next() string {
+func (list *PlanRampPricingList) Next() string {
 	return list.nextPagePath
 }
 
-func (list *PricingList) Data() []Pricing {
+func (list *PlanRampPricingList) Data() []PlanRampPricing {
 	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *PricingList) FetchWithContext(ctx context.Context) error {
-	resources := &pricingList{}
+func (list *PlanRampPricingList) FetchWithContext(ctx context.Context) error {
+	resources := &planRampPricingList{}
 	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
@@ -101,13 +101,13 @@ func (list *PricingList) FetchWithContext(ctx context.Context) error {
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *PricingList) Fetch() error {
+func (list *PlanRampPricingList) Fetch() error {
 	return list.FetchWithContext(context.Background())
 }
 
 // Count returns the count of items on the server that match this pager
-func (list *PricingList) CountWithContext(ctx context.Context) (*int64, error) {
-	resources := &pricingList{}
+func (list *PlanRampPricingList) CountWithContext(ctx context.Context) (*int64, error) {
+	resources := &planRampPricingList{}
 	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
@@ -117,6 +117,6 @@ func (list *PricingList) CountWithContext(ctx context.Context) (*int64, error) {
 }
 
 // Count returns the count of items on the server that match this pager
-func (list *PricingList) Count() (*int64, error) {
+func (list *PlanRampPricingList) Count() (*int64, error) {
 	return list.CountWithContext(context.Background())
 }

--- a/plan_ramp_pricing_create.go
+++ b/plan_ramp_pricing_create.go
@@ -6,15 +6,11 @@ package recurly
 
 import ()
 
-type AddOnPricingCreate struct {
+type PlanRampPricingCreate struct {
 
 	// 3-letter ISO 4217 currency code.
 	Currency *string `json:"currency,omitempty"`
 
-	// Allows up to 2 decimal places. Required unless `unit_amount_decimal` is provided.
+	// Represents the price for the Ramp Interval.
 	UnitAmount *float64 `json:"unit_amount,omitempty"`
-
-	// Allows up to 9 decimal places. Only supported when `add_on_type` = `usage`.
-	// If `unit_amount_decimal` is provided, `unit_amount` cannot be provided.
-	UnitAmountDecimal *string `json:"unit_amount_decimal,omitempty"`
 }

--- a/plan_update.go
+++ b/plan_update.go
@@ -38,6 +38,9 @@ type PlanUpdate struct {
 	// Subscriptions will automatically inherit this value once they are active. If `auto_renew` is `true`, then a subscription will automatically renew its term at renewal. If `auto_renew` is `false`, then a subscription will expire at the end of its term. `auto_renew` can be overridden on the subscription record itself.
 	AutoRenew *bool `json:"auto_renew,omitempty"`
 
+	// Ramp Intervals
+	RampIntervals []PlanRampIntervalCreate `json:"ramp_intervals,omitempty"`
+
 	// Revenue schedule type
 	RevenueScheduleType *string `json:"revenue_schedule_type,omitempty"`
 
@@ -59,7 +62,7 @@ type PlanUpdate struct {
 	// `true` exempts tax on the plan, `false` applies tax on the plan.
 	TaxExempt *bool `json:"tax_exempt,omitempty"`
 
-	// Pricing
+	// Optional when the pricing model is 'ramp'.
 	Currencies []PlanPricingCreate `json:"currencies,omitempty"`
 
 	// Hosted pages settings

--- a/pricing_create.go
+++ b/pricing_create.go
@@ -13,7 +13,4 @@ type PricingCreate struct {
 
 	// Unit price
 	UnitAmount *float64 `json:"unit_amount,omitempty"`
-
-	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-	TaxInclusive *bool `json:"tax_inclusive,omitempty"`
 }

--- a/scripts/clean
+++ b/scripts/clean
@@ -57,6 +57,8 @@ rm -f pricing.go
 rm -f measured_unit.go
 rm -f binary_file.go
 rm -f plan.go
+rm -f plan_ramp_interval.go
+rm -f plan_ramp_pricing.go
 rm -f plan_pricing.go
 rm -f plan_hosted_pages.go
 rm -f add_on.go
@@ -105,6 +107,8 @@ rm -f invoice_refund.go
 rm -f line_item_refund.go
 rm -f external_refund.go
 rm -f plan_create.go
+rm -f plan_ramp_interval_create.go
+rm -f plan_ramp_pricing_create.go
 rm -f plan_pricing_create.go
 rm -f plan_hosted_pages_create.go
 rm -f add_on_create.go

--- a/subscription.go
+++ b/subscription.go
@@ -150,6 +150,9 @@ type Subscription struct {
 
 	// Billing Info ID.
 	BillingInfoId string `json:"billing_info_id,omitempty"`
+
+	// The invoice ID of the latest invoice created for an active subscription.
+	ActiveInvoiceId string `json:"active_invoice_id,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/subscription_add_on.go
+++ b/subscription_add_on.go
@@ -49,14 +49,19 @@ type SubscriptionAddOn struct {
 	// to configure quantity-based pricing models.
 	TierType string `json:"tier_type,omitempty"`
 
+	// The time at which usage totals are reset for billing purposes.
+	UsageTimeframe string `json:"usage_timeframe,omitempty"`
+
 	// If tiers are provided in the request, all existing tiers on the Subscription Add-on will be
 	// removed and replaced by the tiers in the request. If add_on.tier_type is tiered or volume and
 	// add_on.usage_type is percentage use percentage_tiers instead.
+	// There must be one tier without an `ending_quantity` value which represents the final tier.
 	Tiers []SubscriptionAddOnTier `json:"tiers,omitempty"`
 
 	// If percentage tiers are provided in the request, all existing percentage tiers on the Subscription Add-on will be
 	// removed and replaced by the percentage tiers in the request. Use only if add_on.tier_type is tiered or volume and
 	// add_on.usage_type is percentage.
+	// There must be one tier without an `ending_amount` value which represents the final tier.
 	PercentageTiers []SubscriptionAddOnPercentageTier `json:"percentage_tiers,omitempty"`
 
 	// The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0. Required if add_on_type is usage and usage_type is percentage.

--- a/subscription_add_on_create.go
+++ b/subscription_add_on_create.go
@@ -33,13 +33,13 @@ type SubscriptionAddOnCreate struct {
 
 	// If the plan add-on's `tier_type` is `flat`, then `tiers` must be absent. The `tiers` object
 	// must include one to many tiers with `ending_quantity` and `unit_amount`.
-	// There must be one tier without ending_quantity value.
+	// There must be one tier without an `ending_quantity` value which represents the final tier.
 	// See our [Guide](https://developers.recurly.com/guides/item-addon-guide.html)
 	// for an overview of how to configure quantity-based pricing models.
 	Tiers []SubscriptionAddOnTierCreate `json:"tiers,omitempty"`
 
 	// If percentage tiers are provided in the request, all existing percentage tiers on the Subscription Add-on will be
-	// removed and replaced by the percentage tiers in the request. There must be one tier without ending_amount value.
+	// removed and replaced by the percentage tiers in the request. There must be one tier without ending_amount value which represents the final tier.
 	// Use only if add_on.tier_type is tiered or volume and add_on.usage_type is percentage.
 	PercentageTiers []SubscriptionAddOnPercentageTierCreate `json:"percentage_tiers,omitempty"`
 

--- a/subscription_add_on_percentage_tier.go
+++ b/subscription_add_on_percentage_tier.go
@@ -12,12 +12,11 @@ import (
 type SubscriptionAddOnPercentageTier struct {
 	recurlyResponse *ResponseMetadata
 
-	// Ending amount
+	// Ending amount for the tier. Allows up to 2 decimal places. Must be left empty if it is the final tier.
 	EndingAmount float64 `json:"ending_amount,omitempty"`
 
 	// The percentage taken of the monetary amount of usage tracked.
-	// This can be up to 4 decimal places represented as a string. A value between
-	// 0.0 and 100.0.
+	// This can be up to 4 decimal places represented as a string.
 	UsagePercentage string `json:"usage_percentage,omitempty"`
 }
 

--- a/subscription_add_on_percentage_tier_create.go
+++ b/subscription_add_on_percentage_tier_create.go
@@ -8,11 +8,10 @@ import ()
 
 type SubscriptionAddOnPercentageTierCreate struct {
 
-	// Ending amount
+	// Ending amount for the tier. Allows up to 2 decimal places. Must be left empty if it is the final tier.
 	EndingAmount *float64 `json:"ending_amount,omitempty"`
 
 	// The percentage taken of the monetary amount of usage tracked.
-	// This can be up to 4 decimal places represented as a string. A value between
-	// 0.0 and 100.0.
+	// This can be up to 4 decimal places represented as a string.
 	UsagePercentage *string `json:"usage_percentage,omitempty"`
 }

--- a/subscription_add_on_tier.go
+++ b/subscription_add_on_tier.go
@@ -12,7 +12,7 @@ import (
 type SubscriptionAddOnTier struct {
 	recurlyResponse *ResponseMetadata
 
-	// Ending quantity
+	// Ending quantity for the tier.  This represents a unit amount for unit-priced add ons. Must be left empty if it is the final tier.
 	EndingQuantity int `json:"ending_quantity,omitempty"`
 
 	// Allows up to 2 decimal places. Optionally, override the tiers' default unit amount.

--- a/subscription_add_on_tier_create.go
+++ b/subscription_add_on_tier_create.go
@@ -8,7 +8,7 @@ import ()
 
 type SubscriptionAddOnTierCreate struct {
 
-	// Ending quantity
+	// Ending quantity for the tier.  This represents a unit amount for unit-priced add ons. Must be left empty if it is the final tier.
 	EndingQuantity *int `json:"ending_quantity,omitempty"`
 
 	// Allows up to 2 decimal places. Optionally, override the tiers' default unit amount.

--- a/subscription_add_on_update.go
+++ b/subscription_add_on_update.go
@@ -40,9 +40,15 @@ type SubscriptionAddOnUpdate struct {
 
 	// If the plan add-on's `tier_type` is `flat`, then `tiers` must be absent. The `tiers` object
 	// must include one to many tiers with `ending_quantity` and `unit_amount`.
-	// There must be one tier with an `ending_quantity` of 999999999 which is the
-	// default if not provided.
+	// There must be one tier without an `ending_quantity` value
+	// which represents the final tier.
 	Tiers []SubscriptionAddOnTierCreate `json:"tiers,omitempty"`
+
+	// If percentage tiers are provided in the request, all existing percentage tiers on the Subscription Add-on will be
+	// removed and replaced by the percentage tiers in the request. Use only if add_on.tier_type is tiered or volume and
+	// add_on.usage_type is percentage.
+	// There must be one tier without an `ending_amount` value which represents the final tier.
+	PercentageTiers []SubscriptionAddOnPercentageTierCreate `json:"percentage_tiers,omitempty"`
 
 	// The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0. Required if add_on_type is usage and usage_type is percentage.
 	UsagePercentage *float64 `json:"usage_percentage,omitempty"`

--- a/subscription_change.go
+++ b/subscription_change.go
@@ -31,9 +31,6 @@ type SubscriptionChange struct {
 	// Unit amount
 	UnitAmount float64 `json:"unit_amount,omitempty"`
 
-	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-	TaxInclusive bool `json:"tax_inclusive,omitempty"`
-
 	// Subscription quantity
 	Quantity int `json:"quantity,omitempty"`
 

--- a/subscription_change_create.go
+++ b/subscription_change_create.go
@@ -20,9 +20,6 @@ type SubscriptionChangeCreate struct {
 	// Optionally, sets custom pricing for the subscription, overriding the plan's default unit amount. The subscription's current currency will be used.
 	UnitAmount *float64 `json:"unit_amount,omitempty"`
 
-	// Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
-	TaxInclusive *bool `json:"tax_inclusive,omitempty"`
-
 	// Optionally override the default quantity of 1.
 	Quantity *int `json:"quantity,omitempty"`
 

--- a/tier.go
+++ b/tier.go
@@ -12,7 +12,7 @@ import (
 type Tier struct {
 	recurlyResponse *ResponseMetadata
 
-	// Ending quantity for the tier.  This represents a unit amount for unit-priced add ons.
+	// Ending quantity for the tier. This represents a unit amount for unit-priced add ons. Must be left empty if it is the final tier.
 	EndingQuantity int `json:"ending_quantity,omitempty"`
 
 	// Tier pricing


### PR DESCRIPTION
Adds support for the Ramp Pricing feature of Recurly API:

Adds operations for the Ramp Pricing feature of Recurly API:
- Edit ramp intervals on a Plan