### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/billing_info_verify_cvv.go
+++ b/billing_info_verify_cvv.go
@@ -6,11 +6,8 @@ package recurly
 
 import ()
 
-type PlanRampIntervalCreate struct {
+type BillingInfoVerifyCVV struct {
 
-	// Represents the billing cycle where a ramp interval starts.
-	StartingBillingCycle *int `json:"starting_billing_cycle,omitempty"`
-
-	// Represents the price for the ramp interval.
-	Currencies []PlanRampPricingCreate `json:"currencies,omitempty"`
+	// Unique security code for a credit card.
+	VerificationValue *string `json:"verification_value,omitempty"`
 }

--- a/client_operations.go
+++ b/client_operations.go
@@ -64,6 +64,9 @@ type ClientInterface interface {
 	VerifyBillingInfo(accountId string, params *VerifyBillingInfoParams, opts ...Option) (*Transaction, error)
 	VerifyBillingInfoWithContext(ctx context.Context, accountId string, params *VerifyBillingInfoParams, opts ...Option) (*Transaction, error)
 
+	VerifyBillingInfoCvv(accountId string, body *BillingInfoVerifyCVV, opts ...Option) (*Transaction, error)
+	VerifyBillingInfoCvvWithContext(ctx context.Context, accountId string, body *BillingInfoVerifyCVV, opts ...Option) (*Transaction, error)
+
 	ListBillingInfos(accountId string, params *ListBillingInfosParams, opts ...Option) (BillingInfoLister, error)
 
 	CreateBillingInfo(accountId string, body *BillingInfoCreate, opts ...Option) (*BillingInfo, error)
@@ -973,6 +976,35 @@ func (c *Client) verifyBillingInfo(ctx context.Context, accountId string, params
 	requestOptions := NewRequestOptions(opts...)
 	result := &Transaction{}
 	err = c.Call(ctx, http.MethodPost, path, nil, params, requestOptions, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, err
+}
+
+// VerifyBillingInfoCvv wraps VerifyBillingInfoCvvWithContext using the background context
+func (c *Client) VerifyBillingInfoCvv(accountId string, body *BillingInfoVerifyCVV, opts ...Option) (*Transaction, error) {
+	ctx := context.Background()
+	return c.verifyBillingInfoCvv(ctx, accountId, body, opts...)
+}
+
+// VerifyBillingInfoCvvWithContext Verify an account's credit card billing cvv
+//
+// API Documentation: https://developers.recurly.com/api/v2021-02-25#operation/verify_billing_info_cvv
+//
+// Returns: Transaction information from verify.
+func (c *Client) VerifyBillingInfoCvvWithContext(ctx context.Context, accountId string, body *BillingInfoVerifyCVV, opts ...Option) (*Transaction, error) {
+	return c.verifyBillingInfoCvv(ctx, accountId, body, opts...)
+}
+
+func (c *Client) verifyBillingInfoCvv(ctx context.Context, accountId string, body *BillingInfoVerifyCVV, opts ...Option) (*Transaction, error) {
+	path, err := c.InterpolatePath("/accounts/{account_id}/billing_info/verify_cvv", accountId)
+	if err != nil {
+		return nil, err
+	}
+	requestOptions := NewRequestOptions(opts...)
+	result := &Transaction{}
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -2441,6 +2441,47 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Fetched Transaction:
           %v\", transaction)"
+  "/accounts/{account_id}/billing_info/verify_cvv":
+    post:
+      tags:
+      - billing_info
+      operationId: verify_billing_info_cvv
+      summary: Verify an account's credit card billing cvv
+      parameters:
+      - "$ref": "#/components/parameters/account_id"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/BillingInfoVerifyCVV"
+      responses:
+        '200':
+          description: Transaction information from verify.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Transaction"
+        '429':
+          description: Over limit error. A credit card can only be checked 3 times
+            in 24 hours.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '422':
+          description: Invalid billing information, or error running the verification
+            transaction.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorMayHaveTransaction"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/accounts/{account_id}/billing_infos":
     get:
       tags:
@@ -16942,6 +16983,12 @@ components:
           type: string
           description: An identifier for a specific payment gateway.
           maxLength: 13
+    BillingInfoVerifyCVV:
+      type: object
+      properties:
+        verification_value:
+          type: string
+          description: Unique security code for a credit card.
     Coupon:
       type: object
       properties:
@@ -19275,7 +19322,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents the first billing cycle of a ramp.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         currencies:
           type: array
@@ -21239,7 +21286,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         unit_amount:
           type: integer
@@ -21250,7 +21297,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
         remaining_billing_cycles:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.

--- a/plan_ramp_interval.go
+++ b/plan_ramp_interval.go
@@ -12,7 +12,7 @@ import (
 type PlanRampInterval struct {
 	recurlyResponse *ResponseMetadata
 
-	// Represents the first billing cycle of a ramp.
+	// Represents the billing cycle where a ramp interval starts.
 	StartingBillingCycle int `json:"starting_billing_cycle,omitempty"`
 
 	// Represents the price for the ramp interval.

--- a/scripts/clean
+++ b/scripts/clean
@@ -86,6 +86,7 @@ rm -f billing_info_create.go
 rm -f custom_field_create.go
 rm -f account_update.go
 rm -f billing_info_verify.go
+rm -f billing_info_verify_cvv.go
 rm -f coupon_redemption_create.go
 rm -f invoice_create.go
 rm -f line_item_create.go

--- a/subscription_ramp_interval.go
+++ b/subscription_ramp_interval.go
@@ -8,7 +8,7 @@ import ()
 
 type SubscriptionRampInterval struct {
 
-	// Represents how many billing cycles are included in a ramp interval.
+	// Represents the billing cycle where a ramp interval starts.
 	StartingBillingCycle *int `json:"starting_billing_cycle,omitempty"`
 
 	// Represents the price for the ramp interval.

--- a/subscription_ramp_interval_response.go
+++ b/subscription_ramp_interval_response.go
@@ -12,7 +12,7 @@ import (
 type SubscriptionRampIntervalResponse struct {
 	recurlyResponse *ResponseMetadata
 
-	// Represents how many billing cycles are included in a ramp interval.
+	// Represents the billing cycle where a ramp interval starts.
 	StartingBillingCycle int `json:"starting_billing_cycle,omitempty"`
 
 	// Represents how many billing cycles are left in a ramp interval.


### PR DESCRIPTION
- Added `/accounts/{account_id}/billing_info/verify_cvv` route which takes a `verification_value` and returns a `transaction` if the `verification_value` matches the cvv of the credit card on file. A `422` is returned if the `verification_value` does not match the credit card on file and the a `429` is returned if the same credit card is checked more than 3 times in 24 hours.