### PR TITLE
Generated Latest Changes for v2021-02-25 (Proration Settings)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21253,6 +21253,34 @@ components:
           description: |
             The percentage taken of the monetary amount of usage tracked.
             This can be up to 4 decimal places represented as a string.
+    ProrationSettings:
+      type: object
+      title: Proration Settings
+      description: Allows you to control how any resulting charges and credits will
+        be calculated and prorated.
+      properties:
+        charge:
+          "$ref": "#/components/schemas/ProrationSettingsChargeEnum"
+        credit:
+          "$ref": "#/components/schemas/ProrationSettingsCreditEnum"
+    ProrationSettingsChargeEnum:
+      type: string
+      title: Charge
+      description: Determines how the amount charged is determined for this change
+      default: prorated_amount
+      enum:
+      - full_amount
+      - prorated_amount
+      - none
+    ProrationSettingsCreditEnum:
+      type: string
+      title: Credit
+      description: Determines how the amount credited is determined for this change
+      default: prorated_amount
+      enum:
+      - full_amount
+      - prorated_amount
+      - none
     Settings:
       type: object
       properties:
@@ -22476,6 +22504,8 @@ components:
           description: The new set of ramp intervals for the subscription.
           items:
             "$ref": "#/components/schemas/SubscriptionRampInterval"
+        proration_settings:
+          "$ref": "#/components/schemas/ProrationSettings"
     SubscriptionChangeShippingCreate:
       type: object
       title: Shipping details that will be changed on a subscription

--- a/proration_settings.go
+++ b/proration_settings.go
@@ -1,0 +1,16 @@
+// This file is automatically created by Recurly's OpenAPI generation process
+// and thus any edits you make by hand will be lost. If you wish to make a
+// change to this file, please create a Github issue explaining the changes you
+// need and we will usher them to the appropriate places.
+package recurly
+
+import ()
+
+type ProrationSettings struct {
+
+	// Determines how the amount charged is determined for this change
+	Charge *string `json:"charge,omitempty"`
+
+	// Determines how the amount credited is determined for this change
+	Credit *string `json:"credit,omitempty"`
+}

--- a/scripts/clean
+++ b/scripts/clean
@@ -161,6 +161,7 @@ rm -f subscription_change_create.go
 rm -f subscription_change_shipping_create.go
 rm -f subscription_add_on_update.go
 rm -f subscription_change_billing_info_create.go
+rm -f proration_settings.go
 rm -f usage_create.go
 rm -f purchase_create.go
 rm -f account_purchase.go

--- a/subscription_change_create.go
+++ b/subscription_change_create.go
@@ -81,4 +81,7 @@ type SubscriptionChangeCreate struct {
 
 	// The new set of ramp intervals for the subscription.
 	RampIntervals []SubscriptionRampInterval `json:"ramp_intervals,omitempty"`
+
+	// Allows you to control how any resulting charges and credits will be calculated and prorated.
+	ProrationSettings *ProrationSettings `json:"proration_settings,omitempty"`
 }


### PR DESCRIPTION
Adds support for passing `proration_settings` to the following endpoints:

- POST /subscriptions/:id/change
- POST /subscriptions/:id/change/preview