### PR TITLE
Generated Latest Changes for v2021-02-25 (Ramp Dates, Net Terms, Invoice Business Entity, External Subscriptions)

### DIFF
--- a/external_subscription.go
+++ b/external_subscription.go
@@ -34,20 +34,32 @@ type ExternalSubscription struct {
 	// An indication of whether or not the external subscription will auto-renew at the expiration date.
 	AutoRenew bool `json:"auto_renew,omitempty"`
 
+	// An indication of whether or not the external subscription is in a grace period.
+	InGracePeriod bool `json:"in_grace_period,omitempty"`
+
 	// Identifier of the app that generated the external subscription.
 	AppIdentifier string `json:"app_identifier,omitempty"`
 
 	// An indication of the quantity of a subscribed item's quantity.
 	Quantity int `json:"quantity,omitempty"`
 
-	// External subscriptions can be active, canceled, expired, or future.
+	// External subscriptions can be active, canceled, expired, or past_due.
 	State string `json:"state,omitempty"`
 
 	// When the external subscription was activated in the external platform.
 	ActivatedAt time.Time `json:"activated_at,omitempty"`
 
+	// When the external subscription was canceled in the external platform.
+	CanceledAt time.Time `json:"canceled_at,omitempty"`
+
 	// When the external subscription expires in the external platform.
 	ExpiresAt time.Time `json:"expires_at,omitempty"`
+
+	// When the external subscription trial period started in the external platform.
+	TrialStartedAt time.Time `json:"trial_started_at,omitempty"`
+
+	// When the external subscription trial period ends in the external platform.
+	TrialEndsAt time.Time `json:"trial_ends_at,omitempty"`
 
 	// When the external subscription was created in Recurly.
 	CreatedAt time.Time `json:"created_at,omitempty"`

--- a/invoice.go
+++ b/invoice.go
@@ -52,8 +52,24 @@ type Invoice struct {
 	// For manual invoicing, this identifies the PO number associated with the subscription.
 	PoNumber string `json:"po_number,omitempty"`
 
-	// Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+	// Integer paired with `Net Terms Type` and representing the number
+	// of days past the current date (for `net` Net Terms Type) or days after
+	// the last day of the current month (for `eom` Net Terms Type) that the
+	// invoice will become past due. For any value, an additional 24 hours is
+	// added to ensure the customer has the entire last day to make payment before
+	// becoming past due.  For example:
+	// If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+	// If an invoice is due `net 30`, it will become past due at 31 days exactly.
+	// If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+	// When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+	// For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
 	NetTerms int `json:"net_terms,omitempty"`
+
+	// Optionally supplied string that may be either `net` or `eom` (end-of-month).
+	// When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+	// When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+	// This field is only available when the EOM Net Terms feature is enabled.
+	NetTermsType string `json:"net_terms_type,omitempty"`
 
 	Address InvoiceAddress `json:"address,omitempty"`
 

--- a/invoice_create.go
+++ b/invoice_create.go
@@ -20,8 +20,24 @@ type InvoiceCreate struct {
 	// This will default to the Customer Notes text specified on the Invoice Settings for credit invoices. Specify customer notes to add or override Customer Notes on credit invoices.
 	CreditCustomerNotes *string `json:"credit_customer_notes,omitempty"`
 
-	// Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+	// Integer paired with `Net Terms Type` and representing the number
+	// of days past the current date (for `net` Net Terms Type) or days after
+	// the last day of the current month (for `eom` Net Terms Type) that the
+	// invoice will become past due. For any value, an additional 24 hours is
+	// added to ensure the customer has the entire last day to make payment before
+	// becoming past due.  For example:
+	// If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+	// If an invoice is due `net 30`, it will become past due at 31 days exactly.
+	// If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+	// When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+	// For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
 	NetTerms *int `json:"net_terms,omitempty"`
+
+	// Optionally supplied string that may be either `net` or `eom` (end-of-month).
+	// When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+	// When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+	// This field is only available when the EOM Net Terms feature is enabled.
+	NetTermsType *string `json:"net_terms_type,omitempty"`
 
 	// For manual invoicing, this identifies the PO number associated with the subscription.
 	PoNumber *string `json:"po_number,omitempty"`

--- a/invoice_mini.go
+++ b/invoice_mini.go
@@ -21,6 +21,9 @@ type InvoiceMini struct {
 	// Invoice number
 	Number string `json:"number,omitempty"`
 
+	// Unique ID to identify the business entity assigned to the invoice. Available when the `Multiple Business Entities` feature is enabled.
+	BusinessEntityId string `json:"business_entity_id,omitempty"`
+
 	// Invoice type
 	Type string `json:"type,omitempty"`
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -15202,7 +15202,7 @@ paths:
 
         Use for **Adyen HPP** and **Online Banking** transaction requests.
         This runs the validations but not the transactions.
-        The API request allows the inclusion of one of the following fields: **external_hpp_type** with `'adyen'` and **online_banking_payment_type** with `'ideal'` or `'sofort'` in the **billing_info** object.
+        The API request allows the inclusion of the following field: **external_hpp_type** with `'adyen'` in the **billing_info** object.
 
         For additional information regarding shipping fees, please see https://docs.recurly.com/docs/shipping
 
@@ -18291,6 +18291,7 @@ components:
           "$ref": "#/components/schemas/ExternalHppTypeEnum"
         online_banking_payment_type:
           "$ref": "#/components/schemas/OnlineBankingPaymentTypeEnum"
+          deprecated: true
         card_type:
           "$ref": "#/components/schemas/CardTypeEnum"
     BillingInfoVerify:
@@ -19332,13 +19333,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         address:
           "$ref": "#/components/schemas/InvoiceAddress"
         shipping_address:
@@ -19516,13 +19528,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
-          default: 0
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
+          default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         po_number:
           type: string
           title: Purchase order number
@@ -19629,6 +19652,11 @@ components:
         number:
           type: string
           title: Invoice number
+        business_entity_id:
+          type: string
+          title: Business Entity ID
+          description: Unique ID to identify the business entity assigned to the invoice.
+            Available when the `Multiple Business Entities` feature is enabled.
         type:
           title: Invoice type
           "$ref": "#/components/schemas/InvoiceTypeEnum"
@@ -21600,13 +21628,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         terms_and_conditions:
           type: string
           title: Terms and conditions
@@ -22162,13 +22201,17 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer normally paired with `Net Terms Type` and representing the number of days past
+            the current date (for `net` Net Terms Type) or days after the last day of the current
+            month (for `eom` Net Terms Type) that the invoice will become past due. During a subscription
+            change, it's not necessary to provide both the `Net Terms Type` and `Net Terms` parameters.
+
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         transaction_type:
           description: An optional type designation for the payment gateway transaction
             created by this request. Supports 'moto' value, which is the acronym for
@@ -22373,13 +22416,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         transaction_type:
           description: An optional type designation for the payment gateway transaction
             created by this request. Supports 'moto' value, which is the acronym for
@@ -22549,13 +22603,24 @@ components:
         net_terms:
           type: integer
           title: Terms that the subscription is due on
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         gateway_code:
           type: string
           title: Gateway Code
@@ -22694,6 +22759,14 @@ components:
         remaining_billing_cycles:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.
+        starting_on:
+          type: string
+          format: date-time
+          title: Date the ramp interval starts
+        ending_on:
+          type: string
+          format: date-time
+          title: Date the ramp interval ends
         unit_amount:
           type: number
           format: float
@@ -23253,13 +23326,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         terms_and_conditions:
           type: string
           title: Terms and conditions
@@ -23765,6 +23849,12 @@ components:
           description: An indication of whether or not the external subscription will
             auto-renew at the expiration date.
           default: false
+        in_grace_period:
+          type: boolean
+          title: In grace period
+          description: An indication of whether or not the external subscription is
+            in a grace period.
+          default: false
         app_identifier:
           type: string
           title: App identifier
@@ -23778,18 +23868,37 @@ components:
         state:
           type: string
           description: External subscriptions can be active, canceled, expired, or
-            future.
+            past_due.
+          default: active
         activated_at:
           type: string
           format: date-time
           title: Activated at
           description: When the external subscription was activated in the external
             platform.
+        canceled_at:
+          type: string
+          format: date-time
+          title: Canceled at
+          description: When the external subscription was canceled in the external
+            platform.
         expires_at:
           type: string
           format: date-time
           title: Expires at
           description: When the external subscription expires in the external platform.
+        trial_started_at:
+          type: string
+          format: date-time
+          title: Trial started at
+          description: When the external subscription trial period started in the
+            external platform.
+        trial_ends_at:
+          type: string
+          format: date-time
+          title: Trial ends at
+          description: When the external subscription trial period ends in the external
+            platform.
         created_at:
           type: string
           format: date-time
@@ -24773,6 +24882,19 @@ components:
       - at_range_start
       - evenly
       - never
+    NetTermsTypeEnum:
+      type: string
+      title: Net Terms Type
+      description: |
+        Optionally supplied string that may be either `net` or `eom` (end-of-month).
+        When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+        When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+
+        This field is only available when the EOM Net Terms feature is enabled.
+      enum:
+      - net
+      - eom
+      default: net
     InvoiceTypeEnum:
       type: string
       enum:
@@ -25039,6 +25161,7 @@ components:
       - venmo
       - wire_transfer
       - braintree_v_zero
+      - boleto
     CardTypeEnum:
       type: string
       enum:

--- a/purchase_create.go
+++ b/purchase_create.go
@@ -22,8 +22,24 @@ type PurchaseCreate struct {
 	// For manual invoicing, this identifies the PO number associated with the subscription.
 	PoNumber *string `json:"po_number,omitempty"`
 
-	// Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+	// Integer paired with `Net Terms Type` and representing the number
+	// of days past the current date (for `net` Net Terms Type) or days after
+	// the last day of the current month (for `eom` Net Terms Type) that the
+	// invoice will become past due. For any value, an additional 24 hours is
+	// added to ensure the customer has the entire last day to make payment before
+	// becoming past due.  For example:
+	// If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+	// If an invoice is due `net 30`, it will become past due at 31 days exactly.
+	// If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+	// When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+	// For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
 	NetTerms *int `json:"net_terms,omitempty"`
+
+	// Optionally supplied string that may be either `net` or `eom` (end-of-month).
+	// When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+	// When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+	// This field is only available when the EOM Net Terms feature is enabled.
+	NetTermsType *string `json:"net_terms_type,omitempty"`
 
 	// Terms and conditions to be put on the purchase invoice.
 	TermsAndConditions *string `json:"terms_and_conditions,omitempty"`

--- a/subscription.go
+++ b/subscription.go
@@ -118,8 +118,24 @@ type Subscription struct {
 	// For manual invoicing, this identifies the PO number associated with the subscription.
 	PoNumber string `json:"po_number,omitempty"`
 
-	// Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+	// Integer paired with `Net Terms Type` and representing the number
+	// of days past the current date (for `net` Net Terms Type) or days after
+	// the last day of the current month (for `eom` Net Terms Type) that the
+	// invoice will become past due. For any value, an additional 24 hours is
+	// added to ensure the customer has the entire last day to make payment before
+	// becoming past due.  For example:
+	// If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+	// If an invoice is due `net 30`, it will become past due at 31 days exactly.
+	// If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+	// When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+	// For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
 	NetTerms int `json:"net_terms,omitempty"`
+
+	// Optionally supplied string that may be either `net` or `eom` (end-of-month).
+	// When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+	// When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+	// This field is only available when the EOM Net Terms feature is enabled.
+	NetTermsType string `json:"net_terms_type,omitempty"`
 
 	// Terms and conditions
 	TermsAndConditions string `json:"terms_and_conditions,omitempty"`

--- a/subscription_change_create.go
+++ b/subscription_change_create.go
@@ -61,8 +61,18 @@ type SubscriptionChangeCreate struct {
 	// For manual invoicing, this identifies the PO number associated with the subscription.
 	PoNumber *string `json:"po_number,omitempty"`
 
-	// Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+	// Integer normally paired with `Net Terms Type` and representing the number of days past
+	// the current date (for `net` Net Terms Type) or days after the last day of the current
+	// month (for `eom` Net Terms Type) that the invoice will become past due. During a subscription
+	// change, it's not necessary to provide both the `Net Terms Type` and `Net Terms` parameters.
+	// For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
 	NetTerms *int `json:"net_terms,omitempty"`
+
+	// Optionally supplied string that may be either `net` or `eom` (end-of-month).
+	// When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+	// When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+	// This field is only available when the EOM Net Terms feature is enabled.
+	NetTermsType *string `json:"net_terms_type,omitempty"`
 
 	// An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
 	TransactionType *string `json:"transaction_type,omitempty"`

--- a/subscription_create.go
+++ b/subscription_create.go
@@ -84,8 +84,24 @@ type SubscriptionCreate struct {
 	// For manual invoicing, this identifies the PO number associated with the subscription.
 	PoNumber *string `json:"po_number,omitempty"`
 
-	// Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+	// Integer paired with `Net Terms Type` and representing the number
+	// of days past the current date (for `net` Net Terms Type) or days after
+	// the last day of the current month (for `eom` Net Terms Type) that the
+	// invoice will become past due. For any value, an additional 24 hours is
+	// added to ensure the customer has the entire last day to make payment before
+	// becoming past due.  For example:
+	// If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+	// If an invoice is due `net 30`, it will become past due at 31 days exactly.
+	// If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+	// When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+	// For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
 	NetTerms *int `json:"net_terms,omitempty"`
+
+	// Optionally supplied string that may be either `net` or `eom` (end-of-month).
+	// When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+	// When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+	// This field is only available when the EOM Net Terms feature is enabled.
+	NetTermsType *string `json:"net_terms_type,omitempty"`
 
 	// An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.
 	TransactionType *string `json:"transaction_type,omitempty"`

--- a/subscription_ramp_interval_response.go
+++ b/subscription_ramp_interval_response.go
@@ -7,6 +7,7 @@ package recurly
 import (
 	"context"
 	"net/http"
+	"time"
 )
 
 type SubscriptionRampIntervalResponse struct {
@@ -17,6 +18,12 @@ type SubscriptionRampIntervalResponse struct {
 
 	// Represents how many billing cycles are left in a ramp interval.
 	RemainingBillingCycles int `json:"remaining_billing_cycles,omitempty"`
+
+	// Date the ramp interval starts
+	StartingOn time.Time `json:"starting_on,omitempty"`
+
+	// Date the ramp interval ends
+	EndingOn time.Time `json:"ending_on,omitempty"`
 
 	// Represents the price for the ramp interval.
 	UnitAmount float64 `json:"unit_amount,omitempty"`

--- a/subscription_update.go
+++ b/subscription_update.go
@@ -40,8 +40,24 @@ type SubscriptionUpdate struct {
 	// For manual invoicing, this identifies the PO number associated with the subscription.
 	PoNumber *string `json:"po_number,omitempty"`
 
-	// Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.
+	// Integer paired with `Net Terms Type` and representing the number
+	// of days past the current date (for `net` Net Terms Type) or days after
+	// the last day of the current month (for `eom` Net Terms Type) that the
+	// invoice will become past due. For any value, an additional 24 hours is
+	// added to ensure the customer has the entire last day to make payment before
+	// becoming past due.  For example:
+	// If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+	// If an invoice is due `net 30`, it will become past due at 31 days exactly.
+	// If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+	// When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+	// For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
 	NetTerms *int `json:"net_terms,omitempty"`
+
+	// Optionally supplied string that may be either `net` or `eom` (end-of-month).
+	// When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+	// When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+	// This field is only available when the EOM Net Terms feature is enabled.
+	NetTermsType *string `json:"net_terms_type,omitempty"`
 
 	// If present, this subscription's transactions will use the payment gateway with this code.
 	GatewayCode *string `json:"gateway_code,omitempty"`


### PR DESCRIPTION
- Adds `NetTermsType` to the `Subscription`, `SubscriptionChange`, `Purchase`, and `Invoice` resources
- Adds `BusinessEntityId` to the `InvoiceMini` resource
- Adds `StartingOn` and `EndingOn` to `SubscriptionRampIntervalResponse` resources
- Adds `InGracePeriod `, `CanceledAt`, `TrialStartedAt`, `TrialEndsAt` to `ExternalSubscription` resources