### PR TITLE
Generated Latest Changes for v2021-02-25 (Multiple Business Entities)

### DIFF
--- a/account.go
+++ b/account.go
@@ -63,6 +63,9 @@ type Account struct {
 	// The email address used for communicating with this customer. The customer will also use this email address to log into your hosted account management pages. This value does not need to be unique.
 	Email string `json:"email,omitempty"`
 
+	// Unique ID to identify the business entity assigned to the account. Available when the `Multiple Business Entities` feature is enabled.
+	OverrideBusinessEntityId string `json:"override_business_entity_id,omitempty"`
+
 	// Used to determine the language and locale of emails sent on behalf of the merchant to the customer.
 	PreferredLocale string `json:"preferred_locale,omitempty"`
 

--- a/account_create.go
+++ b/account_create.go
@@ -48,6 +48,9 @@ type AccountCreate struct {
 	// The tax exemption certificate number for the account. If the merchant has an integration for the Vertex tax provider, this optional value will be sent in any tax calculation requests for the account.
 	ExemptionCertificate *string `json:"exemption_certificate,omitempty"`
 
+	// Unique ID to identify the business entity assigned to the account. Available when the `Multiple Business Entities` feature is enabled.
+	OverrideBusinessEntityId *string `json:"override_business_entity_id,omitempty"`
+
 	// The account code of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
 	ParentAccountCode *string `json:"parent_account_code,omitempty"`
 

--- a/account_purchase.go
+++ b/account_purchase.go
@@ -46,6 +46,9 @@ type AccountPurchase struct {
 	// The tax exemption certificate number for the account. If the merchant has an integration for the Vertex tax provider, this optional value will be sent in any tax calculation requests for the account.
 	ExemptionCertificate *string `json:"exemption_certificate,omitempty"`
 
+	// Unique ID to identify the business entity assigned to the account. Available when the `Multiple Business Entities` feature is enabled.
+	OverrideBusinessEntityId *string `json:"override_business_entity_id,omitempty"`
+
 	// The account code of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
 	ParentAccountCode *string `json:"parent_account_code,omitempty"`
 

--- a/account_update.go
+++ b/account_update.go
@@ -38,6 +38,9 @@ type AccountUpdate struct {
 	// The tax exemption certificate number for the account. If the merchant has an integration for the Vertex tax provider, this optional value will be sent in any tax calculation requests for the account.
 	ExemptionCertificate *string `json:"exemption_certificate,omitempty"`
 
+	// Unique ID to identify the business entity assigned to the account. Available when the `Multiple Business Entities` feature is enabled.
+	OverrideBusinessEntityId *string `json:"override_business_entity_id,omitempty"`
+
 	// The account code of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.
 	ParentAccountCode *string `json:"parent_account_code,omitempty"`
 

--- a/business_entity.go
+++ b/business_entity.go
@@ -1,0 +1,150 @@
+// This file is automatically created by Recurly's OpenAPI generation process
+// and thus any edits you make by hand will be lost. If you wish to make a
+// change to this file, please create a Github issue explaining the changes you
+// need and we will usher them to the appropriate places.
+package recurly
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+type BusinessEntity struct {
+	recurlyResponse *ResponseMetadata
+
+	// Business entity ID
+	Id string `json:"id,omitempty"`
+
+	// Object type
+	Object string `json:"object,omitempty"`
+
+	// The entity code of the business entity.
+	Code string `json:"code,omitempty"`
+
+	// This name describes your business entity and will appear on the invoice.
+	Name string `json:"name,omitempty"`
+
+	// Address information for the business entity that will appear on the invoice.
+	InvoiceDisplayAddress Address `json:"invoice_display_address,omitempty"`
+
+	// Address information for the business entity that will be used for calculating taxes.
+	TaxAddress Address `json:"tax_address,omitempty"`
+
+	// VAT number for the customer used on the invoice.
+	DefaultVatNumber string `json:"default_vat_number,omitempty"`
+
+	// Registration number for the customer used on the invoice.
+	DefaultRegistrationNumber string `json:"default_registration_number,omitempty"`
+
+	// List of countries for which the business entity will be used.
+	SubscriberLocationCountries []string `json:"subscriber_location_countries,omitempty"`
+
+	// Created at
+	CreatedAt time.Time `json:"created_at,omitempty"`
+
+	// Last updated at
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+}
+
+// GetResponse returns the ResponseMetadata that generated this resource
+func (resource *BusinessEntity) GetResponse() *ResponseMetadata {
+	return resource.recurlyResponse
+}
+
+// setResponse sets the ResponseMetadata that generated this resource
+func (resource *BusinessEntity) setResponse(res *ResponseMetadata) {
+	resource.recurlyResponse = res
+}
+
+// internal struct for deserializing accounts
+type businessEntityList struct {
+	ListMetadata
+	Data            []BusinessEntity `json:"data"`
+	recurlyResponse *ResponseMetadata
+}
+
+// GetResponse returns the ResponseMetadata that generated this resource
+func (resource *businessEntityList) GetResponse() *ResponseMetadata {
+	return resource.recurlyResponse
+}
+
+// setResponse sets the ResponseMetadata that generated this resource
+func (resource *businessEntityList) setResponse(res *ResponseMetadata) {
+	resource.recurlyResponse = res
+}
+
+// BusinessEntityList allows you to paginate BusinessEntity objects
+type BusinessEntityList struct {
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
+	hasMore        bool
+	data           []BusinessEntity
+}
+
+func NewBusinessEntityList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *BusinessEntityList {
+	return &BusinessEntityList{
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		hasMore:        true,
+	}
+}
+
+type BusinessEntityLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []BusinessEntity
+	HasMore() bool
+	Next() string
+}
+
+func (list *BusinessEntityList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *BusinessEntityList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *BusinessEntityList) Data() []BusinessEntity {
+	return list.data
+}
+
+// Fetch fetches the next page of data into the `Data` property
+func (list *BusinessEntityList) FetchWithContext(ctx context.Context) error {
+	resources := &businessEntityList{}
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
+	if err != nil {
+		return err
+	}
+	// copy over properties from the response
+	list.nextPagePath = resources.Next
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
+	return nil
+}
+
+// Fetch fetches the next page of data into the `Data` property
+func (list *BusinessEntityList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *BusinessEntityList) CountWithContext(ctx context.Context) (*int64, error) {
+	resources := &businessEntityList{}
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
+	if err != nil {
+		return nil, err
+	}
+	resp := resources.GetResponse()
+	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *BusinessEntityList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
+}

--- a/invoice.go
+++ b/invoice.go
@@ -133,6 +133,9 @@ type Invoice struct {
 
 	// Last communication attempt.
 	FinalDunningEvent bool `json:"final_dunning_event,omitempty"`
+
+	// Unique ID to identify the business entity assigned to the invoice. Available when the `Multiple Business Entities` feature is enabled.
+	BusinessEntityId string `json:"business_entity_id,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -228,6 +228,7 @@ x-tagGroups:
   - custom_field_definition
   - shipping_method
   - dunning_campaigns
+  - business_entities
 tags:
 - name: site
   x-displayName: Site
@@ -374,6 +375,10 @@ tags:
   description: An account from an external resource that is not managed by the Recurly
     platform and instead is managed by third-party platforms like Apple App Store
     and Google Play Store.
+- name: business_entities
+  x-displayName: Business Entities
+  description: Describes the business address that will be used for invoices and taxes
+    depending on settings and subscriber location.
 paths:
   "/sites":
     get:
@@ -15974,6 +15979,60 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
+  "/business_entities/{business_entity_id}":
+    parameters:
+    - "$ref": "#/components/parameters/business_entity_id"
+    get:
+      tags:
+      - business_entities
+      operationId: get_business_entity
+      summary: Fetch a business entity
+      responses:
+        '200':
+          description: Business entity details
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BusinessEntity"
+        '404':
+          description: Incorrect site or business entity ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+  "/business_entities":
+    get:
+      tags:
+      - business_entities
+      operationId: list_business_entities
+      summary: List business entities
+      responses:
+        '200':
+          description: List of all business entities on your site.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BusinessEntityList"
+        '404':
+          description: Incorrect site.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/gift_cards":
     get:
       tags:
@@ -16143,6 +16202,49 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
+  "/business_entities/{business_entity_id}/invoices":
+    get:
+      tags:
+      - invoice
+      operationId: list_business_entity_invoices
+      summary: List a business entity's invoices
+      description: See the [Pagination Guide](/developers/guides/pagination.html)
+        to learn how to use pagination in the API and Client Libraries.
+      parameters:
+      - "$ref": "#/components/parameters/business_entity_id"
+      - "$ref": "#/components/parameters/ids"
+      - "$ref": "#/components/parameters/limit"
+      - "$ref": "#/components/parameters/order"
+      - "$ref": "#/components/parameters/sort_dates"
+      - "$ref": "#/components/parameters/filter_begin_time"
+      - "$ref": "#/components/parameters/filter_end_time"
+      - "$ref": "#/components/parameters/filter_invoice_type"
+      responses:
+        '200':
+          description: A list of the business entity's invoices.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/InvoiceList"
+        '400':
+          description: Invalid or unpermitted parameter.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Incorrect site or business entity ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
 servers:
 - url: https://v3.recurly.com
 - url: https://v3.eu.recurly.com
@@ -16177,6 +16279,14 @@ components:
       in: path
       description: Billing Info ID. Can ONLY be used for sites utilizing the Wallet
         feature.
+      required: true
+      schema:
+        type: string
+    business_entity_id:
+      name: business_entity_id
+      in: path
+      description: Business Entity ID. For ID no prefix is used e.g. `e28zov4fw0v2`.
+        For code use prefix `code-`, e.g. `code-entity1`.
       required: true
       schema:
         type: string
@@ -17101,6 +17211,11 @@ components:
             merchant has an integration for the Vertex tax provider, this optional
             value will be sent in any tax calculation requests for the account.
           maxLength: 30
+        override_business_entity_id:
+          type: string
+          title: Override Business Entity ID
+          description: Unique ID to identify the business entity assigned to the account.
+            Available when the `Multiple Business Entities` feature is enabled.
         parent_account_code:
           type: string
           maxLength: 50
@@ -17169,6 +17284,11 @@ components:
             The customer will also use this email address to log into your hosted
             account management pages. This value does not need to be unique.
           maxLength: 255
+        override_business_entity_id:
+          type: string
+          title: Override Business Entity ID
+          description: Unique ID to identify the business entity assigned to the account.
+            Available when the `Multiple Business Entities` feature is enabled.
         preferred_locale:
           description: Used to determine the language and locale of emails sent on
             behalf of the merchant to the customer.
@@ -19358,6 +19478,11 @@ components:
           type: boolean
           title: Final Dunning Event
           description: Last communication attempt.
+        business_entity_id:
+          type: string
+          title: Business Entity ID
+          description: Unique ID to identify the business entity assigned to the invoice.
+            Available when the `Multiple Business Entities` feature is enabled.
     InvoiceCreate:
       type: object
       properties:
@@ -23939,6 +24064,84 @@ components:
           type: string
           description: Username of the associated payment method. Currently only associated
             with Venmo.
+    BusinessEntityList:
+      type: object
+      properties:
+        object:
+          type: string
+          title: Object type
+          description: Will always be List.
+        has_more:
+          type: boolean
+          description: Indicates there are more results on subsequent pages.
+        next:
+          type: string
+          description: Path to subsequent page of results.
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/BusinessEntity"
+    BusinessEntity:
+      type: object
+      description: Business entity details
+      properties:
+        id:
+          title: Business entity ID
+          type: string
+          maxLength: 13
+          readOnly: true
+        object:
+          title: Object type
+          type: string
+          readOnly: true
+        code:
+          title: Business entity code
+          type: string
+          maxLength: 50
+          description: The entity code of the business entity.
+        name:
+          type: string
+          title: Name
+          description: This name describes your business entity and will appear on
+            the invoice.
+          maxLength: 255
+        invoice_display_address:
+          title: Invoice display address
+          description: Address information for the business entity that will appear
+            on the invoice.
+          "$ref": "#/components/schemas/Address"
+        tax_address:
+          title: Tax address
+          description: Address information for the business entity that will be used
+            for calculating taxes.
+          "$ref": "#/components/schemas/Address"
+        default_vat_number:
+          type: string
+          title: Default VAT number
+          description: VAT number for the customer used on the invoice.
+          maxLength: 20
+        default_registration_number:
+          type: string
+          title: Default registration number
+          description: Registration number for the customer used on the invoice.
+          maxLength: 30
+        subscriber_location_countries:
+          type: array
+          title: Subscriber location countries
+          description: List of countries for which the business entity will be used.
+          items:
+            type: string
+            title: Country code
+        created_at:
+          type: string
+          format: date-time
+          title: Created at
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          title: Last updated at
+          readOnly: true
     GiftCardList:
       type: object
       properties:

--- a/scripts/clean
+++ b/scripts/clean
@@ -89,6 +89,7 @@ rm -f entitlements.go
 rm -f entitlement.go
 rm -f customer_permission.go
 rm -f granted_by.go
+rm -f business_entity.go
 rm -f gift_card.go
 rm -f gift_card_delivery.go
 rm -f account_create.go


### PR DESCRIPTION
Adds support for Multiple Business Entities:
  - Adds operations for Multiple Business Entities:
    - `GetBusinessEntity`
    - `GetBusinessEntityWithContext`
    - `ListBusinessEntities`
    - `ListBusinessEntityInvoices`
  - Adds `OverrideBusinessEntityId` to `Account` and as params for the following requests:
    - `AccountCreate`
    - `AccountUpdate`
    - `AccountPurchase`
  - Adds `BusinessEntityId` to the `Invoice` resource
