### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -17535,7 +17535,7 @@ components:
           title: Field value
           description: Any values that resemble a credit card number or security code
             (CVV/CVC) will be rejected.
-          maxLength: 100
+          maxLength: 255
       required:
       - name
       - value
@@ -18959,6 +18959,14 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        pricing_model:
+          title: Pricing Model
+          "$ref": "#/components/schemas/PricingModelTypeEnum"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -19121,6 +19129,14 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        pricing_model:
+          title: Pricing Model
+          "$ref": "#/components/schemas/PricingModelTypeEnum"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -19242,6 +19258,7 @@ components:
           type: number
           format: float
           title: Unit price
+          description: This field should not be sent when the pricing model is 'ramp'.
           minimum: 0
           maximum: 1000000
         tax_inclusive:
@@ -19250,6 +19267,19 @@ components:
           default: false
           description: This field is deprecated. Please do not use it.
           deprecated: true
+    PlanRampInterval:
+      type: object
+      title: Plan Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents the first billing cycle of a ramp.
+          default: 1
+        currencies:
+          type: array
+          description: Represents the price for the ramp interval.
+          items:
+            "$ref": "#/components/schemas/PlanRampPricing"
     PlanUpdate:
       type: object
       properties:
@@ -19316,6 +19346,11 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -19362,6 +19397,7 @@ components:
         currencies:
           type: array
           title: Pricing
+          description: Optional when the pricing model is 'ramp'.
           items:
             "$ref": "#/components/schemas/PlanPricing"
           minItems: 1
@@ -19441,6 +19477,24 @@ components:
             If `unit_amount_decimal` is provided, `unit_amount` cannot be provided.
       required:
       - currency
+    PlanRampPricing:
+      type: object
+      properties:
+        currency:
+          type: string
+          title: Currency
+          description: 3-letter ISO 4217 currency code.
+          maxLength: 3
+        unit_amount:
+          type: number
+          format: float
+          title: Unit price
+          description: Represents the price for the Ramp Interval.
+          minimum: 0
+          maximum: 1000000
+      required:
+      - currency
+      - unit_amount
     Pricing:
       type: object
       properties:
@@ -20044,6 +20098,13 @@ components:
           default: true
           title: Auto renew
           description: Whether the subscription renews at the end of its term.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The ramp intervals representing the pricing schedule for the
+            subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampIntervalResponse"
         paused_at:
           type: string
           format: date-time
@@ -20546,6 +20607,13 @@ components:
           readOnly: true
         billing_info:
           "$ref": "#/components/schemas/SubscriptionChangeBillingInfo"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The ramp intervals representing the pricing schedule for the
+            subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampIntervalResponse"
     SubscriptionChangeBillingInfo:
       type: object
       description: Accept nested attributes for three_d_secure_action_result_token_id
@@ -20671,6 +20739,12 @@ components:
           "$ref": "#/components/schemas/GatewayTransactionTypeEnum"
         billing_info:
           "$ref": "#/components/schemas/SubscriptionChangeBillingInfoCreate"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
     SubscriptionChangeShippingCreate:
       type: object
       title: Shipping details that will be changed on a subscription
@@ -20825,6 +20899,12 @@ components:
           default: true
           title: Auto renew
           description: Whether the subscription renews at the end of its term.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -20964,6 +21044,12 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
       required:
       - plan_code
     SubscriptionUpdate:
@@ -21145,6 +21231,30 @@ components:
           format: float
           title: Assigns the subscription's shipping cost. If this is greater than
             zero then a `method_id` or `method_code` is required.
+    SubscriptionRampInterval:
+      type: object
+      title: Subscription Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents how many billing cycles are included in a ramp interval.
+          default: 1
+        unit_amount:
+          type: integer
+          description: Represents the price for the ramp interval.
+    SubscriptionRampIntervalResponse:
+      type: object
+      title: Subscription Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents how many billing cycles are included in a ramp interval.
+        remaining_billing_cycles:
+          type: integer
+          description: Represents how many billing cycles are left in a ramp interval.
+        unit_amount:
+          type: integer
+          description: Represents the price for the ramp interval.
     TaxInfo:
       type: object
       title: Tax info
@@ -21998,6 +22108,10 @@ components:
         routing_number_bank:
           type: string
           description: The bank name of this routing number.
+        username:
+          type: string
+          description: Username of the associated payment method. Currently only associated
+            with Venmo.
     Error:
       type: object
       properties:
