### PR TITLE
Generated Latest Changes for v2021-02-25 (Taxable Address Control, RevRec)

### DIFF
--- a/add_on.go
+++ b/add_on.go
@@ -46,6 +46,21 @@ type AddOn struct {
 	// System-generated unique identifier for an measured unit associated with the add-on.
 	MeasuredUnitId string `json:"measured_unit_id,omitempty"`
 
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	LiabilityGlAccountId string `json:"liability_gl_account_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	RevenueGlAccountId string `json:"revenue_gl_account_id,omitempty"`
+
+	// The ID of a performance obligation. Performance obligations are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	PerformanceObligationId string `json:"performance_obligation_id,omitempty"`
+
 	// Accounting code for invoice line items for this add-on. If no value is provided, it defaults to add-on's code.
 	AccountingCode string `json:"accounting_code,omitempty"`
 

--- a/add_on_create.go
+++ b/add_on_create.go
@@ -8,7 +8,7 @@ import ()
 
 type AddOnCreate struct {
 
-	// Unique code to identify an item. Available when the `Credit Invoices` feature are enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
+	// Unique code to identify an item. Available when the `Credit Invoices` feature is enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
 	ItemCode *string `json:"item_code,omitempty"`
 
 	// System-generated unique identifier for an item. Available when the `Credit Invoices` feature is enabled. If `item_id` and `item_code` are both present, `item_id` will be used.
@@ -43,6 +43,21 @@ type AddOnCreate struct {
 	// Plan ID
 	PlanId *string `json:"plan_id,omitempty"`
 
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	LiabilityGlAccountId *string `json:"liability_gl_account_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	RevenueGlAccountId *string `json:"revenue_gl_account_id,omitempty"`
+
+	// The ID of a performance obligation. Performance obligations are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	PerformanceObligationId *string `json:"performance_obligation_id,omitempty"`
+
 	// Accounting code for invoice line items for this add-on. If no value is provided, it defaults to add-on's code. If `item_code`/`item_id` is part of the request then `accounting_code` must be absent.
 	AccountingCode *string `json:"accounting_code,omitempty"`
 
@@ -68,7 +83,7 @@ type AddOnCreate struct {
 	TaxCode *string `json:"tax_code,omitempty"`
 
 	// * If `item_code`/`item_id` is part of the request and the item
-	// has a default currency then `currencies` is optional. If the item does
+	// has a default currency, then `currencies` is optional. If the item does
 	// not have a default currency, then `currencies` is required. If `item_code`/`item_id`
 	// is not present `currencies` is required.
 	// * If the add-on's `tier_type` is `tiered`, `volume`, or `stairstep`,

--- a/add_on_update.go
+++ b/add_on_update.go
@@ -32,6 +32,21 @@ type AddOnUpdate struct {
 	// Accounting code for invoice line items for this add-on. If no value is provided, it defaults to add-on's code. If an `Item` is associated to the `AddOn` then `accounting code` must be absent.
 	AccountingCode *string `json:"accounting_code,omitempty"`
 
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	LiabilityGlAccountId *string `json:"liability_gl_account_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	RevenueGlAccountId *string `json:"revenue_gl_account_id,omitempty"`
+
+	// The ID of a performance obligation. Performance obligations are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	PerformanceObligationId *string `json:"performance_obligation_id,omitempty"`
+
 	// When this add-on is invoiced, the line item will use this revenue schedule. If `item_code`/`item_id` is part of the request then `revenue_schedule_type` must be absent in the request as the value will be set from the item.
 	RevenueScheduleType *string `json:"revenue_schedule_type,omitempty"`
 
@@ -67,7 +82,7 @@ type AddOnUpdate struct {
 	// `percentage_tiers` is an array of objects, which must have the set of tiers
 	// per currency and the currency code. The tier_type must be `volume` or `tiered`,
 	// if not, it must be absent. There must be one tier without an `ending_amount` value
-	// which represents the final tier.  This feature is currently in development and
+	// which represents the final tier. This feature is currently in development and
 	// requires approval and enablement, please contact support.
 	PercentageTiers []PercentageTiersByCurrencyCreate `json:"percentage_tiers,omitempty"`
 }

--- a/business_entity.go
+++ b/business_entity.go
@@ -31,6 +31,12 @@ type BusinessEntity struct {
 	// Address information for the business entity that will be used for calculating taxes.
 	TaxAddress Address `json:"tax_address,omitempty"`
 
+	// The source of the address that will be used as the origin in determining taxes. Available only when the site is on an Elite plan. A value of "origin" refers to the "Business entity tax address". A value of "destination" refers to the "Customer tax address".
+	OriginTaxAddressSource string `json:"origin_tax_address_source,omitempty"`
+
+	// The source of the address that will be used as the destinaion in determining taxes. Available only when the site is on an Elite plan. A value of "destination" refers to the "Customer tax address". A value of "origin" refers to the "Business entity tax address".
+	DestinationTaxAddressSource string `json:"destination_tax_address_source,omitempty"`
+
 	// VAT number for the customer used on the invoice.
 	DefaultVatNumber string `json:"default_vat_number,omitempty"`
 
@@ -39,6 +45,16 @@ type BusinessEntity struct {
 
 	// List of countries for which the business entity will be used.
 	SubscriberLocationCountries []string `json:"subscriber_location_countries,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	DefaultLiabilityGlAccountId string `json:"default_liability_gl_account_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	DefaultRevenueGlAccountId string `json:"default_revenue_gl_account_id,omitempty"`
 
 	// Created at
 	CreatedAt time.Time `json:"created_at,omitempty"`

--- a/client_operations.go
+++ b/client_operations.go
@@ -181,6 +181,22 @@ type ClientInterface interface {
 	GetCustomFieldDefinition(customFieldDefinitionId string, opts ...Option) (*CustomFieldDefinition, error)
 	GetCustomFieldDefinitionWithContext(ctx context.Context, customFieldDefinitionId string, opts ...Option) (*CustomFieldDefinition, error)
 
+	CreateGeneralLedgerAccount(body *GeneralLedgerAccountCreate, opts ...Option) (*GeneralLedgerAccount, error)
+	CreateGeneralLedgerAccountWithContext(ctx context.Context, body *GeneralLedgerAccountCreate, opts ...Option) (*GeneralLedgerAccount, error)
+
+	ListGeneralLedgerAccounts(params *ListGeneralLedgerAccountsParams, opts ...Option) (GeneralLedgerAccountLister, error)
+
+	GetGeneralLedgerAccount(generalLedgerAccountId string, opts ...Option) (*GeneralLedgerAccount, error)
+	GetGeneralLedgerAccountWithContext(ctx context.Context, generalLedgerAccountId string, opts ...Option) (*GeneralLedgerAccount, error)
+
+	UpdateGeneralLedgerAccount(generalLedgerAccountId string, body *GeneralLedgerAccountUpdate, opts ...Option) (*GeneralLedgerAccount, error)
+	UpdateGeneralLedgerAccountWithContext(ctx context.Context, generalLedgerAccountId string, body *GeneralLedgerAccountUpdate, opts ...Option) (*GeneralLedgerAccount, error)
+
+	GetPerformanceObligation(performanceObligationId string, opts ...Option) (*PerformanceObligation, error)
+	GetPerformanceObligationWithContext(ctx context.Context, performanceObligationId string, opts ...Option) (*PerformanceObligation, error)
+
+	GetPerformanceObligations(opts ...Option) (PerformanceObligationLister, error)
+
 	ListInvoiceTemplateAccounts(invoiceTemplateId string, params *ListInvoiceTemplateAccountsParams, opts ...Option) (AccountLister, error)
 
 	ListItems(params *ListItemsParams, opts ...Option) (ItemLister, error)
@@ -3088,7 +3104,7 @@ func (c *Client) GetCustomFieldDefinition(customFieldDefinitionId string, opts .
 //
 // API Documentation: https://developers.recurly.com/api/v2021-02-25#operation/get_custom_field_definition
 //
-// Returns: An custom field definition.
+// Returns: A custom field definition.
 func (c *Client) GetCustomFieldDefinitionWithContext(ctx context.Context, customFieldDefinitionId string, opts ...Option) (*CustomFieldDefinition, error) {
 	return c.getCustomFieldDefinition(ctx, customFieldDefinitionId, opts...)
 }
@@ -3105,6 +3121,205 @@ func (c *Client) getCustomFieldDefinition(ctx context.Context, customFieldDefini
 		return nil, err
 	}
 	return result, err
+}
+
+// CreateGeneralLedgerAccount wraps CreateGeneralLedgerAccountWithContext using the background context
+func (c *Client) CreateGeneralLedgerAccount(body *GeneralLedgerAccountCreate, opts ...Option) (*GeneralLedgerAccount, error) {
+	ctx := context.Background()
+	return c.createGeneralLedgerAccount(ctx, body, opts...)
+}
+
+// CreateGeneralLedgerAccountWithContext Create a new general ledger account
+//
+// API Documentation: https://developers.recurly.com/api/v2021-02-25#operation/create_general_ledger_account
+//
+// Returns: A new general ledger account.
+func (c *Client) CreateGeneralLedgerAccountWithContext(ctx context.Context, body *GeneralLedgerAccountCreate, opts ...Option) (*GeneralLedgerAccount, error) {
+	return c.createGeneralLedgerAccount(ctx, body, opts...)
+}
+
+func (c *Client) createGeneralLedgerAccount(ctx context.Context, body *GeneralLedgerAccountCreate, opts ...Option) (*GeneralLedgerAccount, error) {
+	path, err := c.InterpolatePath("/general_ledger_accounts")
+	if err != nil {
+		return nil, err
+	}
+	requestOptions := NewRequestOptions(opts...)
+	result := &GeneralLedgerAccount{}
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, err
+}
+
+type ListGeneralLedgerAccountsParams struct {
+
+	// Ids - Filter results by their IDs. Up to 200 IDs can be passed at once using
+	// commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
+	// **Important notes:**
+	// * The `ids` parameter cannot be used with any other ordering or filtering
+	//   parameters (`limit`, `order`, `sort`, `begin_time`, `end_time`, etc)
+	// * Invalid or unknown IDs will be ignored, so you should check that the
+	//   results correspond to your request.
+	// * Records are returned in an arbitrary order. Since results are all
+	//   returned at once you can sort the records yourself.
+	Ids []string
+
+	// Limit - Limit number of records 1-200.
+	Limit *int
+
+	// Order - Sort order.
+	Order *string
+
+	// Sort - Sort field. You *really* only want to sort by `updated_at` in ascending
+	// order. In descending order updated records will move behind the cursor and could
+	// prevent some records from being returned.
+	Sort *string
+
+	// AccountType - General Ledger Account type by which to filter the response.
+	AccountType *string
+}
+
+func (list *ListGeneralLedgerAccountsParams) URLParams() []KeyValue {
+	var options []KeyValue
+
+	if list.Ids != nil {
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+	}
+
+	if list.Limit != nil {
+		options = append(options, KeyValue{Key: "limit", Value: strconv.Itoa(*list.Limit)})
+	}
+
+	if list.Order != nil {
+		options = append(options, KeyValue{Key: "order", Value: *list.Order})
+	}
+
+	if list.Sort != nil {
+		options = append(options, KeyValue{Key: "sort", Value: *list.Sort})
+	}
+
+	if list.AccountType != nil {
+		options = append(options, KeyValue{Key: "account_type", Value: *list.AccountType})
+	}
+
+	return options
+}
+
+// ListGeneralLedgerAccounts List a site's general ledger accounts
+//
+// API Documentation: https://developers.recurly.com/api/v2021-02-25#operation/list_general_ledger_accounts
+//
+// Returns: A list of the site's general ledger accounts.
+func (c *Client) ListGeneralLedgerAccounts(params *ListGeneralLedgerAccountsParams, opts ...Option) (GeneralLedgerAccountLister, error) {
+	path, err := c.InterpolatePath("/general_ledger_accounts")
+	if err != nil {
+		return nil, err
+	}
+	requestOptions := NewRequestOptions(opts...)
+	path = BuildURL(path, params)
+	return NewGeneralLedgerAccountList(c, path, requestOptions), nil
+}
+
+// GetGeneralLedgerAccount wraps GetGeneralLedgerAccountWithContext using the background context
+func (c *Client) GetGeneralLedgerAccount(generalLedgerAccountId string, opts ...Option) (*GeneralLedgerAccount, error) {
+	ctx := context.Background()
+	return c.getGeneralLedgerAccount(ctx, generalLedgerAccountId, opts...)
+}
+
+// GetGeneralLedgerAccountWithContext Fetch a general ledger account
+//
+// API Documentation: https://developers.recurly.com/api/v2021-02-25#operation/get_general_ledger_account
+//
+// Returns: A general ledger account.
+func (c *Client) GetGeneralLedgerAccountWithContext(ctx context.Context, generalLedgerAccountId string, opts ...Option) (*GeneralLedgerAccount, error) {
+	return c.getGeneralLedgerAccount(ctx, generalLedgerAccountId, opts...)
+}
+
+func (c *Client) getGeneralLedgerAccount(ctx context.Context, generalLedgerAccountId string, opts ...Option) (*GeneralLedgerAccount, error) {
+	path, err := c.InterpolatePath("/general_ledger_accounts/{general_ledger_account_id}", generalLedgerAccountId)
+	if err != nil {
+		return nil, err
+	}
+	requestOptions := NewRequestOptions(opts...)
+	result := &GeneralLedgerAccount{}
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, err
+}
+
+// UpdateGeneralLedgerAccount wraps UpdateGeneralLedgerAccountWithContext using the background context
+func (c *Client) UpdateGeneralLedgerAccount(generalLedgerAccountId string, body *GeneralLedgerAccountUpdate, opts ...Option) (*GeneralLedgerAccount, error) {
+	ctx := context.Background()
+	return c.updateGeneralLedgerAccount(ctx, generalLedgerAccountId, body, opts...)
+}
+
+// UpdateGeneralLedgerAccountWithContext Update a general ledger account
+//
+// API Documentation: https://developers.recurly.com/api/v2021-02-25#operation/update_general_ledger_account
+//
+// Returns: The updated general ledger account.
+func (c *Client) UpdateGeneralLedgerAccountWithContext(ctx context.Context, generalLedgerAccountId string, body *GeneralLedgerAccountUpdate, opts ...Option) (*GeneralLedgerAccount, error) {
+	return c.updateGeneralLedgerAccount(ctx, generalLedgerAccountId, body, opts...)
+}
+
+func (c *Client) updateGeneralLedgerAccount(ctx context.Context, generalLedgerAccountId string, body *GeneralLedgerAccountUpdate, opts ...Option) (*GeneralLedgerAccount, error) {
+	path, err := c.InterpolatePath("/general_ledger_accounts/{general_ledger_account_id}", generalLedgerAccountId)
+	if err != nil {
+		return nil, err
+	}
+	requestOptions := NewRequestOptions(opts...)
+	result := &GeneralLedgerAccount{}
+	err = c.Call(ctx, http.MethodPut, path, body, nil, requestOptions, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, err
+}
+
+// GetPerformanceObligation wraps GetPerformanceObligationWithContext using the background context
+func (c *Client) GetPerformanceObligation(performanceObligationId string, opts ...Option) (*PerformanceObligation, error) {
+	ctx := context.Background()
+	return c.getPerformanceObligation(ctx, performanceObligationId, opts...)
+}
+
+// GetPerformanceObligationWithContext Get a single Performance Obligation.
+//
+// API Documentation: https://developers.recurly.com/api/v2021-02-25#operation/get_performance_obligation
+//
+// Returns: A single Performance Obligation.
+func (c *Client) GetPerformanceObligationWithContext(ctx context.Context, performanceObligationId string, opts ...Option) (*PerformanceObligation, error) {
+	return c.getPerformanceObligation(ctx, performanceObligationId, opts...)
+}
+
+func (c *Client) getPerformanceObligation(ctx context.Context, performanceObligationId string, opts ...Option) (*PerformanceObligation, error) {
+	path, err := c.InterpolatePath("/performance_obligations/{performance_obligation_id}", performanceObligationId)
+	if err != nil {
+		return nil, err
+	}
+	requestOptions := NewRequestOptions(opts...)
+	result := &PerformanceObligation{}
+	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, err
+}
+
+// GetPerformanceObligations Get a site's Performance Obligations
+//
+// API Documentation: https://developers.recurly.com/api/v2021-02-25#operation/get_performance_obligations
+//
+// Returns: A list of Performance Obligations.
+func (c *Client) GetPerformanceObligations(opts ...Option) (PerformanceObligationLister, error) {
+	path, err := c.InterpolatePath("/performance_obligations")
+	if err != nil {
+		return nil, err
+	}
+	requestOptions := NewRequestOptions(opts...)
+	return NewPerformanceObligationList(c, path, requestOptions), nil
 }
 
 type ListInvoiceTemplateAccountsParams struct {
@@ -7174,11 +7389,11 @@ func (c *Client) GetExternalSubscriptionExternalPaymentPhase(externalSubscriptio
 	return c.getExternalSubscriptionExternalPaymentPhase(ctx, externalSubscriptionId, externalPaymentPhaseId, opts...)
 }
 
-// GetExternalSubscriptionExternalPaymentPhaseWithContext Fetch an external payment_phase
+// GetExternalSubscriptionExternalPaymentPhaseWithContext Fetch an external payment phase
 //
 // API Documentation: https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription_external_payment_phase
 //
-// Returns: Details for an external payment_phase.
+// Returns: Details for an external payment phase.
 func (c *Client) GetExternalSubscriptionExternalPaymentPhaseWithContext(ctx context.Context, externalSubscriptionId string, externalPaymentPhaseId string, opts ...Option) (*ExternalPaymentPhase, error) {
 	return c.getExternalSubscriptionExternalPaymentPhase(ctx, externalSubscriptionId, externalPaymentPhaseId, opts...)
 }

--- a/external_subscription.go
+++ b/external_subscription.go
@@ -25,6 +25,9 @@ type ExternalSubscription struct {
 	// External Product Reference details
 	ExternalProductReference ExternalProductReferenceMini `json:"external_product_reference,omitempty"`
 
+	// The phases of the external subscription payment lifecycle.
+	ExternalPaymentPhases []ExternalPaymentPhase `json:"external_payment_phases,omitempty"`
+
 	// The id of the subscription in the external systems., I.e. Apple App Store or Google Play Store.
 	ExternalId string `json:"external_id,omitempty"`
 
@@ -63,6 +66,9 @@ type ExternalSubscription struct {
 
 	// An indication of whether or not the external subscription was purchased in a sandbox environment.
 	Test bool `json:"test,omitempty"`
+
+	// An indication of whether or not the external subscription was created by a historical data import.
+	Imported bool `json:"imported,omitempty"`
 
 	// When the external subscription was created in Recurly.
 	CreatedAt time.Time `json:"created_at,omitempty"`

--- a/general_ledger_account.go
+++ b/general_ledger_account.go
@@ -10,90 +10,72 @@ import (
 	"time"
 )
 
-type ExternalPaymentPhase struct {
+type GeneralLedgerAccount struct {
 	recurlyResponse *ResponseMetadata
 
-	// System-generated unique identifier for an external payment phase ID, e.g. `e28zov4fw0v2`.
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
 	Id string `json:"id,omitempty"`
 
 	// Object type
 	Object string `json:"object,omitempty"`
 
-	// Started At
-	StartedAt time.Time `json:"started_at,omitempty"`
+	// Unique code to identify the ledger account. Each code must start
+	// with a letter or number. The following special characters are
+	// allowed: `-_.,:`
+	Code string `json:"code,omitempty"`
 
-	// Ends At
-	EndsAt time.Time `json:"ends_at,omitempty"`
+	// Optional description.
+	Description string `json:"description,omitempty"`
 
-	// Starting Billing Period Index
-	StartingBillingPeriodIndex int `json:"starting_billing_period_index,omitempty"`
+	AccountType string `json:"account_type,omitempty"`
 
-	// Ending Billing Period Index
-	EndingBillingPeriodIndex int `json:"ending_billing_period_index,omitempty"`
-
-	// Type of discount offer given, e.g. "FREE_TRIAL"
-	OfferType string `json:"offer_type,omitempty"`
-
-	// Name of the discount offer given, e.g. "introductory"
-	OfferName string `json:"offer_name,omitempty"`
-
-	// Number of billing periods
-	PeriodCount int `json:"period_count,omitempty"`
-
-	// Billing cycle length
-	PeriodLength string `json:"period_length,omitempty"`
-
-	// Allows up to 9 decimal places
-	Amount string `json:"amount,omitempty"`
-
-	// 3-letter ISO 4217 currency code.
-	Currency string `json:"currency,omitempty"`
-
-	// When the external subscription was created in Recurly.
+	// Created at
 	CreatedAt time.Time `json:"created_at,omitempty"`
 
-	// When the external subscription was updated in Recurly.
+	// Last updated at
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource
-func (resource *ExternalPaymentPhase) GetResponse() *ResponseMetadata {
+func (resource *GeneralLedgerAccount) GetResponse() *ResponseMetadata {
 	return resource.recurlyResponse
 }
 
 // setResponse sets the ResponseMetadata that generated this resource
-func (resource *ExternalPaymentPhase) setResponse(res *ResponseMetadata) {
+func (resource *GeneralLedgerAccount) setResponse(res *ResponseMetadata) {
 	resource.recurlyResponse = res
 }
 
 // internal struct for deserializing accounts
-type externalPaymentPhaseList struct {
+type generalLedgerAccountList struct {
 	ListMetadata
-	Data            []ExternalPaymentPhase `json:"data"`
+	Data            []GeneralLedgerAccount `json:"data"`
 	recurlyResponse *ResponseMetadata
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource
-func (resource *externalPaymentPhaseList) GetResponse() *ResponseMetadata {
+func (resource *generalLedgerAccountList) GetResponse() *ResponseMetadata {
 	return resource.recurlyResponse
 }
 
 // setResponse sets the ResponseMetadata that generated this resource
-func (resource *externalPaymentPhaseList) setResponse(res *ResponseMetadata) {
+func (resource *generalLedgerAccountList) setResponse(res *ResponseMetadata) {
 	resource.recurlyResponse = res
 }
 
-// ExternalPaymentPhaseList allows you to paginate ExternalPaymentPhase objects
-type ExternalPaymentPhaseList struct {
+// GeneralLedgerAccountList allows you to paginate GeneralLedgerAccount objects
+type GeneralLedgerAccountList struct {
 	client         HTTPCaller
 	requestOptions *RequestOptions
 	nextPagePath   string
 	hasMore        bool
-	data           []ExternalPaymentPhase
+	data           []GeneralLedgerAccount
 }
 
-func NewExternalPaymentPhaseList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *ExternalPaymentPhaseList {
-	return &ExternalPaymentPhaseList{
+func NewGeneralLedgerAccountList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *GeneralLedgerAccountList {
+	return &GeneralLedgerAccountList{
 		client:         client,
 		requestOptions: requestOptions,
 		nextPagePath:   nextPagePath,
@@ -101,31 +83,31 @@ func NewExternalPaymentPhaseList(client HTTPCaller, nextPagePath string, request
 	}
 }
 
-type ExternalPaymentPhaseLister interface {
+type GeneralLedgerAccountLister interface {
 	Fetch() error
 	FetchWithContext(ctx context.Context) error
 	Count() (*int64, error)
 	CountWithContext(ctx context.Context) (*int64, error)
-	Data() []ExternalPaymentPhase
+	Data() []GeneralLedgerAccount
 	HasMore() bool
 	Next() string
 }
 
-func (list *ExternalPaymentPhaseList) HasMore() bool {
+func (list *GeneralLedgerAccountList) HasMore() bool {
 	return list.hasMore
 }
 
-func (list *ExternalPaymentPhaseList) Next() string {
+func (list *GeneralLedgerAccountList) Next() string {
 	return list.nextPagePath
 }
 
-func (list *ExternalPaymentPhaseList) Data() []ExternalPaymentPhase {
+func (list *GeneralLedgerAccountList) Data() []GeneralLedgerAccount {
 	return list.data
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *ExternalPaymentPhaseList) FetchWithContext(ctx context.Context) error {
-	resources := &externalPaymentPhaseList{}
+func (list *GeneralLedgerAccountList) FetchWithContext(ctx context.Context) error {
+	resources := &generalLedgerAccountList{}
 	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return err
@@ -138,13 +120,13 @@ func (list *ExternalPaymentPhaseList) FetchWithContext(ctx context.Context) erro
 }
 
 // Fetch fetches the next page of data into the `Data` property
-func (list *ExternalPaymentPhaseList) Fetch() error {
+func (list *GeneralLedgerAccountList) Fetch() error {
 	return list.FetchWithContext(context.Background())
 }
 
 // Count returns the count of items on the server that match this pager
-func (list *ExternalPaymentPhaseList) CountWithContext(ctx context.Context) (*int64, error) {
-	resources := &externalPaymentPhaseList{}
+func (list *GeneralLedgerAccountList) CountWithContext(ctx context.Context) (*int64, error) {
+	resources := &generalLedgerAccountList{}
 	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
 	if err != nil {
 		return nil, err
@@ -154,6 +136,6 @@ func (list *ExternalPaymentPhaseList) CountWithContext(ctx context.Context) (*in
 }
 
 // Count returns the count of items on the server that match this pager
-func (list *ExternalPaymentPhaseList) Count() (*int64, error) {
+func (list *GeneralLedgerAccountList) Count() (*int64, error) {
 	return list.CountWithContext(context.Background())
 }

--- a/general_ledger_account_create.go
+++ b/general_ledger_account_create.go
@@ -1,0 +1,20 @@
+// This file is automatically created by Recurly's OpenAPI generation process
+// and thus any edits you make by hand will be lost. If you wish to make a
+// change to this file, please create a Github issue explaining the changes you
+// need and we will usher them to the appropriate places.
+package recurly
+
+import ()
+
+type GeneralLedgerAccountCreate struct {
+
+	// Unique code to identify the ledger account. Each code must start
+	// with a letter or number. The following special characters are
+	// allowed: `-_.,:`
+	Code *string `json:"code,omitempty"`
+
+	// Optional description.
+	Description *string `json:"description,omitempty"`
+
+	AccountType *string `json:"account_type,omitempty"`
+}

--- a/general_ledger_account_update.go
+++ b/general_ledger_account_update.go
@@ -1,0 +1,18 @@
+// This file is automatically created by Recurly's OpenAPI generation process
+// and thus any edits you make by hand will be lost. If you wish to make a
+// change to this file, please create a Github issue explaining the changes you
+// need and we will usher them to the appropriate places.
+package recurly
+
+import ()
+
+type GeneralLedgerAccountUpdate struct {
+
+	// Unique code to identify the ledger account. Each code must start
+	// with a letter or number. The following special characters are
+	// allowed: `-_.,:`
+	Code *string `json:"code,omitempty"`
+
+	// Optional description.
+	Description *string `json:"description,omitempty"`
+}

--- a/gift_card.go
+++ b/gift_card.go
@@ -49,6 +49,21 @@ type GiftCard struct {
 	// The delivery details for the gift card.
 	Delivery GiftCardDelivery `json:"delivery,omitempty"`
 
+	// The ID of a performance obligation. Performance obligations are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	PerformanceObligationId string `json:"performance_obligation_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	LiabilityGlAccountId string `json:"liability_gl_account_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	RevenueGlAccountId string `json:"revenue_gl_account_id,omitempty"`
+
 	// Created at
 	CreatedAt time.Time `json:"created_at,omitempty"`
 

--- a/item.go
+++ b/item.go
@@ -40,6 +40,21 @@ type Item struct {
 	// Revenue schedule type
 	RevenueScheduleType string `json:"revenue_schedule_type,omitempty"`
 
+	// The ID of a performance obligation. Performance obligations are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	PerformanceObligationId string `json:"performance_obligation_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	LiabilityGlAccountId string `json:"liability_gl_account_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	RevenueGlAccountId string `json:"revenue_gl_account_id,omitempty"`
+
 	// Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
 	AvalaraTransactionType int `json:"avalara_transaction_type,omitempty"`
 

--- a/item_create.go
+++ b/item_create.go
@@ -26,6 +26,21 @@ type ItemCreate struct {
 	// Revenue schedule type
 	RevenueScheduleType *string `json:"revenue_schedule_type,omitempty"`
 
+	// The ID of a performance obligation. Performance obligations are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	PerformanceObligationId *string `json:"performance_obligation_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	LiabilityGlAccountId *string `json:"liability_gl_account_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	RevenueGlAccountId *string `json:"revenue_gl_account_id,omitempty"`
+
 	// Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
 	AvalaraTransactionType *int `json:"avalara_transaction_type,omitempty"`
 

--- a/item_update.go
+++ b/item_update.go
@@ -26,6 +26,21 @@ type ItemUpdate struct {
 	// Revenue schedule type
 	RevenueScheduleType *string `json:"revenue_schedule_type,omitempty"`
 
+	// The ID of a performance obligation. Performance obligations are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	PerformanceObligationId *string `json:"performance_obligation_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	LiabilityGlAccountId *string `json:"liability_gl_account_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	RevenueGlAccountId *string `json:"revenue_gl_account_id,omitempty"`
+
 	// Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.
 	AvalaraTransactionType *int `json:"avalara_transaction_type,omitempty"`
 

--- a/line_item.go
+++ b/line_item.go
@@ -122,6 +122,21 @@ type LineItem struct {
 	// The discount applied to the line item.
 	Discount float64 `json:"discount,omitempty"`
 
+	// Unique code to identify the ledger account. Each code must start
+	// with a letter or number. The following special characters are
+	// allowed: `-_.,:`
+	LiabilityGlAccountCode string `json:"liability_gl_account_code,omitempty"`
+
+	// Unique code to identify the ledger account. Each code must start
+	// with a letter or number. The following special characters are
+	// allowed: `-_.,:`
+	RevenueGlAccountCode string `json:"revenue_gl_account_code,omitempty"`
+
+	// The ID of a performance obligation. Performance obligations are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	PerformanceObligationId string `json:"performance_obligation_id,omitempty"`
+
 	// The tax amount for the line item.
 	Tax float64 `json:"tax,omitempty"`
 
@@ -142,6 +157,12 @@ type LineItem struct {
 
 	// Only for merchants using Recurly's In-The-Box taxes.
 	TaxInfo TaxInfo `json:"tax_info,omitempty"`
+
+	// The source of the address that will be used as the origin in determining taxes. Available only when the site is on an Elite plan. A value of "origin" refers to the "Business entity tax address". A value of "destination" refers to the "Customer tax address".
+	OriginTaxAddressSource string `json:"origin_tax_address_source,omitempty"`
+
+	// The source of the address that will be used as the destinaion in determining taxes. Available only when the site is on an Elite plan. A value of "destination" refers to the "Customer tax address". A value of "origin" refers to the "Business entity tax address".
+	DestinationTaxAddressSource string `json:"destination_tax_address_source,omitempty"`
 
 	// When a line item has been prorated, this is the rate of the proration. Proration rates were made available for line items created after March 30, 2017. For line items created prior to that date, the proration rate will be `null`, even if the line item was prorated.
 	ProrationRate float64 `json:"proration_rate,omitempty"`

--- a/line_item_create.go
+++ b/line_item_create.go
@@ -46,6 +46,21 @@ type LineItemCreate struct {
 	// Accounting Code for the `LineItem`. If `item_code`/`item_id` is part of the request then `accounting_code` must be absent.
 	AccountingCode *string `json:"accounting_code,omitempty"`
 
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	LiabilityGlAccountId *string `json:"liability_gl_account_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	RevenueGlAccountId *string `json:"revenue_gl_account_id,omitempty"`
+
+	// The ID of a performance obligation. Performance obligations are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	PerformanceObligationId *string `json:"performance_obligation_id,omitempty"`
+
 	// `true` exempts tax on charges, `false` applies tax on charges. If not defined, then defaults to the Plan and Site settings. This attribute does not work for credits (negative line items). Credits are always applied post-tax. Pre-tax discounts should use the Coupons feature.
 	TaxExempt *bool `json:"tax_exempt,omitempty"`
 
@@ -72,4 +87,10 @@ type LineItemCreate struct {
 
 	// If this date is provided, it indicates the end of a time range.
 	EndDate *time.Time `json:"end_date,omitempty"`
+
+	// The source of the address that will be used as the origin in determining taxes. Available only when the site is on an Elite plan. A value of "origin" refers to the "Business entity tax address". A value of "destination" refers to the "Customer tax address".
+	OriginTaxAddressSource *string `json:"origin_tax_address_source,omitempty"`
+
+	// The source of the address that will be used as the destinaion in determining taxes. Available only when the site is on an Elite plan. A value of "destination" refers to the "Customer tax address". A value of "origin" refers to the "Business entity tax address".
+	DestinationTaxAddressSource *string `json:"destination_tax_address_source,omitempty"`
 }

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -230,6 +230,8 @@ x-tagGroups:
   - shipping_method
   - dunning_campaigns
   - business_entities
+  - general_ledger_account
+  - performance_obligations
 tags:
 - name: site
   x-displayName: Site
@@ -242,7 +244,7 @@ tags:
   description: |-
     For merchants who sell the same things to many customers, documenting those offerings in a catalog allows for faster charge creation, easier management of offerings, and analytics about your offerings across all sales channels. Because your offerings can be physical, digital, or service-oriented, Recurly collectively calls these offerings "Items".
 
-    Recurly's item catalog requires the Credit Invoices features to be enabled.
+    Recurly's item catalog requires the Credit Invoices feature to be enabled.
 - name: plan
   x-displayName: Plan
   description: A plan tells Recurly how often and how much to charge your customers.
@@ -385,6 +387,55 @@ tags:
   x-displayName: Business Entities
   description: Describes the business address that will be used for invoices and taxes
     depending on settings and subscriber location.
+- name: general_ledger_account
+  x-displayName: General Ledger Account
+  description: |
+    A general ledger account is an account of record used to sort, store
+    and summarize a company's transactions. Recurly supports the balance
+    sheet (Liability) account and income (Revenue) account to be attached
+    to business entities, plans, or at the item level.
+
+    When invoices are created, system can default to the accounts based
+    on the GL Accounts attached at the plan/item level. The accounts can
+    be defaulted from the business entity level as well.
+
+    These accounts will be used in the Revenue Recognition module to create
+    the revenue journals that can be posted into Merchant GL system.
+
+    Revenue and Liability accounts can defined in the system using this
+    API or via the General Ledger Accounting page in the Admin UI and then
+    used at the plan/item level.
+
+    Recurly allows merchants to default the accounts at the following levels:
+    - Business Entities (default)
+    - Plans
+        - Base Price
+        - Setup Fee
+        - Add-ons
+    - Items
+    - Charges
+    - Gift Cards
+    - Shipping Methods
+    - Credits
+
+    If you are interested in Recurly Revenue Recognition features, please
+    contact a Recurly customer service representative.
+- name: performance_obligations
+  x-displayName: Performance Obligations
+  description: |
+    A performance obligation is a promise to provide a distinct good or
+    service or a series of distinct goods or services as defined by the revenue standard.
+    Performance obligations are completed and revenue is recognized either at a point in
+    time or over a period of time, depending on the type of obligation.
+    - Point in time  a company has to go through the criteria and determine if a performance
+    obligation is satisfied over time. If it does not meet those criteria, then the performance
+    obligation is satisfied and revenue recognized at the point in time when control of the good
+    or service is transferred to the customer.
+    - Over a period of time  a performance obligation is satisfied and revenue is recognized over
+    time if at least one of the following are met:
+      - The customer receives and consumes the benefits of the goods or services as they are provided
+      by the entity (routine, recurring services like a cleaning service are an example of a series of
+      services that are substantially the same and have the same pattern of transfer)
 paths:
   "/sites":
     get:
@@ -6566,7 +6617,7 @@ paths:
       - "$ref": "#/components/parameters/custom_field_definition_id"
       responses:
         '200':
-          description: An custom field definition.
+          description: A custom field definition.
           content:
             application/json:
               schema:
@@ -6672,6 +6723,150 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Custom
           Field Definition: %s\", definition.Id)"
+  "/general_ledger_accounts":
+    post:
+      tags:
+      - general_ledger_account
+      operationId: create_general_ledger_account
+      summary: Create a new general ledger account
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/GeneralLedgerAccountCreate"
+        required: true
+      responses:
+        '201':
+          description: A new general ledger account.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GeneralLedgerAccount"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+    get:
+      tags:
+      - general_ledger_account
+      operationId: list_general_ledger_accounts
+      summary: List a site's general ledger accounts
+      description: See the [Pagination Guide](/developers/guides/pagination.html)
+        to learn how to use pagination in the API and Client Libraries.
+      parameters:
+      - "$ref": "#/components/parameters/ids"
+      - "$ref": "#/components/parameters/limit"
+      - "$ref": "#/components/parameters/order"
+      - "$ref": "#/components/parameters/sort_dates"
+      - "$ref": "#/components/parameters/general_ledger_account_type_enum"
+      responses:
+        '200':
+          description: A list of the site's general ledger accounts.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GeneralLedgerAccountList"
+        '404':
+          description: Incorrect site ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+  "/general_ledger_accounts/{general_ledger_account_id}":
+    get:
+      tags:
+      - general_ledger_account
+      operationId: get_general_ledger_account
+      summary: Fetch a general ledger account
+      parameters:
+      - "$ref": "#/components/parameters/general_ledger_account_id"
+      responses:
+        '200':
+          description: A general ledger account.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GeneralLedgerAccount"
+        '404':
+          description: Incorrect site or general ledger account ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+    put:
+      tags:
+      - general_ledger_account
+      operationId: update_general_ledger_account
+      summary: Update a general ledger account
+      parameters:
+      - "$ref": "#/components/parameters/general_ledger_account_id"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/GeneralLedgerAccountUpdate"
+        required: true
+      responses:
+        '200':
+          description: The updated general ledger account.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GeneralLedgerAccount"
+        '404':
+          description: Incorrect site or general ledger account ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+  "/performance_obligations/{performance_obligation_id}":
+    get:
+      tags:
+      - performance_obligations
+      operationId: get_performance_obligation
+      summary: Get a single Performance Obligation.
+      parameters:
+      - "$ref": "#/components/parameters/performance_obligation_id"
+      responses:
+        '200':
+          description: A single Performance Obligation.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PerformanceObligation"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+  "/performance_obligations":
+    get:
+      tags:
+      - performance_obligations
+      operationId: get_performance_obligations
+      summary: Get a site's Performance Obligations
+      responses:
+        '200':
+          description: A list of Performance Obligations.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PerformanceObligationList"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/invoice_templates/{invoice_template_id}/accounts":
     get:
       tags:
@@ -8034,7 +8229,7 @@ paths:
       x-code-samples: []
   "/external_subscriptions/{external_subscription_id}":
     parameters:
-    - "$ref": "#/components/parameters/external_subscription_id"
+    - "$ref": "#/components/parameters/external_subscription_id_fetch"
     get:
       tags:
       - external_subscriptions
@@ -16093,10 +16288,10 @@ paths:
       tags:
       - external_payment_phases
       operationId: get_external_subscription_external_payment_phase
-      summary: Fetch an external payment_phase
+      summary: Fetch an external payment phase
       responses:
         '200':
-          description: Details for an external payment_phase.
+          description: Details for an external payment phase.
           content:
             application/json:
               schema:
@@ -16545,6 +16740,14 @@ components:
       required: true
       schema:
         type: string
+    external_subscription_id_fetch:
+      name: external_subscription_id
+      in: path
+      description: External subscription ID or external_id. For ID no prefix is used
+        e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456`.
+      required: true
+      schema:
+        type: string
     external_subscription_id:
       name: external_subscription_id
       in: path
@@ -16559,6 +16762,25 @@ components:
       required: true
       schema:
         type: string
+    general_ledger_account_id:
+      name: general_ledger_account_id
+      in: path
+      description: General Ledger Account ID
+      required: true
+      schema:
+        type: string
+        title: General Ledger Account ID
+        description: |
+          The ID of a general ledger account. General ledger accounts are
+          only accessible as a part of the Recurly RevRec Standard and
+          Recurly RevRec Advanced features.
+        maxLength: 13
+    general_ledger_account_type_enum:
+      name: account_type
+      in: query
+      description: General Ledger Account type by which to filter the response.
+      schema:
+        "$ref": "#/components/schemas/GeneralLedgerAccountTypeEnum"
     invoice_template_id:
       name: invoice_template_id
       in: path
@@ -16604,6 +16826,19 @@ components:
       required: true
       schema:
         type: string
+    performance_obligation_id:
+      name: performance_obligation_id
+      in: path
+      description: Performance Obligation id.
+      required: true
+      schema:
+        type: string
+        title: Performance Obligation ID
+        description: |
+          The ID of a performance obligation. Performance obligations are
+          only accessible as a part of the Recurly RevRec Standard and
+          Recurly RevRec Advanced features.
+        maxLength: 13
     plan_id:
       name: plan_id
       in: path
@@ -17858,6 +18093,30 @@ components:
           description: System-generated unique identifier for an measured unit associated
             with the add-on.
           maxLength: 13
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         accounting_code:
           type: string
           title: Accounting code
@@ -17972,7 +18231,7 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the `Credit
-            Invoices` feature are enabled. If `item_id` and `item_code` are both present,
+            Invoices` feature is enabled. If `item_id` and `item_code` are both present,
             `item_id` will be used.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
@@ -18031,6 +18290,30 @@ components:
           title: Plan ID
           maxLength: 13
           readOnly: true
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         accounting_code:
           type: string
           title: Accounting code
@@ -18100,7 +18383,7 @@ components:
           minItems: 1
           description: |
             * If `item_code`/`item_id` is part of the request and the item
-            has a default currency then `currencies` is optional. If the item does
+            has a default currency, then `currencies` is optional. If the item does
             not have a default currency, then `currencies` is required. If `item_code`/`item_id`
             is not present `currencies` is required.
             * If the add-on's `tier_type` is `tiered`, `volume`, or `stairstep`,
@@ -18189,6 +18472,30 @@ components:
             to the `AddOn` then `accounting code` must be absent.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 20
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         revenue_schedule_type:
           title: Revenue schedule type
           description: When this add-on is invoiced, the line item will use this revenue
@@ -18271,7 +18578,7 @@ components:
             `percentage_tiers` is an array of objects, which must have the set of tiers
             per currency and the currency code. The tier_type must be `volume` or `tiered`,
             if not, it must be absent. There must be one tier without an `ending_amount` value
-            which represents the final tier.  This feature is currently in development and
+            which represents the final tier. This feature is currently in development and
             requires approval and enablement, please contact support.
     BillingInfo:
       type: object
@@ -19210,6 +19517,171 @@ components:
             are removed from the accouts or subscriptions, will be hard deleted an
             no longer visible.
           readOnly: true
+    GeneralLedgerAccountId:
+      type: string
+      title: General Ledger Account ID
+      description: |
+        The ID of a general ledger account. General ledger accounts are
+        only accessible as a part of the Recurly RevRec Standard and
+        Recurly RevRec Advanced features.
+      maxLength: 13
+    GeneralLedgerAccountCode:
+      type: string
+      title: Accounting code for the ledger account.
+      description: |
+        Unique code to identify the ledger account. Each code must start
+        with a letter or number. The following special characters are
+        allowed: `-_.,:`
+      pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+      maxLength: 255
+    GeneralLedgerAccountDescription:
+      type: string
+      title: Description
+      description: Optional description.
+      maxLength: 255
+    GeneralLedgerAccount:
+      type: object
+      description: Full general ledger account details.
+      properties:
+        id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        object:
+          type: string
+          title: Object type
+          default: general_ledger_account
+          readOnly: true
+        code:
+          type: string
+          title: Accounting code for the ledger account.
+          description: |
+            Unique code to identify the ledger account. Each code must start
+            with a letter or number. The following special characters are
+            allowed: `-_.,:`
+          pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+          maxLength: 255
+        description:
+          type: string
+          title: Description
+          description: Optional description.
+          maxLength: 255
+        account_type:
+          "$ref": "#/components/schemas/GeneralLedgerAccountTypeEnum"
+        created_at:
+          type: string
+          format: date-time
+          title: Created at
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          title: Last updated at
+          readOnly: true
+    GeneralLedgerAccountList:
+      type: object
+      properties:
+        object:
+          type: string
+          title: Object type
+          description: Will always be List.
+        has_more:
+          type: boolean
+          description: Indicates there are more results on subsequent pages.
+        next:
+          type: string
+          description: Path to subsequent page of results.
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/GeneralLedgerAccount"
+    GeneralLedgerAccountCreate:
+      type: object
+      description: Create a new liability or revenue general ledger account.
+      properties:
+        code:
+          type: string
+          title: Accounting code for the ledger account.
+          description: |
+            Unique code to identify the ledger account. Each code must start
+            with a letter or number. The following special characters are
+            allowed: `-_.,:`
+          pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+          maxLength: 255
+        description:
+          type: string
+          title: Description
+          description: Optional description.
+          maxLength: 255
+        account_type:
+          "$ref": "#/components/schemas/GeneralLedgerAccountTypeEnum"
+    GeneralLedgerAccountUpdate:
+      type: object
+      description: Update an existing general ledger account.
+      properties:
+        code:
+          type: string
+          title: Accounting code for the ledger account.
+          description: |
+            Unique code to identify the ledger account. Each code must start
+            with a letter or number. The following special characters are
+            allowed: `-_.,:`
+          pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+          maxLength: 255
+        description:
+          type: string
+          title: Description
+          description: Optional description.
+          maxLength: 255
+    PerformanceObligationId:
+      type: string
+      title: Performance Obligation ID
+      description: |
+        The ID of a performance obligation. Performance obligations are
+        only accessible as a part of the Recurly RevRec Standard and
+        Recurly RevRec Advanced features.
+      maxLength: 13
+    PerformanceObligation:
+      type: object
+      description: Performance obligation details
+      properties:
+        id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        name:
+          title: Performance Obligation Name
+          type: string
+        created_at:
+          title: Created At
+          type: string
+          readOnly: true
+          format: date-time
+        updated_at:
+          title: Last updated at
+          type: string
+          readOnly: true
+          format: date-time
+    PerformanceObligationList:
+      type: object
+      description: List of Performance Obligations
+      properties:
+        object:
+          title: Object type
+          type: string
+        data:
+          title: Performance Obligation
+          type: array
+          items:
+            "$ref": "#/components/schemas/PerformanceObligation"
     ItemMini:
       type: object
       title: Item mini details
@@ -19294,6 +19766,30 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         avalara_transaction_type:
           type: integer
           title: Avalara Transaction Type
@@ -19378,6 +19874,30 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         avalara_transaction_type:
           type: integer
           title: Avalara Transaction Type
@@ -19450,6 +19970,30 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         avalara_transaction_type:
           type: integer
           title: Avalara Transaction Type
@@ -20269,6 +20813,32 @@ components:
           format: float
           title: Discount
           description: The discount applied to the line item.
+        liability_gl_account_code:
+          type: string
+          title: Accounting code for the ledger account.
+          description: |
+            Unique code to identify the ledger account. Each code must start
+            with a letter or number. The following special characters are
+            allowed: `-_.,:`
+          pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+          maxLength: 255
+        revenue_gl_account_code:
+          type: string
+          title: Accounting code for the ledger account.
+          description: |
+            Unique code to identify the ledger account. Each code must start
+            with a letter or number. The following special characters are
+            allowed: `-_.,:`
+          pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+          maxLength: 255
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         tax:
           type: number
           format: float
@@ -20310,6 +20880,10 @@ components:
           maxLength: 50
         tax_info:
           "$ref": "#/components/schemas/TaxInfo"
+        origin_tax_address_source:
+          "$ref": "#/components/schemas/OriginTaxAddressSourceEnum"
+        destination_tax_address_source:
+          "$ref": "#/components/schemas/DestinationTaxAddressSourceEnum"
         proration_rate:
           type: number
           format: float
@@ -20470,6 +21044,30 @@ components:
             is part of the request then `accounting_code` must be absent.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 20
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         tax_exempt:
           type: boolean
           title: Tax exempt?
@@ -20537,6 +21135,10 @@ components:
           format: date-time
           title: End date
           description: If this date is provided, it indicates the end of a time range.
+        origin_tax_address_source:
+          "$ref": "#/components/schemas/OriginTaxAddressSourceEnum"
+        destination_tax_address_source:
+          "$ref": "#/components/schemas/DestinationTaxAddressSourceEnum"
       required:
       - currency
       - unit_amount
@@ -20834,6 +21436,54 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         setup_fee_revenue_schedule_type:
           title: Setup fee revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -21050,6 +21700,54 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         setup_fee_revenue_schedule_type:
           title: Setup fee revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -21508,6 +22206,30 @@ components:
             - `FR010200` – Delivery by Company Vehicle After Passage of Title
             - `NT` – Non-Taxable
           maxLength: 50
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         created_at:
           type: string
           format: date-time
@@ -21580,6 +22302,30 @@ components:
             - `FR010200` – Delivery by Company Vehicle After Passage of Title
             - `NT` – Non-Taxable
           maxLength: 50
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
       required:
       - code
       - name
@@ -21618,6 +22364,30 @@ components:
             - `FR010200` – Delivery by Company Vehicle After Passage of Title
             - `NT` – Non-Taxable
           maxLength: 50
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
     ShippingFeeCreate:
       type: object
       properties:
@@ -23980,8 +24750,6 @@ components:
         object:
           type: string
           title: Object type
-        external_subscription:
-          "$ref": "#/components/schemas/ExternalSubscription"
         started_at:
           type: string
           format: date-time
@@ -24279,6 +25047,12 @@ components:
           "$ref": "#/components/schemas/AccountMini"
         external_product_reference:
           "$ref": "#/components/schemas/ExternalProductReferenceMini"
+        external_payment_phases:
+          type: array
+          title: External payment phases
+          description: The phases of the external subscription payment lifecycle.
+          items:
+            "$ref": "#/components/schemas/ExternalPaymentPhase"
         external_id:
           type: string
           title: External Id
@@ -24351,6 +25125,12 @@ components:
           title: Test
           description: An indication of whether or not the external subscription was
             purchased in a sandbox environment.
+          default: false
+        imported:
+          type: boolean
+          title: Imported
+          description: An indication of whether or not the external subscription was
+            created by a historical data import.
           default: false
         created_at:
           type: string
@@ -24682,6 +25462,10 @@ components:
           description: Address information for the business entity that will be used
             for calculating taxes.
           "$ref": "#/components/schemas/Address"
+        origin_tax_address_source:
+          "$ref": "#/components/schemas/OriginTaxAddressSourceEnum"
+        destination_tax_address_source:
+          "$ref": "#/components/schemas/DestinationTaxAddressSourceEnum"
         default_vat_number:
           type: string
           title: Default VAT number
@@ -24699,6 +25483,22 @@ components:
           items:
             type: string
             title: Country code
+        default_liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        default_revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         created_at:
           type: string
           format: date-time
@@ -24797,6 +25597,30 @@ components:
           description: The delivery details for the gift card.
           readOnly: true
           "$ref": "#/components/schemas/GiftCardDelivery"
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         created_at:
           type: string
           format: date-time
@@ -25978,3 +26802,30 @@ components:
       type: string
       enum:
       - paid
+    GeneralLedgerAccountTypeEnum:
+      type: string
+      enum:
+      - liability
+      - revenue
+    OriginTaxAddressSourceEnum:
+      type: string
+      title: Origin tax address source
+      description: The source of the address that will be used as the origin in determining
+        taxes. Available only when the site is on an Elite plan. A value of "origin"
+        refers to the "Business entity tax address". A value of "destination" refers
+        to the "Customer tax address".
+      default: origin
+      enum:
+      - origin
+      - destination
+    DestinationTaxAddressSourceEnum:
+      type: string
+      title: Destination tax address source
+      description: The source of the address that will be used as the destinaion in
+        determining taxes. Available only when the site is on an Elite plan. A value
+        of "destination" refers to the "Customer tax address". A value of "origin"
+        refers to the "Business entity tax address".
+      default: destination
+      enum:
+      - destination
+      - origin

--- a/performance_obligation.go
+++ b/performance_obligation.go
@@ -1,0 +1,131 @@
+// This file is automatically created by Recurly's OpenAPI generation process
+// and thus any edits you make by hand will be lost. If you wish to make a
+// change to this file, please create a Github issue explaining the changes you
+// need and we will usher them to the appropriate places.
+package recurly
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+type PerformanceObligation struct {
+	recurlyResponse *ResponseMetadata
+
+	// The ID of a performance obligation. Performance obligations are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	Id string `json:"id,omitempty"`
+
+	// Performance Obligation Name
+	Name string `json:"name,omitempty"`
+
+	// Created At
+	CreatedAt time.Time `json:"created_at,omitempty"`
+
+	// Last updated at
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+}
+
+// GetResponse returns the ResponseMetadata that generated this resource
+func (resource *PerformanceObligation) GetResponse() *ResponseMetadata {
+	return resource.recurlyResponse
+}
+
+// setResponse sets the ResponseMetadata that generated this resource
+func (resource *PerformanceObligation) setResponse(res *ResponseMetadata) {
+	resource.recurlyResponse = res
+}
+
+// internal struct for deserializing accounts
+type performanceObligationList struct {
+	ListMetadata
+	Data            []PerformanceObligation `json:"data"`
+	recurlyResponse *ResponseMetadata
+}
+
+// GetResponse returns the ResponseMetadata that generated this resource
+func (resource *performanceObligationList) GetResponse() *ResponseMetadata {
+	return resource.recurlyResponse
+}
+
+// setResponse sets the ResponseMetadata that generated this resource
+func (resource *performanceObligationList) setResponse(res *ResponseMetadata) {
+	resource.recurlyResponse = res
+}
+
+// PerformanceObligationList allows you to paginate PerformanceObligation objects
+type PerformanceObligationList struct {
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
+	hasMore        bool
+	data           []PerformanceObligation
+}
+
+func NewPerformanceObligationList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *PerformanceObligationList {
+	return &PerformanceObligationList{
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		hasMore:        true,
+	}
+}
+
+type PerformanceObligationLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []PerformanceObligation
+	HasMore() bool
+	Next() string
+}
+
+func (list *PerformanceObligationList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *PerformanceObligationList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *PerformanceObligationList) Data() []PerformanceObligation {
+	return list.data
+}
+
+// Fetch fetches the next page of data into the `Data` property
+func (list *PerformanceObligationList) FetchWithContext(ctx context.Context) error {
+	resources := &performanceObligationList{}
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
+	if err != nil {
+		return err
+	}
+	// copy over properties from the response
+	list.nextPagePath = resources.Next
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
+	return nil
+}
+
+// Fetch fetches the next page of data into the `Data` property
+func (list *PerformanceObligationList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *PerformanceObligationList) CountWithContext(ctx context.Context) (*int64, error) {
+	resources := &performanceObligationList{}
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
+	if err != nil {
+		return nil, err
+	}
+	resp := resources.GetResponse()
+	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *PerformanceObligationList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
+}

--- a/plan_create.go
+++ b/plan_create.go
@@ -55,6 +55,36 @@ type PlanCreate struct {
 	// Revenue schedule type
 	RevenueScheduleType *string `json:"revenue_schedule_type,omitempty"`
 
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	LiabilityGlAccountId *string `json:"liability_gl_account_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	RevenueGlAccountId *string `json:"revenue_gl_account_id,omitempty"`
+
+	// The ID of a performance obligation. Performance obligations are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	PerformanceObligationId *string `json:"performance_obligation_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	SetupFeeLiabilityGlAccountId *string `json:"setup_fee_liability_gl_account_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	SetupFeeRevenueGlAccountId *string `json:"setup_fee_revenue_gl_account_id,omitempty"`
+
+	// The ID of a performance obligation. Performance obligations are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	SetupFeePerformanceObligationId *string `json:"setup_fee_performance_obligation_id,omitempty"`
+
 	// Setup fee revenue schedule type
 	SetupFeeRevenueScheduleType *string `json:"setup_fee_revenue_schedule_type,omitempty"`
 

--- a/plan_update.go
+++ b/plan_update.go
@@ -47,6 +47,36 @@ type PlanUpdate struct {
 	// Revenue schedule type
 	RevenueScheduleType *string `json:"revenue_schedule_type,omitempty"`
 
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	LiabilityGlAccountId *string `json:"liability_gl_account_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	RevenueGlAccountId *string `json:"revenue_gl_account_id,omitempty"`
+
+	// The ID of a performance obligation. Performance obligations are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	PerformanceObligationId *string `json:"performance_obligation_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	SetupFeeLiabilityGlAccountId *string `json:"setup_fee_liability_gl_account_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	SetupFeeRevenueGlAccountId *string `json:"setup_fee_revenue_gl_account_id,omitempty"`
+
+	// The ID of a performance obligation. Performance obligations are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	SetupFeePerformanceObligationId *string `json:"setup_fee_performance_obligation_id,omitempty"`
+
 	// Setup fee revenue schedule type
 	SetupFeeRevenueScheduleType *string `json:"setup_fee_revenue_schedule_type,omitempty"`
 

--- a/scripts/clean
+++ b/scripts/clean
@@ -36,6 +36,7 @@ rm -f credit_payment.go
 rm -f external_invoice.go
 rm -f external_subscription.go
 rm -f external_product_reference_mini.go
+rm -f external_payment_phase.go
 rm -f external_charge.go
 rm -f invoice.go
 rm -f invoice_address.go
@@ -60,6 +61,8 @@ rm -f subscription_ramp_interval_response.go
 rm -f unique_coupon_code_params.go
 rm -f unique_coupon_code.go
 rm -f custom_field_definition.go
+rm -f general_ledger_account.go
+rm -f performance_obligation.go
 rm -f item.go
 rm -f pricing.go
 rm -f measured_unit.go
@@ -87,7 +90,6 @@ rm -f dunning_cycle.go
 rm -f dunning_interval.go
 rm -f dunning_campaigns_bulk_update_response.go
 rm -f invoice_template.go
-rm -f external_payment_phase.go
 rm -f entitlements.go
 rm -f entitlement.go
 rm -f customer_permission.go
@@ -116,6 +118,8 @@ rm -f coupon_create.go
 rm -f coupon_pricing.go
 rm -f coupon_update.go
 rm -f coupon_bulk_create.go
+rm -f general_ledger_account_create.go
+rm -f general_ledger_account_update.go
 rm -f item_create.go
 rm -f pricing_create.go
 rm -f item_update.go

--- a/shipping_method.go
+++ b/shipping_method.go
@@ -40,6 +40,21 @@ type ShippingMethod struct {
 	// - `NT` – Non-Taxable
 	TaxCode string `json:"tax_code,omitempty"`
 
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	LiabilityGlAccountId string `json:"liability_gl_account_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	RevenueGlAccountId string `json:"revenue_gl_account_id,omitempty"`
+
+	// The ID of a performance obligation. Performance obligations are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	PerformanceObligationId string `json:"performance_obligation_id,omitempty"`
+
 	// Created at
 	CreatedAt time.Time `json:"created_at,omitempty"`
 

--- a/shipping_method_create.go
+++ b/shipping_method_create.go
@@ -28,4 +28,19 @@ type ShippingMethodCreate struct {
 	// - `FR010200` – Delivery by Company Vehicle After Passage of Title
 	// - `NT` – Non-Taxable
 	TaxCode *string `json:"tax_code,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	LiabilityGlAccountId *string `json:"liability_gl_account_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	RevenueGlAccountId *string `json:"revenue_gl_account_id,omitempty"`
+
+	// The ID of a performance obligation. Performance obligations are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	PerformanceObligationId *string `json:"performance_obligation_id,omitempty"`
 }

--- a/shipping_method_update.go
+++ b/shipping_method_update.go
@@ -28,4 +28,19 @@ type ShippingMethodUpdate struct {
 	// - `FR010200` – Delivery by Company Vehicle After Passage of Title
 	// - `NT` – Non-Taxable
 	TaxCode *string `json:"tax_code,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	LiabilityGlAccountId *string `json:"liability_gl_account_id,omitempty"`
+
+	// The ID of a general ledger account. General ledger accounts are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	RevenueGlAccountId *string `json:"revenue_gl_account_id,omitempty"`
+
+	// The ID of a performance obligation. Performance obligations are
+	// only accessible as a part of the Recurly RevRec Standard and
+	// Recurly RevRec Advanced features.
+	PerformanceObligationId *string `json:"performance_obligation_id,omitempty"`
 }


### PR DESCRIPTION
**Taxable Address Control**
* GET external_subscription by external-id
* Add `destination_tax_address_source` and `origin_tax_address_source` to line_item and business_entity resources

**RevRec**
*  list_general_ledger_accounts
* get_general_ledger_account by `liability_gl_account_id` or `revenue_gl_account_id`
* update_general_ledger_account by `liability_gl_account_id` or `revenue_gl_account_id`
* get_performance_obligations
* get_performance_obligation by `performance_obligation_id`
* Add `default_liability_gl_account_id` and `default_revenue_gl_account_id` to business_entity resource
* Add `liability_gl_account_id`, `revenue_gl_account_id`, and `performance_obligation_id` to the following resources
    - add_on
    - business_entity
    - gift_card
    - item
    - shipping_method
* Add `liability_gl_account_code` and `revenue_gl_account_code` to line_item resource