### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/billing_info_create.go
+++ b/billing_info_create.go
@@ -94,10 +94,10 @@ type BillingInfoCreate struct {
 	// The `backup_payment_method` field is used to designate a billing info as a backup on the account that will be tried if the initial billing info used for an invoice is declined. All payment methods, including the billing info marked `primary_payment_method` can be set as a backup. An account can have a maximum of 1 backup, if a user sets a different payment method as a backup, the existing backup will no longer be marked as such.
 	BackupPaymentMethod *bool `json:"backup_payment_method,omitempty"`
 
-	// Use for Adyen HPP billing info.
+	// Use for Adyen HPP billing info. This should only be used as part of a pending purchase request, when the billing info is nested inside an account object.
 	ExternalHppType *string `json:"external_hpp_type,omitempty"`
 
-	// Use for Online Banking billing info.
+	// Use for Online Banking billing info. This should only be used as part of a pending purchase request, when the billing info is nested inside an account object.
 	OnlineBankingPaymentType *string `json:"online_banking_payment_type,omitempty"`
 
 	CardType *string `json:"card_type,omitempty"`

--- a/invoice.go
+++ b/invoice.go
@@ -124,6 +124,12 @@ type Invoice struct {
 
 	// Unique ID to identify the dunning campaign used when dunning the invoice. For sites without multiple dunning campaigns enabled, this will always be the default dunning campaign.
 	DunningCampaignId string `json:"dunning_campaign_id,omitempty"`
+
+	// Number of times the event was sent.
+	DunningEventsSent int `json:"dunning_events_sent,omitempty"`
+
+	// Last communication attempt.
+	FinalDunningEvent bool `json:"final_dunning_event,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/line_item.go
+++ b/line_item.go
@@ -104,6 +104,9 @@ type LineItem struct {
 	// This number will be multiplied by the unit amount to compute the subtotal before any discounts or taxes.
 	Quantity int `json:"quantity,omitempty"`
 
+	// A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.
+	QuantityDecimal string `json:"quantity_decimal,omitempty"`
+
 	// Positive amount for a charge, negative amount for a credit.
 	UnitAmount float64 `json:"unit_amount,omitempty"`
 
@@ -148,6 +151,9 @@ type LineItem struct {
 
 	// For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds).
 	RefundedQuantity int `json:"refunded_quantity,omitempty"`
+
+	// A floating-point alternative to Refunded Quantity. For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds). The Decimal Quantity feature must be enabled to utilize this field.
+	RefundedQuantityDecimal string `json:"refunded_quantity_decimal,omitempty"`
 
 	// The amount of credit from this line item that was applied to the invoice.
 	CreditApplied float64 `json:"credit_applied,omitempty"`

--- a/line_item_refund.go
+++ b/line_item_refund.go
@@ -14,6 +14,9 @@ type LineItemRefund struct {
 	// Line item quantity to be refunded.
 	Quantity *int `json:"quantity,omitempty"`
 
+	// A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.
+	QuantityDecimal *string `json:"quantity_decimal,omitempty"`
+
 	// Set to `true` if the line item should be prorated; set to `false` if not.
 	// This can only be used on line items that have a start and end date.
 	Prorate *bool `json:"prorate,omitempty"`

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -18141,6 +18141,14 @@ components:
           description: Unique ID to identify the dunning campaign used when dunning
             the invoice. For sites without multiple dunning campaigns enabled, this
             will always be the default dunning campaign.
+        dunning_events_sent:
+          type: integer
+          title: Dunning Event Sent
+          description: Number of times the event was sent.
+        final_dunning_event:
+          type: boolean
+          title: Final Dunning Event
+          description: Last communication attempt.
     InvoiceCreate:
       type: object
       properties:
@@ -18622,6 +18630,14 @@ components:
           description: This number will be multiplied by the unit amount to compute
             the subtotal before any discounts or taxes.
           default: 1
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         unit_amount:
           type: number
           format: float
@@ -18706,6 +18722,13 @@ components:
           title: Refunded Quantity
           description: For refund charges, the quantity being refunded. For non-refund
             charges, the total quantity refunded (possibly over multiple refunds).
+        refunded_quantity_decimal:
+          type: string
+          title: Refunded Quantity Decimal
+          description: A floating-point alternative to Refunded Quantity. For refund
+            charges, the quantity being refunded. For non-refund charges, the total
+            quantity refunded (possibly over multiple refunds). The Decimal Quantity
+            feature must be enabled to utilize this field.
         credit_applied:
           type: number
           format: float
@@ -18747,6 +18770,14 @@ components:
           type: integer
           title: Quantity
           description: Line item quantity to be refunded.
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         prorate:
           type: boolean
           title: Prorate
@@ -21667,10 +21698,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         usage_type:
           "$ref": "#/components/schemas/UsageTypeEnum"
         tier_type:
@@ -21741,10 +21773,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         recording_timestamp:
           type: string
           format: date-time
@@ -23058,12 +23091,16 @@ components:
       - savings
     ExternalHppTypeEnum:
       type: string
-      description: Use for Adyen HPP billing info.
+      description: Use for Adyen HPP billing info. This should only be used as part
+        of a pending purchase request, when the billing info is nested inside an account
+        object.
       enum:
       - adyen
     OnlineBankingPaymentTypeEnum:
       type: string
-      description: Use for Online Banking billing info.
+      description: Use for Online Banking billing info. This should only be used as
+        part of a pending purchase request, when the billing info is nested inside
+        an account object.
       enum:
       - ideal
       - sofort

--- a/usage.go
+++ b/usage.go
@@ -21,7 +21,7 @@ type Usage struct {
 	// Custom field for recording the id in your own system associated with the usage, so you can provide auditable usage displays to your customers using a GET on this endpoint.
 	MerchantTag string `json:"merchant_tag,omitempty"`
 
-	// The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+	// The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is "500").
 	Amount float64 `json:"amount,omitempty"`
 
 	// Type of usage, returns usage type if `add_on_type` is `usage`.

--- a/usage_create.go
+++ b/usage_create.go
@@ -13,7 +13,7 @@ type UsageCreate struct {
 	// Custom field for recording the id in your own system associated with the usage, so you can provide auditable usage displays to your customers using a GET on this endpoint.
 	MerchantTag *string `json:"merchant_tag,omitempty"`
 
-	// The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+	// The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is "500").
 	Amount *float64 `json:"amount,omitempty"`
 
 	// When the usage was recorded in your system.


### PR DESCRIPTION
Adds support for the for decimal usages amount and decimal line items quantity :

- Add `QuantityDecimal ` and `RefundedQuantityDecimal ` properties to `LineItem` class
- Add `QuantityDecimal ` property to `LineItemRefund` class.
- Update `Usage` `amount` property description

Invoice request format has changed:
- Added `dunning_events_sent` and `final_dunning_event`
