### PR TITLE
Generated Latest Changes for v2019-10-10(Decimal Usage and Quantities)

### DIFF
--- a/client_operations.go
+++ b/client_operations.go
@@ -376,8 +376,8 @@ type ClientInterface interface {
 	GetDunningCampaign(dunningCampaignId string, opts ...Option) (*DunningCampaign, error)
 	GetDunningCampaignWithContext(ctx context.Context, dunningCampaignId string, opts ...Option) (*DunningCampaign, error)
 
-	PutDunningCampaignBulkUpdate(body *DunningCampaignsBulkUpdate, opts ...Option) (*DunningCampaignsBulkUpdateResponse, error)
-	PutDunningCampaignBulkUpdateWithContext(ctx context.Context, body *DunningCampaignsBulkUpdate, opts ...Option) (*DunningCampaignsBulkUpdateResponse, error)
+	PutDunningCampaignBulkUpdate(dunningCampaignId string, body *DunningCampaignsBulkUpdate, opts ...Option) (*DunningCampaignsBulkUpdateResponse, error)
+	PutDunningCampaignBulkUpdateWithContext(ctx context.Context, dunningCampaignId string, body *DunningCampaignsBulkUpdate, opts ...Option) (*DunningCampaignsBulkUpdateResponse, error)
 }
 
 type ListSitesParams struct {
@@ -6472,12 +6472,12 @@ func (c *Client) getDunningCampaign(ctx context.Context, dunningCampaignId strin
 }
 
 // PutDunningCampaignBulkUpdate wraps PutDunningCampaignBulkUpdateWithContext using the background context
-func (c *Client) PutDunningCampaignBulkUpdate(body *DunningCampaignsBulkUpdate, opts ...Option) (*DunningCampaignsBulkUpdateResponse, error) {
+func (c *Client) PutDunningCampaignBulkUpdate(dunningCampaignId string, body *DunningCampaignsBulkUpdate, opts ...Option) (*DunningCampaignsBulkUpdateResponse, error) {
 	ctx := context.Background()
 	if body.Params.Context != nil {
 		ctx = body.Params.Context
 	}
-	return c.putDunningCampaignBulkUpdate(ctx, body, opts...)
+	return c.putDunningCampaignBulkUpdate(ctx, dunningCampaignId, body, opts...)
 }
 
 // PutDunningCampaignBulkUpdateWithContext Assign a dunning campaign to multiple plans
@@ -6485,12 +6485,12 @@ func (c *Client) PutDunningCampaignBulkUpdate(body *DunningCampaignsBulkUpdate, 
 // API Documentation: https://developers.recurly.com/api/v2019-10-10#operation/put_dunning_campaign_bulk_update
 //
 // Returns: A list of updated plans.
-func (c *Client) PutDunningCampaignBulkUpdateWithContext(ctx context.Context, body *DunningCampaignsBulkUpdate, opts ...Option) (*DunningCampaignsBulkUpdateResponse, error) {
-	return c.putDunningCampaignBulkUpdate(ctx, body, opts...)
+func (c *Client) PutDunningCampaignBulkUpdateWithContext(ctx context.Context, dunningCampaignId string, body *DunningCampaignsBulkUpdate, opts ...Option) (*DunningCampaignsBulkUpdateResponse, error) {
+	return c.putDunningCampaignBulkUpdate(ctx, dunningCampaignId, body, opts...)
 }
 
-func (c *Client) putDunningCampaignBulkUpdate(ctx context.Context, body *DunningCampaignsBulkUpdate, opts ...Option) (*DunningCampaignsBulkUpdateResponse, error) {
-	path, err := c.InterpolatePath("/dunning_campaigns/{dunning_campaign_id}/bulk_update")
+func (c *Client) putDunningCampaignBulkUpdate(ctx context.Context, dunningCampaignId string, body *DunningCampaignsBulkUpdate, opts ...Option) (*DunningCampaignsBulkUpdateResponse, error) {
+	path, err := c.InterpolatePath("/dunning_campaigns/{dunning_campaign_id}/bulk_update", dunningCampaignId)
 	if err != nil {
 		// NOOP in 3.x client
 	}

--- a/line_item.go
+++ b/line_item.go
@@ -104,6 +104,9 @@ type LineItem struct {
 	// This number will be multiplied by the unit amount to compute the subtotal before any discounts or taxes.
 	Quantity int `json:"quantity,omitempty"`
 
+	// A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.
+	QuantityDecimal string `json:"quantity_decimal,omitempty"`
+
 	// Positive amount for a charge, negative amount for a credit.
 	UnitAmount float64 `json:"unit_amount,omitempty"`
 
@@ -145,6 +148,9 @@ type LineItem struct {
 
 	// For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds).
 	RefundedQuantity int `json:"refunded_quantity,omitempty"`
+
+	// A floating-point alternative to Refunded Quantity. For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds). The Decimal Quantity feature must be enabled to utilize this field.
+	RefundedQuantityDecimal string `json:"refunded_quantity_decimal,omitempty"`
 
 	// The amount of credit from this line item that was applied to the invoice.
 	CreditApplied float64 `json:"credit_applied,omitempty"`

--- a/line_item_refund.go
+++ b/line_item_refund.go
@@ -15,6 +15,9 @@ type LineItemRefund struct {
 	// Line item quantity to be refunded.
 	Quantity *int `json:"quantity,omitempty"`
 
+	// A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.
+	QuantityDecimal *string `json:"quantity_decimal,omitempty"`
+
 	// Set to `true` if the line item should be prorated; set to `false` if not.
 	// This can only be used on line items that have a start and end date.
 	Prorate *bool `json:"prorate,omitempty"`

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -14463,6 +14463,8 @@ paths:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
   "/dunning_campaigns/{dunning_campaign_id}/bulk_update":
+    parameters:
+    - "$ref": "#/components/parameters/dunning_campaign_id"
     put:
       tags:
       - dunning_campaigns
@@ -18423,6 +18425,14 @@ components:
           description: This number will be multiplied by the unit amount to compute
             the subtotal before any discounts or taxes.
           default: 1
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         unit_amount:
           type: number
           format: float
@@ -18503,6 +18513,13 @@ components:
           title: Refunded Quantity
           description: For refund charges, the quantity being refunded. For non-refund
             charges, the total quantity refunded (possibly over multiple refunds).
+        refunded_quantity_decimal:
+          type: string
+          title: Refunded Quantity Decimal
+          description: A floating-point alternative to Refunded Quantity. For refund
+            charges, the quantity being refunded. For non-refund charges, the total
+            quantity refunded (possibly over multiple refunds). The Decimal Quantity
+            feature must be enabled to utilize this field.
         credit_applied:
           type: number
           format: float
@@ -18544,6 +18561,14 @@ components:
           type: integer
           title: Quantity
           description: Line item quantity to be refunded.
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         prorate:
           type: boolean
           title: Prorate
@@ -19335,7 +19360,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents the first billing cycle of a ramp.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         currencies:
           type: array
@@ -21093,7 +21118,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         unit_amount:
           type: integer
@@ -21104,7 +21129,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
         remaining_billing_cycles:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.
@@ -21533,10 +21558,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         usage_type:
           type: string
           enum:
@@ -21609,10 +21635,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         recording_timestamp:
           type: string
           format: date-time

--- a/plan_ramp_interval.go
+++ b/plan_ramp_interval.go
@@ -12,7 +12,7 @@ import (
 type PlanRampInterval struct {
 	recurlyResponse *ResponseMetadata
 
-	// Represents the first billing cycle of a ramp.
+	// Represents the billing cycle where a ramp interval starts.
 	StartingBillingCycle int `json:"starting_billing_cycle,omitempty"`
 
 	// Represents the price for the ramp interval.

--- a/plan_ramp_interval_create.go
+++ b/plan_ramp_interval_create.go
@@ -9,7 +9,7 @@ import ()
 type PlanRampIntervalCreate struct {
 	Params `json:"-"`
 
-	// Represents the first billing cycle of a ramp.
+	// Represents the billing cycle where a ramp interval starts.
 	StartingBillingCycle *int `json:"starting_billing_cycle,omitempty"`
 
 	// Represents the price for the ramp interval.

--- a/subscription_ramp_interval.go
+++ b/subscription_ramp_interval.go
@@ -9,7 +9,7 @@ import ()
 type SubscriptionRampInterval struct {
 	Params `json:"-"`
 
-	// Represents how many billing cycles are included in a ramp interval.
+	// Represents the billing cycle where a ramp interval starts.
 	StartingBillingCycle *int `json:"starting_billing_cycle,omitempty"`
 
 	// Represents the price for the ramp interval.

--- a/subscription_ramp_interval_response.go
+++ b/subscription_ramp_interval_response.go
@@ -12,7 +12,7 @@ import (
 type SubscriptionRampIntervalResponse struct {
 	recurlyResponse *ResponseMetadata
 
-	// Represents how many billing cycles are included in a ramp interval.
+	// Represents the billing cycle where a ramp interval starts.
 	StartingBillingCycle int `json:"starting_billing_cycle,omitempty"`
 
 	// Represents how many billing cycles are left in a ramp interval.

--- a/usage.go
+++ b/usage.go
@@ -21,7 +21,7 @@ type Usage struct {
 	// Custom field for recording the id in your own system associated with the usage, so you can provide auditable usage displays to your customers using a GET on this endpoint.
 	MerchantTag string `json:"merchant_tag,omitempty"`
 
-	// The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+	// The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is "500").
 	Amount float64 `json:"amount,omitempty"`
 
 	// Type of usage, returns usage type if `add_on_type` is `usage`.

--- a/usage_create.go
+++ b/usage_create.go
@@ -14,7 +14,7 @@ type UsageCreate struct {
 	// Custom field for recording the id in your own system associated with the usage, so you can provide auditable usage displays to your customers using a GET on this endpoint.
 	MerchantTag *string `json:"merchant_tag,omitempty"`
 
-	// The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+	// The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is "500").
 	Amount *float64 `json:"amount,omitempty"`
 
 	// When the usage was recorded in your system.


### PR DESCRIPTION
Adds support for the for decimal usages amount and decimal line items quantity :

- Add `QuantityDecimal ` and `RefundedQuantityDecimal ` properties to `LineItem` class
- Add `QuantityDecimal ` property to `LineItemRefund` class.
- Update `Usage` `amount` property description

Fix Bulk Dunning Campaign update
- Update `PutDunningCampaignBulkUpdate ` method to receive the `dunningCampaignId`
