### PR TITLE
Generated Latest Changes for v2019-10-10 (UsedTaxService on Invoice)

### DIFF
--- a/billing_info_create.go
+++ b/billing_info_create.go
@@ -35,6 +35,9 @@ type BillingInfoCreate struct {
 	// *STRONGLY RECOMMENDED*
 	Cvv *string `json:"cvv,omitempty"`
 
+	// 3-letter ISO 4217 currency code.
+	Currency *string `json:"currency,omitempty"`
+
 	// VAT number
 	VatNumber *string `json:"vat_number,omitempty"`
 

--- a/custom_field_definition.go
+++ b/custom_field_definition.go
@@ -30,6 +30,7 @@ type CustomFieldDefinition struct {
 	// - `read_only` - Users with the Customers role will be able to view this field's data via the admin UI, but
 	//   editing will only be available via the API.
 	// - `write` - Users with the Customers role will be able to view and edit this field's data via the admin UI.
+	// - `set_only` - Users with the Customers role will be able to set this field's data via the admin console.
 	UserAccess string `json:"user_access,omitempty"`
 
 	// Used to label the field when viewing and editing the field in Recurly's admin UI.

--- a/invoice.go
+++ b/invoice.go
@@ -83,6 +83,9 @@ type Invoice struct {
 	// Tax info
 	TaxInfo TaxInfo `json:"tax_info,omitempty"`
 
+	// Will be `true` when the invoice had a successful response from the tax service and `false` when the invoice was not sent to tax service due to a lack of address or enabled jurisdiction or was processed without tax due to a non-blocking error returned from the tax service.
+	UsedTaxService bool `json:"used_tax_service,omitempty"`
+
 	// VAT registration number for the customer on this invoice. This will come from the VAT Number field in the Billing Info or the Account Info depending on your tax settings and the invoice collection method.
 	VatNumber string `json:"vat_number,omitempty"`
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -224,8 +224,8 @@ tags:
   x-displayName: Site
 - name: custom_field_definition
   x-displayName: Custom Field Definition
-  description: Describes the fields that can use used as custom fields on accounts
-    or subscriptions.
+  description: Describes the fields that can be used as custom fields on accounts,
+    items, line-items (one time charges), plans, or subscriptions.
 - name: item
   x-displayName: Item
   description: |-
@@ -15561,7 +15561,9 @@ components:
           - es-MX
           - es-US
           - fi-FI
+          - fr-BE
           - fr-CA
+          - fr-CH
           - fr-FR
           - hi-IN
           - it-IT
@@ -15698,7 +15700,9 @@ components:
           - es-MX
           - es-US
           - fi-FI
+          - fr-BE
           - fr-CA
+          - fr-CH
           - fr-FR
           - hi-IN
           - it-IT
@@ -16619,6 +16623,9 @@ components:
           title: Security code or CVV
           description: "*STRONGLY RECOMMENDED*"
           maxLength: 4
+        currency:
+          type: string
+          description: 3-letter ISO 4217 currency code.
         vat_number:
           type: string
           title: VAT number
@@ -17468,10 +17475,12 @@ components:
             - `read_only` - Users with the Customers role will be able to view this field's data via the admin UI, but
               editing will only be available via the API.
             - `write` - Users with the Customers role will be able to view and edit this field's data via the admin UI.
+            - `set_only` - Users with the Customers role will be able to set this field's data via the admin console.
           enum:
           - api_only
           - read_only
           - write
+          - set_only
         display_name:
           type: string
           title: Display name
@@ -17966,6 +17975,13 @@ components:
           description: The outstanding balance remaining on this invoice.
         tax_info:
           "$ref": "#/components/schemas/TaxInfo"
+        used_tax_service:
+          type: boolean
+          title: Used Tax Service?
+          description: Will be `true` when the invoice had a successful response from
+            the tax service and `false` when the invoice was not sent to tax service
+            due to a lack of address or enabled jurisdiction or was processed without
+            tax due to a non-blocking error returned from the tax service.
         vat_number:
           type: string
           title: VAT number


### PR DESCRIPTION
`Invoice` response format has changed:
- Added `UsedTaxService`. Field is present if taxes are enabled. Value is `true` or `false` based on a successful response from the tax service.