### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21353,6 +21353,11 @@ components:
           title: Tax exempt?
           description: "`true` exempts tax on the plan, `false` applies tax on the
             plan."
+        vertex_transaction_type:
+          type: string
+          title: Vertex Transaction Type
+          description: Used by Vertex for tax calculations. Possible values are `sale`,
+            `rental`, `lease`.
         currencies:
           type: array
           title: Pricing
@@ -21568,6 +21573,11 @@ components:
           title: Tax exempt?
           description: "`true` exempts tax on the plan, `false` applies tax on the
             plan."
+        vertex_transaction_type:
+          type: string
+          title: Vertex Transaction Type
+          description: Used by Vertex for tax calculations. Possible values are `sale`,
+            `rental`, `lease`.
         currencies:
           type: array
           title: Pricing
@@ -21832,6 +21842,11 @@ components:
           title: Tax exempt?
           description: "`true` exempts tax on the plan, `false` applies tax on the
             plan."
+        vertex_transaction_type:
+          type: string
+          title: Vertex Transaction Type
+          description: Used by Vertex for tax calculations. Possible values are `sale`,
+            `rental`, `lease`.
         currencies:
           type: array
           title: Pricing

--- a/plan.go
+++ b/plan.go
@@ -87,6 +87,9 @@ type Plan struct {
 	// `true` exempts tax on the plan, `false` applies tax on the plan.
 	TaxExempt bool `json:"tax_exempt,omitempty"`
 
+	// Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`.
+	VertexTransactionType string `json:"vertex_transaction_type,omitempty"`
+
 	// Pricing
 	Currencies []PlanPricing `json:"currencies,omitempty"`
 

--- a/plan_create.go
+++ b/plan_create.go
@@ -103,6 +103,9 @@ type PlanCreate struct {
 	// `true` exempts tax on the plan, `false` applies tax on the plan.
 	TaxExempt *bool `json:"tax_exempt,omitempty"`
 
+	// Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`.
+	VertexTransactionType *string `json:"vertex_transaction_type,omitempty"`
+
 	// Pricing
 	Currencies []PlanPricingCreate `json:"currencies,omitempty"`
 

--- a/plan_update.go
+++ b/plan_update.go
@@ -95,6 +95,9 @@ type PlanUpdate struct {
 	// `true` exempts tax on the plan, `false` applies tax on the plan.
 	TaxExempt *bool `json:"tax_exempt,omitempty"`
 
+	// Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`.
+	VertexTransactionType *string `json:"vertex_transaction_type,omitempty"`
+
 	// Optional when the pricing model is 'ramp'.
 	Currencies []PlanPricingCreate `json:"currencies,omitempty"`
 


### PR DESCRIPTION
This PR adds the ability to send a plan's `vertex_transaction_type` to vertex. 
 ```
vertex_transaction_type:
  type: string
  title: Vertex Transaction Type
  description: Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`.
```