### PR TITLE
Generated Latest Changes for v2021-02-25 (UsedTaxService on Invoice)

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -86,6 +86,9 @@ type Invoice struct {
 	// Tax info
 	TaxInfo TaxInfo `json:"tax_info,omitempty"`
 
+	// Will be `true` when the invoice had a successful response from the tax service and `false` when the invoice was not sent to tax service due to a lack of address or enabled jurisdiction or was processed without tax due to a non-blocking error returned from the tax service.
+	UsedTaxService bool `json:"used_tax_service,omitempty"`
+
 	// VAT registration number for the customer on this invoice. This will come from the VAT Number field in the Billing Info or the Account Info depending on your tax settings and the invoice collection method.
 	VatNumber string `json:"vat_number,omitempty"`
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -19032,6 +19032,13 @@ components:
           description: The outstanding balance remaining on this invoice.
         tax_info:
           "$ref": "#/components/schemas/TaxInfo"
+        used_tax_service:
+          type: boolean
+          title: Used Tax Service?
+          description: Will be `true` when the invoice had a successful response from
+            the tax service and `false` when the invoice was not sent to tax service
+            due to a lack of address or enabled jurisdiction or was processed without
+            tax due to a non-blocking error returned from the tax service.
         vat_number:
           type: string
           title: VAT number
@@ -24043,7 +24050,9 @@ components:
       - es-MX
       - es-US
       - fi-FI
+      - fr-BE
       - fr-CA
+      - fr-CH
       - fr-FR
       - hi-IN
       - it-IT


### PR DESCRIPTION
`Invoice` response format has changed:
- Added `UsedTaxService`. Field is present if taxes are enabled. Value is `true` or `false` based on a successful response from the tax service.