@@ -22327,6 +22441,16 @@ components:
       - api_only
       - read_only
       - write
+    PricingModelTypeEnum:
+      type: string
+      enum:
+      - fixed
+      - ramp
+      default: fixed
+      description: |
+        A fixed pricing model has the same price for each billing period.
+        A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+        a specified cadence of billing periods. The price change could be an increase or decrease.
     RevenueScheduleTypeEnum:
       type: string
       enum:
@@ -22594,6 +22718,7 @@ components:
       - paypal_billing_agreement
       - roku
       - sepadirectdebit
+      - venmo
       - wire_transfer
       - braintree_v_zero
     CardTypeEnum:

--- a/payment_method.go
+++ b/payment_method.go
@@ -55,6 +55,9 @@ type PaymentMethod struct {
 
 	// The bank name of this routing number.
 	RoutingNumberBank string `json:"routing_number_bank,omitempty"`
+
+	// Username of the associated payment method. Currently only associated with Venmo.
+	Username string `json:"username,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/plan.go
+++ b/plan.go
@@ -52,6 +52,14 @@ type Plan struct {
 	// Subscriptions will automatically inherit this value once they are active. If `auto_renew` is `true`, then a subscription will automatically renew its term at renewal. If `auto_renew` is `false`, then a subscription will expire at the end of its term. `auto_renew` can be overridden on the subscription record itself.
 	AutoRenew bool `json:"auto_renew,omitempty"`
 
+	// A fixed pricing model has the same price for each billing period.
+	// A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+	// a specified cadence of billing periods. The price change could be an increase or decrease.
+	PricingModel string `json:"pricing_model,omitempty"`
+
+	// Ramp Intervals
+	RampIntervals []PlanRampInterval `json:"ramp_intervals,omitempty"`
+
 	// Revenue schedule type
 	RevenueScheduleType string `json:"revenue_schedule_type,omitempty"`
 

--- a/plan_create.go
+++ b/plan_create.go
@@ -41,6 +41,14 @@ type PlanCreate struct {
 	// Subscriptions will automatically inherit this value once they are active. If `auto_renew` is `true`, then a subscription will automatically renew its term at renewal. If `auto_renew` is `false`, then a subscription will expire at the end of its term. `auto_renew` can be overridden on the subscription record itself.
 	AutoRenew *bool `json:"auto_renew,omitempty"`
 
+	// A fixed pricing model has the same price for each billing period.
+	// A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+	// a specified cadence of billing periods. The price change could be an increase or decrease.
+	PricingModel *string `json:"pricing_model,omitempty"`
+
+	// Ramp Intervals
+	RampIntervals []PlanRampIntervalCreate `json:"ramp_intervals,omitempty"`
+
 	// Revenue schedule type
 	RevenueScheduleType *string `json:"revenue_schedule_type,omitempty"`
 

--- a/plan_pricing_create.go
+++ b/plan_pricing_create.go
@@ -14,7 +14,7 @@ type PlanPricingCreate struct {
 	// Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
 	SetupFee *float64 `json:"setup_fee,omitempty"`
 
-	// Unit price
+	// This field should not be sent when the pricing model is 'ramp'.
 	UnitAmount *float64 `json:"unit_amount,omitempty"`
 
 	// This field is deprecated. Please do not use it.

--- a/plan_ramp_interval.go
+++ b/plan_ramp_interval.go
@@ -9,60 +9,54 @@ import (
 	"net/http"
 )
 
-type PlanPricing struct {
+type PlanRampInterval struct {
 	recurlyResponse *ResponseMetadata
 
-	// 3-letter ISO 4217 currency code.
-	Currency string `json:"currency,omitempty"`
+	// Represents the first billing cycle of a ramp.
+	StartingBillingCycle int `json:"starting_billing_cycle,omitempty"`
 
-	// Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
-	SetupFee float64 `json:"setup_fee,omitempty"`
-
-	// This field should not be sent when the pricing model is 'ramp'.
-	UnitAmount float64 `json:"unit_amount,omitempty"`
-
-	// This field is deprecated. Please do not use it.
-	TaxInclusive bool `json:"tax_inclusive,omitempty"`
+	// Represents the price for the ramp interval.
+	Currencies []PlanRampPricing `json:"currencies,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource
-func (resource *PlanPricing) GetResponse() *ResponseMetadata {
+func (resource *PlanRampInterval) GetResponse() *ResponseMetadata {
 	return resource.recurlyResponse
 }
 
 // setResponse sets the ResponseMetadata that generated this resource
-func (resource *PlanPricing) setResponse(res *ResponseMetadata) {
+func (resource *PlanRampInterval) setResponse(res *ResponseMetadata) {
 	resource.recurlyResponse = res
 }
 
 // internal struct for deserializing accounts
-type planPricingList struct {
+type planRampIntervalList struct {
 	ListMetadata
-	Data            []PlanPricing `json:"data"`
+	Data            []PlanRampInterval `json:"data"`
 	recurlyResponse *ResponseMetadata
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource
-func (resource *planPricingList) GetResponse() *ResponseMetadata {
+func (resource *planRampIntervalList) GetResponse() *ResponseMetadata {
 	return resource.recurlyResponse
 }
 
 // setResponse sets the ResponseMetadata that generated this resource
-func (resource *planPricingList) setResponse(res *ResponseMetadata) {
+func (resource *planRampIntervalList) setResponse(res *ResponseMetadata) {
 	resource.recurlyResponse = res
 }
 
-// PlanPricingList allows you to paginate PlanPricing objects
-type PlanPricingList struct {
+// PlanRampIntervalList allows you to paginate PlanRampInterval objects
+type PlanRampIntervalList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
 	hasMore        bool
-	data           []PlanPricing
+	data           []PlanRampInterval
 }
 
-func NewPlanPricingList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PlanPricingList {
-	return &PlanPricingList{
+func NewPlanRampIntervalList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PlanRampIntervalList {
+	return &PlanRampIntervalList{
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
@@ -70,31 +64,31 @@ func NewPlanPricingList(client HTTPCaller, nextPagePath string, requestOptions *
 	}
 }
 
-type PlanPricingLister interface {
+type PlanRampIntervalLister interface {
 	Fetch() error
 	FetchWithContext(ctx context.Context) error
 	Count() (*int64, error)
 	CountWithContext(ctx context.Context) (*int64, error)
-	Data() []PlanPricing
+	Data() []PlanRampInterval
 	HasMore() bool
 	Next() string
 }
 
-func (list *PlanPricingList) HasMore() bool {
+func (list *PlanRampIntervalList) HasMore() bool {
 	return list.hasMore
 }
 
-func (list *PlanPricingList) Next() string {
+func (list *PlanRampIntervalList) Next() string {
 	return list.nextPagePath
 }
 
-func (list *PlanPricingList) Data() []PlanPricing {
+func (list *PlanRampIntervalList) Data() []PlanRampInterval {
 	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *PlanPricingList) FetchWithContext(ctx context.Context) error {
-	resources := &planPricingList{}
+func (list *PlanRampIntervalList) FetchWithContext(ctx context.Context) error {
+	resources := &planRampIntervalList{}
 	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
@@ -107,13 +101,13 @@ func (list *PlanPricingList) FetchWithContext(ctx context.Context) error {
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *PlanPricingList) Fetch() error {
+func (list *PlanRampIntervalList) Fetch() error {
 	return list.FetchWithContext(context.Background())
 }
 
 // Count returns the count of items on the server that match this pager
-func (list *PlanPricingList) CountWithContext(ctx context.Context) (*int64, error) {
-	resources := &planPricingList{}
+func (list *PlanRampIntervalList) CountWithContext(ctx context.Context) (*int64, error) {
+	resources := &planRampIntervalList{}
 	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
@@ -123,6 +117,6 @@ func (list *PlanPricingList) CountWithContext(ctx context.Context) (*int64, erro
 }
 
 // Count returns the count of items on the server that match this pager
-func (list *PlanPricingList) Count() (*int64, error) {
+func (list *PlanRampIntervalList) Count() (*int64, error) {
 	return list.CountWithContext(context.Background())
 }

--- a/plan_ramp_interval_create.go
+++ b/plan_ramp_interval_create.go
@@ -1,0 +1,16 @@
+// This file is automatically created by Recurly's OpenAPI generation process
+// and thus any edits you make by hand will be lost. If you wish to make a
+// change to this file, please create a Github issue explaining the changes you
+// need and we will usher them to the appropriate places.
+package recurly
+
+import ()
+
+type PlanRampIntervalCreate struct {
+
+	// Represents the first billing cycle of a ramp.
+	StartingBillingCycle *int `json:"starting_billing_cycle,omitempty"`
+
+	// Represents the price for the ramp interval.
+	Currencies []PlanRampPricingCreate `json:"currencies,omitempty"`
+}

--- a/plan_ramp_pricing.go
+++ b/plan_ramp_pricing.go
@@ -9,60 +9,54 @@ import (
 	"net/http"
 )
 
-type PlanPricing struct {
+type PlanRampPricing struct {
 	recurlyResponse *ResponseMetadata
 
 	// 3-letter ISO 4217 currency code.
 	Currency string `json:"currency,omitempty"`
 
-	// Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
-	SetupFee float64 `json:"setup_fee,omitempty"`
-
-	// This field should not be sent when the pricing model is 'ramp'.
+	// Represents the price for the Ramp Interval.
 	UnitAmount float64 `json:"unit_amount,omitempty"`
-
-	// This field is deprecated. Please do not use it.
-	TaxInclusive bool `json:"tax_inclusive,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource
-func (resource *PlanPricing) GetResponse() *ResponseMetadata {
+func (resource *PlanRampPricing) GetResponse() *ResponseMetadata {
 	return resource.recurlyResponse
 }
 
 // setResponse sets the ResponseMetadata that generated this resource
-func (resource *PlanPricing) setResponse(res *ResponseMetadata) {
+func (resource *PlanRampPricing) setResponse(res *ResponseMetadata) {
 	resource.recurlyResponse = res
 }
 
 // internal struct for deserializing accounts
-type planPricingList struct {
+type planRampPricingList struct {
 	ListMetadata
-	Data            []PlanPricing `json:"data"`
+	Data            []PlanRampPricing `json:"data"`
 	recurlyResponse *ResponseMetadata
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource
-func (resource *planPricingList) GetResponse() *ResponseMetadata {
+func (resource *planRampPricingList) GetResponse() *ResponseMetadata {
 	return resource.recurlyResponse
 }
 
 // setResponse sets the ResponseMetadata that generated this resource
-func (resource *planPricingList) setResponse(res *ResponseMetadata) {
+func (resource *planRampPricingList) setResponse(res *ResponseMetadata) {
 	resource.recurlyResponse = res
 }
 
-// PlanPricingList allows you to paginate PlanPricing objects
-type PlanPricingList struct {
+// PlanRampPricingList allows you to paginate PlanRampPricing objects
+type PlanRampPricingList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
 	hasMore        bool
-	data           []PlanPricing
+	data           []PlanRampPricing
 }
 
-func NewPlanPricingList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PlanPricingList {
-	return &PlanPricingList{
+func NewPlanRampPricingList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PlanRampPricingList {
+	return &PlanRampPricingList{
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
@@ -70,31 +64,31 @@ func NewPlanPricingList(client HTTPCaller, nextPagePath string, requestOptions *
 	}
 }
 
-type PlanPricingLister interface {
+type PlanRampPricingLister interface {
 	Fetch() error
 	FetchWithContext(ctx context.Context) error
 	Count() (*int64, error)
 	CountWithContext(ctx context.Context) (*int64, error)
-	Data() []PlanPricing
+	Data() []PlanRampPricing
 	HasMore() bool
 	Next() string
 }
 
-func (list *PlanPricingList) HasMore() bool {
+func (list *PlanRampPricingList) HasMore() bool {
 	return list.hasMore
 }
 
-func (list *PlanPricingList) Next() string {
+func (list *PlanRampPricingList) Next() string {
 	return list.nextPagePath
 }
 
-func (list *PlanPricingList) Data() []PlanPricing {
+func (list *PlanRampPricingList) Data() []PlanRampPricing {
 	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *PlanPricingList) FetchWithContext(ctx context.Context) error {
-	resources := &planPricingList{}
+func (list *PlanRampPricingList) FetchWithContext(ctx context.Context) error {
+	resources := &planRampPricingList{}
 	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
@@ -107,13 +101,13 @@ func (list *PlanPricingList) FetchWithContext(ctx context.Context) error {
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *PlanPricingList) Fetch() error {
+func (list *PlanRampPricingList) Fetch() error {
 	return list.FetchWithContext(context.Background())
 }
 
 // Count returns the count of items on the server that match this pager
-func (list *PlanPricingList) CountWithContext(ctx context.Context) (*int64, error) {
-	resources := &planPricingList{}
+func (list *PlanRampPricingList) CountWithContext(ctx context.Context) (*int64, error) {
+	resources := &planRampPricingList{}
 	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
@@ -123,6 +117,6 @@ func (list *PlanPricingList) CountWithContext(ctx context.Context) (*int64, erro
 }
 
 // Count returns the count of items on the server that match this pager
-func (list *PlanPricingList) Count() (*int64, error) {
+func (list *PlanRampPricingList) Count() (*int64, error) {
 	return list.CountWithContext(context.Background())
 }

--- a/plan_ramp_pricing_create.go
+++ b/plan_ramp_pricing_create.go
@@ -1,0 +1,16 @@
+// This file is automatically created by Recurly's OpenAPI generation process
+// and thus any edits you make by hand will be lost. If you wish to make a
+// change to this file, please create a Github issue explaining the changes you
+// need and we will usher them to the appropriate places.
+package recurly
+
+import ()
+
+type PlanRampPricingCreate struct {
+
+	// 3-letter ISO 4217 currency code.
+	Currency *string `json:"currency,omitempty"`
+
+	// Represents the price for the Ramp Interval.
+	UnitAmount *float64 `json:"unit_amount,omitempty"`
+}

--- a/plan_update.go
+++ b/plan_update.go
@@ -38,6 +38,9 @@ type PlanUpdate struct {
 	// Subscriptions will automatically inherit this value once they are active. If `auto_renew` is `true`, then a subscription will automatically renew its term at renewal. If `auto_renew` is `false`, then a subscription will expire at the end of its term. `auto_renew` can be overridden on the subscription record itself.
 	AutoRenew *bool `json:"auto_renew,omitempty"`
 
+	// Ramp Intervals
+	RampIntervals []PlanRampIntervalCreate `json:"ramp_intervals,omitempty"`
+
 	// Revenue schedule type
 	RevenueScheduleType *string `json:"revenue_schedule_type,omitempty"`
 
@@ -59,7 +62,7 @@ type PlanUpdate struct {
 	// `true` exempts tax on the plan, `false` applies tax on the plan.
 	TaxExempt *bool `json:"tax_exempt,omitempty"`
 
-	// Pricing
+	// Optional when the pricing model is 'ramp'.
 	Currencies []PlanPricingCreate `json:"currencies,omitempty"`
 
 	// Hosted pages settings

--- a/scripts/clean
+++ b/scripts/clean
@@ -48,6 +48,7 @@ rm -f add_on_mini.go
 rm -f subscription_add_on_tier.go
 rm -f subscription_add_on_percentage_tier.go
 rm -f subscription_change_billing_info.go
+rm -f subscription_ramp_interval_response.go
 rm -f unique_coupon_code_params.go
 rm -f unique_coupon_code.go
 rm -f custom_field_definition.go
@@ -56,6 +57,8 @@ rm -f pricing.go
 rm -f measured_unit.go
 rm -f binary_file.go
 rm -f plan.go
+rm -f plan_ramp_interval.go
+rm -f plan_ramp_pricing.go
 rm -f plan_pricing.go
 rm -f plan_hosted_pages.go
 rm -f add_on.go
@@ -104,6 +107,8 @@ rm -f invoice_refund.go
 rm -f line_item_refund.go
 rm -f external_refund.go
 rm -f plan_create.go
+rm -f plan_ramp_interval_create.go
+rm -f plan_ramp_pricing_create.go
 rm -f plan_pricing_create.go
 rm -f plan_hosted_pages_create.go
 rm -f add_on_create.go
@@ -121,6 +126,7 @@ rm -f subscription_shipping_create.go
 rm -f subscription_add_on_create.go
 rm -f subscription_add_on_tier_create.go
 rm -f subscription_add_on_percentage_tier_create.go
+rm -f subscription_ramp_interval.go
 rm -f subscription_update.go
 rm -f subscription_shipping_update.go
 rm -f subscription_cancel.go

--- a/subscription.go
+++ b/subscription.go
@@ -70,6 +70,9 @@ type Subscription struct {
 	// Whether the subscription renews at the end of its term.
 	AutoRenew bool `json:"auto_renew,omitempty"`
 
+	// The ramp intervals representing the pricing schedule for the subscription.
+	RampIntervals []SubscriptionRampIntervalResponse `json:"ramp_intervals,omitempty"`
+
 	// Null unless subscription is paused or will pause at the end of the current billing period.
 	PausedAt time.Time `json:"paused_at,omitempty"`
 

--- a/subscription_change.go
+++ b/subscription_change.go
@@ -66,6 +66,9 @@ type SubscriptionChange struct {
 
 	// Accept nested attributes for three_d_secure_action_result_token_id
 	BillingInfo SubscriptionChangeBillingInfo `json:"billing_info,omitempty"`
+
+	// The ramp intervals representing the pricing schedule for the subscription.
+	RampIntervals []SubscriptionRampIntervalResponse `json:"ramp_intervals,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/subscription_change_create.go
+++ b/subscription_change_create.go
@@ -68,4 +68,7 @@ type SubscriptionChangeCreate struct {
 	TransactionType *string `json:"transaction_type,omitempty"`
 
 	BillingInfo *SubscriptionChangeBillingInfoCreate `json:"billing_info,omitempty"`
+
+	// The new set of ramp intervals for the subscription.
+	RampIntervals []SubscriptionRampInterval `json:"ramp_intervals,omitempty"`
 }

--- a/subscription_create.go
+++ b/subscription_create.go
@@ -66,6 +66,9 @@ type SubscriptionCreate struct {
 	// Whether the subscription renews at the end of its term.
 	AutoRenew *bool `json:"auto_renew,omitempty"`
 
+	// The new set of ramp intervals for the subscription.
+	RampIntervals []SubscriptionRampInterval `json:"ramp_intervals,omitempty"`
+
 	// Revenue schedule type
 	RevenueScheduleType *string `json:"revenue_schedule_type,omitempty"`
 

--- a/subscription_purchase.go
+++ b/subscription_purchase.go
@@ -54,4 +54,7 @@ type SubscriptionPurchase struct {
 
 	// Revenue schedule type
 	RevenueScheduleType *string `json:"revenue_schedule_type,omitempty"`
+
+	// The new set of ramp intervals for the subscription.
+	RampIntervals []SubscriptionRampInterval `json:"ramp_intervals,omitempty"`
 }

--- a/subscription_ramp_interval.go
+++ b/subscription_ramp_interval.go
@@ -1,0 +1,16 @@
+// This file is automatically created by Recurly's OpenAPI generation process
+// and thus any edits you make by hand will be lost. If you wish to make a
+// change to this file, please create a Github issue explaining the changes you
+// need and we will usher them to the appropriate places.
+package recurly
+
+import ()
+
+type SubscriptionRampInterval struct {
+
+	// Represents how many billing cycles are included in a ramp interval.
+	StartingBillingCycle *int `json:"starting_billing_cycle,omitempty"`
+
+	// Represents the price for the ramp interval.
+	UnitAmount *int `json:"unit_amount,omitempty"`
+}

--- a/subscription_ramp_interval_response.go
+++ b/subscription_ramp_interval_response.go
@@ -9,60 +9,57 @@ import (
 	"net/http"
 )
 
-type PlanPricing struct {
+type SubscriptionRampIntervalResponse struct {
 	recurlyResponse *ResponseMetadata
 
-	// 3-letter ISO 4217 currency code.
-	Currency string `json:"currency,omitempty"`
+	// Represents how many billing cycles are included in a ramp interval.
+	StartingBillingCycle int `json:"starting_billing_cycle,omitempty"`
 
-	// Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
-	SetupFee float64 `json:"setup_fee,omitempty"`
+	// Represents how many billing cycles are left in a ramp interval.
+	RemainingBillingCycles int `json:"remaining_billing_cycles,omitempty"`
 
-	// This field should not be sent when the pricing model is 'ramp'.
-	UnitAmount float64 `json:"unit_amount,omitempty"`
-
-	// This field is deprecated. Please do not use it.
-	TaxInclusive bool `json:"tax_inclusive,omitempty"`
+	// Represents the price for the ramp interval.
+	UnitAmount int `json:"unit_amount,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource
-func (resource *PlanPricing) GetResponse() *ResponseMetadata {
+func (resource *SubscriptionRampIntervalResponse) GetResponse() *ResponseMetadata {
 	return resource.recurlyResponse
 }
 
 // setResponse sets the ResponseMetadata that generated this resource
-func (resource *PlanPricing) setResponse(res *ResponseMetadata) {
+func (resource *SubscriptionRampIntervalResponse) setResponse(res *ResponseMetadata) {
 	resource.recurlyResponse = res
 }
 
 // internal struct for deserializing accounts
-type planPricingList struct {
+type subscriptionRampIntervalResponseList struct {
 	ListMetadata
-	Data            []PlanPricing `json:"data"`
+	Data            []SubscriptionRampIntervalResponse `json:"data"`
 	recurlyResponse *ResponseMetadata
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource
-func (resource *planPricingList) GetResponse() *ResponseMetadata {
+func (resource *subscriptionRampIntervalResponseList) GetResponse() *ResponseMetadata {
 	return resource.recurlyResponse
 }
 
 // setResponse sets the ResponseMetadata that generated this resource
-func (resource *planPricingList) setResponse(res *ResponseMetadata) {
+func (resource *subscriptionRampIntervalResponseList) setResponse(res *ResponseMetadata) {
 	resource.recurlyResponse = res
 }
 
-// PlanPricingList allows you to paginate PlanPricing objects
-type PlanPricingList struct {
+// SubscriptionRampIntervalResponseList allows you to paginate SubscriptionRampIntervalResponse objects
+type SubscriptionRampIntervalResponseList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
 	hasMore        bool
-	data           []PlanPricing
+	data           []SubscriptionRampIntervalResponse
 }
 
-func NewPlanPricingList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PlanPricingList {
-	return &PlanPricingList{
+func NewSubscriptionRampIntervalResponseList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *SubscriptionRampIntervalResponseList {
+	return &SubscriptionRampIntervalResponseList{
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
@@ -70,31 +67,31 @@ func NewPlanPricingList(client HTTPCaller, nextPagePath string, requestOptions *
 	}
 }
 
-type PlanPricingLister interface {
+type SubscriptionRampIntervalResponseLister interface {
 	Fetch() error
 	FetchWithContext(ctx context.Context) error
 	Count() (*int64, error)
 	CountWithContext(ctx context.Context) (*int64, error)
-	Data() []PlanPricing
+	Data() []SubscriptionRampIntervalResponse
 	HasMore() bool
 	Next() string
 }
 
-func (list *PlanPricingList) HasMore() bool {
+func (list *SubscriptionRampIntervalResponseList) HasMore() bool {
 	return list.hasMore
 }
 
-func (list *PlanPricingList) Next() string {
+func (list *SubscriptionRampIntervalResponseList) Next() string {
 	return list.nextPagePath
 }
 
-func (list *PlanPricingList) Data() []PlanPricing {
+func (list *SubscriptionRampIntervalResponseList) Data() []SubscriptionRampIntervalResponse {
 	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *PlanPricingList) FetchWithContext(ctx context.Context) error {
-	resources := &planPricingList{}
+func (list *SubscriptionRampIntervalResponseList) FetchWithContext(ctx context.Context) error {
+	resources := &subscriptionRampIntervalResponseList{}
 	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
@@ -107,13 +104,13 @@ func (list *PlanPricingList) FetchWithContext(ctx context.Context) error {
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *PlanPricingList) Fetch() error {
+func (list *SubscriptionRampIntervalResponseList) Fetch() error {
 	return list.FetchWithContext(context.Background())
 }
 
 // Count returns the count of items on the server that match this pager
-func (list *PlanPricingList) CountWithContext(ctx context.Context) (*int64, error) {
-	resources := &planPricingList{}
+func (list *SubscriptionRampIntervalResponseList) CountWithContext(ctx context.Context) (*int64, error) {
+	resources := &subscriptionRampIntervalResponseList{}
 	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
@@ -123,6 +120,6 @@ func (list *PlanPricingList) CountWithContext(ctx context.Context) (*int64, erro
 }
 
 // Count returns the count of items on the server that match this pager
-func (list *PlanPricingList) Count() (*int64, error) {
+func (list *SubscriptionRampIntervalResponseList) Count() (*int64, error) {
 	return list.CountWithContext(context.Background())
 }


### PR DESCRIPTION
- Adds `pricing_model` property to plan requests and responses (`Plan`, `PlanCreate`), which indicates if the plan is 'fixed' or 'ramp' -priced
- Adds `ramp_intervals` property (`PlanRampInterval`) to plan requests and responses (`Plan`, `PlanCreate`), which defines the pricing schedule of a ramp plan
- Adds `ramp_intervals` property (`SubscriptionRampIntervalResponse`, `SubscriptionRampInterval`) to subscription requests and responses (`Subscription`, `SubscriptionCreate`, `SubscriptionChangeCreate`, `SubscriptionChangePreview`, `SubscriptionPurchase`), which defines the pricing schedule of a ramp subscription
- Adds `username` property to `PaymentMethod`