### PR TITLE
Generated Latest Changes for v2019-10-10 (gateway_attributes on PaymentMethod)

### DIFF
--- a/billing_info_create.go
+++ b/billing_info_create.go
@@ -50,6 +50,9 @@ type BillingInfoCreate struct {
 	// An identifier for a specific payment gateway. Must be used in conjunction with `gateway_token`.
 	GatewayCode *string `json:"gateway_code,omitempty"`
 
+	// Additional attributes to send to the gateway.
+	GatewayAttributes *GatewayAttributesCreate `json:"gateway_attributes,omitempty"`
+
 	// Amazon billing agreement ID
 	AmazonBillingAgreementId *string `json:"amazon_billing_agreement_id,omitempty"`
 

--- a/gateway_attributes.go
+++ b/gateway_attributes.go
@@ -1,0 +1,97 @@
+// This file is automatically created by Recurly's OpenAPI generation process
+// and thus any edits you make by hand will be lost. If you wish to make a
+// change to this file, please create a Github issue explaining the changes you
+// need and we will usher them to the appropriate places.
+package recurly
+
+import (
+	"context"
+	"net/http"
+)
+
+type GatewayAttributes struct {
+	recurlyResponse *ResponseMetadata
+
+	// Used by Adyen gateways. The Shopper Reference value used when the external token was created.
+	AccountReference string `json:"account_reference,omitempty"`
+}
+
+// GetResponse returns the ResponseMetadata that generated this resource
+func (resource *GatewayAttributes) GetResponse() *ResponseMetadata {
+	return resource.recurlyResponse
+}
+
+// setResponse sets the ResponseMetadata that generated this resource
+func (resource *GatewayAttributes) setResponse(res *ResponseMetadata) {
+	resource.recurlyResponse = res
+}
+
+// internal struct for deserializing accounts
+type gatewayAttributesList struct {
+	ListMetadata
+	Data            []GatewayAttributes `json:"data"`
+	recurlyResponse *ResponseMetadata
+}
+
+// GetResponse returns the ResponseMetadata that generated this resource
+func (resource *gatewayAttributesList) GetResponse() *ResponseMetadata {
+	return resource.recurlyResponse
+}
+
+// setResponse sets the ResponseMetadata that generated this resource
+func (resource *gatewayAttributesList) setResponse(res *ResponseMetadata) {
+	resource.recurlyResponse = res
+}
+
+// GatewayAttributesList allows you to paginate GatewayAttributes objects
+type GatewayAttributesList struct {
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
+	HasMore        bool
+	Data           []GatewayAttributes
+}
+
+func NewGatewayAttributesList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *GatewayAttributesList {
+	return &GatewayAttributesList{
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		HasMore:        true,
+	}
+}
+
+// Fetch fetches the next page of data into the `Data` property
+func (list *GatewayAttributesList) FetchWithContext(ctx context.Context) error {
+	resources := &gatewayAttributesList{}
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
+	if err != nil {
+		return err
+	}
+	// copy over properties from the response
+	list.nextPagePath = resources.Next
+	list.HasMore = resources.HasMore
+	list.Data = resources.Data
+	return nil
+}
+
+// Fetch fetches the next page of data into the `Data` property
+func (list *GatewayAttributesList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *GatewayAttributesList) CountWithContext(ctx context.Context) (*int64, error) {
+	resources := &gatewayAttributesList{}
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
+	if err != nil {
+		return nil, err
+	}
+	resp := resources.GetResponse()
+	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *GatewayAttributesList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
+}

--- a/gateway_attributes_create.go
+++ b/gateway_attributes_create.go
@@ -1,0 +1,23 @@
+// This file is automatically created by Recurly's OpenAPI generation process
+// and thus any edits you make by hand will be lost. If you wish to make a
+// change to this file, please create a Github issue explaining the changes you
+// need and we will usher them to the appropriate places.
+package recurly
+
+import ()
+
+type GatewayAttributesCreate struct {
+	Params `json:"-"`
+
+	// Used by Adyen gateways. The Shopper Reference value used when the external token was created. Must be used in conjunction with gateway_token and gateway_code.
+	AccountReference *string `json:"account_reference,omitempty"`
+}
+
+func (attr *GatewayAttributesCreate) toParams() *Params {
+	return &Params{
+		IdempotencyKey: attr.IdempotencyKey,
+		Header:         attr.Header,
+		Context:        attr.Context,
+		Data:           attr,
+	}
+}

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16645,6 +16645,17 @@ components:
           title: An identifier for a specific payment gateway. Must be used in conjunction
             with `gateway_token`.
           maxLength: 12
+        gateway_attributes:
+          type: object
+          description: Additional attributes to send to the gateway.
+          x-class-name: GatewayAttributes
+          properties:
+            account_reference:
+              type: string
+              description: Used by Adyen gateways. The Shopper Reference value used
+                when the external token was created. Must be used in conjunction with
+                gateway_token and gateway_code.
+              maxLength: 264
         amazon_billing_agreement_id:
           type: string
           title: Amazon billing agreement ID
@@ -21470,6 +21481,7 @@ components:
           - force_collect
           - refunded_externally
           - chargeback
+          - external_recovery
         currency:
           type: string
           title: Currency
@@ -22185,6 +22197,7 @@ components:
         object:
           type: string
           enum:
+          - bacs
           - credit_card
           - paypal
           - amazon
@@ -22255,6 +22268,16 @@ components:
           type: string
           description: An identifier for a specific payment gateway.
           maxLength: 13
+        gateway_attributes:
+          type: object
+          description: Gateway specific attributes associated with this PaymentMethod
+          x-class-name: GatewayAttributes
+          properties:
+            account_reference:
+              type: string
+              description: Used by Adyen gateways. The Shopper Reference value used
+                when the external token was created.
+              maxLength: 264
         billing_agreement_id:
           type: string
           description: Billing Agreement identifier. Only present for Amazon or Paypal

--- a/payment_method.go
+++ b/payment_method.go
@@ -41,6 +41,9 @@ type PaymentMethod struct {
 	// An identifier for a specific payment gateway.
 	GatewayCode string `json:"gateway_code,omitempty"`
 
+	// Gateway specific attributes associated with this PaymentMethod
+	GatewayAttributes GatewayAttributes `json:"gateway_attributes,omitempty"`
+
 	// Billing Agreement identifier. Only present for Amazon or Paypal payment methods.
 	BillingAgreementId string `json:"billing_agreement_id,omitempty"`
 

--- a/scripts/clean
+++ b/scripts/clean
@@ -8,6 +8,7 @@ rm -f account.go
 rm -f shipping_address.go
 rm -f billing_info.go
 rm -f payment_method.go
+rm -f gateway_attributes.go
 rm -f fraud_info.go
 rm -f billing_info_updated_by.go
 rm -f custom_field.go
@@ -77,6 +78,7 @@ rm -f account_acquisition_cost_create.go
 rm -f shipping_address_create.go
 rm -f address_create.go
 rm -f billing_info_create.go
+rm -f gateway_attributes_create.go
 rm -f custom_field_create.go
 rm -f account_update.go
 rm -f billing_info_verify.go


### PR DESCRIPTION
Add new property to `BillingInfoCreate` and `PaymentMethod`

- Added `gateway_attributes` property
- `gateway_attributes` allows an `account_reference` value to be be submitted. This field must be passed in with a `gateway_code` and `gateway_token`
- `gateway_attributes` is returned in response if present
