### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -88,6 +88,9 @@ type Invoice struct {
 	// The total tax on this invoice.
 	Tax float64 `json:"tax,omitempty"`
 
+	// Reference Only Currency Conversion
+	ReferenceOnlyCurrencyConversion ReferenceOnlyCurrencyConversion `json:"reference_only_currency_conversion,omitempty"`
+
 	// The final total on this invoice. The summation of invoice charges, discounts, credits, and tax.
 	Total float64 `json:"total,omitempty"`
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -20276,6 +20276,8 @@ components:
           format: float
           title: Tax
           description: The total tax on this invoice.
+        reference_only_currency_conversion:
+          "$ref": "#/components/schemas/ReferenceOnlyCurrencyConversion"
         total:
           type: number
           format: float
@@ -22289,6 +22291,25 @@ components:
           title: Updated at
           format: date-time
           readOnly: true
+    ReferenceOnlyCurrencyConversion:
+      type: object
+      title: Reference Only Currency Conversion
+      properties:
+        currency:
+          type: string
+          title: Currency
+          description: 3-letter ISO 4217 currency code.
+          maxLength: 3
+        subtotal_in_cents:
+          type: number
+          format: float
+          title: Subtotal In Cents
+          description: The subtotal converted to the currency.
+        tax_in_cents:
+          type: number
+          format: float
+          title: Tax In Cents
+          description: The tax converted to the currency.
     ShippingAddressCreate:
       type: object
       properties:

--- a/reference_only_currency_conversion.go
+++ b/reference_only_currency_conversion.go
@@ -1,0 +1,125 @@
+// This file is automatically created by Recurly's OpenAPI generation process
+// and thus any edits you make by hand will be lost. If you wish to make a
+// change to this file, please create a Github issue explaining the changes you
+// need and we will usher them to the appropriate places.
+package recurly
+
+import (
+	"context"
+	"net/http"
+)
+
+type ReferenceOnlyCurrencyConversion struct {
+	recurlyResponse *ResponseMetadata
+
+	// 3-letter ISO 4217 currency code.
+	Currency string `json:"currency,omitempty"`
+
+	// The subtotal converted to the currency.
+	SubtotalInCents float64 `json:"subtotal_in_cents,omitempty"`
+
+	// The tax converted to the currency.
+	TaxInCents float64 `json:"tax_in_cents,omitempty"`
+}
+
+// GetResponse returns the ResponseMetadata that generated this resource
+func (resource *ReferenceOnlyCurrencyConversion) GetResponse() *ResponseMetadata {
+	return resource.recurlyResponse
+}
+
+// setResponse sets the ResponseMetadata that generated this resource
+func (resource *ReferenceOnlyCurrencyConversion) setResponse(res *ResponseMetadata) {
+	resource.recurlyResponse = res
+}
+
+// internal struct for deserializing accounts
+type referenceOnlyCurrencyConversionList struct {
+	ListMetadata
+	Data            []ReferenceOnlyCurrencyConversion `json:"data"`
+	recurlyResponse *ResponseMetadata
+}
+
+// GetResponse returns the ResponseMetadata that generated this resource
+func (resource *referenceOnlyCurrencyConversionList) GetResponse() *ResponseMetadata {
+	return resource.recurlyResponse
+}
+
+// setResponse sets the ResponseMetadata that generated this resource
+func (resource *referenceOnlyCurrencyConversionList) setResponse(res *ResponseMetadata) {
+	resource.recurlyResponse = res
+}
+
+// ReferenceOnlyCurrencyConversionList allows you to paginate ReferenceOnlyCurrencyConversion objects
+type ReferenceOnlyCurrencyConversionList struct {
+	client         HTTPCaller
+	requestOptions *RequestOptions
+	nextPagePath   string
+	hasMore        bool
+	data           []ReferenceOnlyCurrencyConversion
+}
+
+func NewReferenceOnlyCurrencyConversionList(client HTTPCaller, nextPagePath string, requestOptions *RequestOptions) *ReferenceOnlyCurrencyConversionList {
+	return &ReferenceOnlyCurrencyConversionList{
+		client:         client,
+		requestOptions: requestOptions,
+		nextPagePath:   nextPagePath,
+		hasMore:        true,
+	}
+}
+
+type ReferenceOnlyCurrencyConversionLister interface {
+	Fetch() error
+	FetchWithContext(ctx context.Context) error
+	Count() (*int64, error)
+	CountWithContext(ctx context.Context) (*int64, error)
+	Data() []ReferenceOnlyCurrencyConversion
+	HasMore() bool
+	Next() string
+}
+
+func (list *ReferenceOnlyCurrencyConversionList) HasMore() bool {
+	return list.hasMore
+}
+
+func (list *ReferenceOnlyCurrencyConversionList) Next() string {
+	return list.nextPagePath
+}
+
+func (list *ReferenceOnlyCurrencyConversionList) Data() []ReferenceOnlyCurrencyConversion {
+	return list.data
+}
+
+// Fetch fetches the next page of data into the `Data` property
+func (list *ReferenceOnlyCurrencyConversionList) FetchWithContext(ctx context.Context) error {
+	resources := &referenceOnlyCurrencyConversionList{}
+	err := list.client.Call(ctx, http.MethodGet, list.nextPagePath, nil, nil, list.requestOptions, resources)
+	if err != nil {
+		return err
+	}
+	// copy over properties from the response
+	list.nextPagePath = resources.Next
+	list.hasMore = resources.HasMore
+	list.data = resources.Data
+	return nil
+}
+
+// Fetch fetches the next page of data into the `Data` property
+func (list *ReferenceOnlyCurrencyConversionList) Fetch() error {
+	return list.FetchWithContext(context.Background())
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *ReferenceOnlyCurrencyConversionList) CountWithContext(ctx context.Context) (*int64, error) {
+	resources := &referenceOnlyCurrencyConversionList{}
+	err := list.client.Call(ctx, http.MethodHead, list.nextPagePath, nil, nil, list.requestOptions, resources)
+	if err != nil {
+		return nil, err
+	}
+	resp := resources.GetResponse()
+	return resp.TotalRecords, nil
+}
+
+// Count returns the count of items on the server that match this pager
+func (list *ReferenceOnlyCurrencyConversionList) Count() (*int64, error) {
+	return list.CountWithContext(context.Background())
+}

--- a/scripts/clean
+++ b/scripts/clean
@@ -41,6 +41,7 @@ rm -f external_payment_phase.go
 rm -f external_charge.go
 rm -f invoice.go
 rm -f invoice_address.go
+rm -f reference_only_currency_conversion.go
 rm -f tax_info.go
 rm -f tax_detail.go
 rm -f line_item.go


### PR DESCRIPTION
This PR adds `reference_only_currency_conversion` values to Invoice responses.

```json
  "reference_only_currency_conversion": {
    "currency": "str",
    "subtotal_in_cents": 0,
    "tax_in_cents": 0
  },
  ```