### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21302,7 +21302,9 @@ components:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.
         unit_amount:
-          type: integer
+          type: number
+          format: float
+          title: Unit price
           description: Represents the price for the ramp interval.
     TaxInfo:
       type: object

--- a/subscription_ramp_interval_response.go
+++ b/subscription_ramp_interval_response.go
@@ -19,7 +19,7 @@ type SubscriptionRampIntervalResponse struct {
 	RemainingBillingCycles int `json:"remaining_billing_cycles,omitempty"`
 
 	// Represents the price for the ramp interval.
-	UnitAmount int `json:"unit_amount,omitempty"`
+	UnitAmount float64 `json:"unit_amount,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource


### PR DESCRIPTION
Fixed incorrect type in OpenAPI spec for SubscriptionRampIntervalResponse, `unit_amount` is now `float64`