### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21322,8 +21322,8 @@ components:
           type: string
           title: Token
           description: Reference value used when the external token was created. If
-            Stripe gateway is used, this value will need to be accompanied by its
-            reference_type.
+            a Stripe gateway or Ebanx gateway is used, this value will need to be
+            accompanied by its reference_type.
         reference_type:
           type: string
           title: Reference Type
@@ -23682,7 +23682,7 @@ components:
           type: string
           format: date-time
           title: Start date
-          description: If set, the subscription will begin in the future on this date.
+          description: If set, the subscription will begin on this specified date.
             The subscription will apply the setup fee and trial period, unless the
             plan has no trial.
         next_bill_date:
@@ -23855,7 +23855,7 @@ components:
           type: string
           format: date-time
           title: Start date
-          description: If set, the subscription will begin in the future on this date.
+          description: If set, the subscription will begin on this specified date.
             The subscription will apply the setup fee and trial period, unless the
             plan has no trial.
         next_bill_date:
@@ -26564,11 +26564,12 @@ components:
     PaymentGatewayReferencesEnum:
       type: string
       description: The type of reference token. Required if token is passed in for
-        Stripe Gateway.
+        Stripe Gateway or Ebanx UPI.
       enum:
       - stripe_confirmation_token
       - stripe_customer
       - stripe_payment_method
+      - upi_vpa
     GatewayTransactionTypeEnum:
       type: string
       enum:

--- a/payment_gateway_references.go
+++ b/payment_gateway_references.go
@@ -12,10 +12,10 @@ import (
 type PaymentGatewayReferences struct {
 	recurlyResponse *ResponseMetadata
 
-	// Reference value used when the external token was created. If Stripe gateway is used, this value will need to be accompanied by its reference_type.
+	// Reference value used when the external token was created. If a Stripe gateway or Ebanx gateway is used, this value will need to be accompanied by its reference_type.
 	Token string `json:"token,omitempty"`
 
-	// The type of reference token. Required if token is passed in for Stripe Gateway.
+	// The type of reference token. Required if token is passed in for Stripe Gateway or Ebanx UPI.
 	ReferenceType string `json:"reference_type,omitempty"`
 }
 

--- a/payment_gateway_references_create.go
+++ b/payment_gateway_references_create.go
@@ -8,9 +8,9 @@ import ()
 
 type PaymentGatewayReferencesCreate struct {
 
-	// Reference value used when the external token was created. If Stripe gateway is used, this value will need to be accompanied by its reference_type.
+	// Reference value used when the external token was created. If a Stripe gateway or Ebanx gateway is used, this value will need to be accompanied by its reference_type.
 	Token *string `json:"token,omitempty"`
 
-	// The type of reference token. Required if token is passed in for Stripe Gateway.
+	// The type of reference token. Required if token is passed in for Stripe Gateway or Ebanx UPI.
 	ReferenceType *string `json:"reference_type,omitempty"`
 }

--- a/subscription_create.go
+++ b/subscription_create.go
@@ -57,7 +57,7 @@ type SubscriptionCreate struct {
 	// If set, overrides the default trial behavior for the subscription. When the current date time or a past date time is provided the subscription will begin with no trial phase (overriding any plan default trial). When a future date time is provided the subscription will begin with a trial phase ending at the specified date time.
 	TrialEndsAt *time.Time `json:"trial_ends_at,omitempty"`
 
-	// If set, the subscription will begin in the future on this date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
+	// If set, the subscription will begin on this specified date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
 	StartsAt *time.Time `json:"starts_at,omitempty"`
 
 	// If present, this sets the date the subscription's next billing period will start (`current_period_ends_at`). This can be used to align the subscription’s billing to a specific day of the month. The initial invoice will be prorated for the period between the subscription's activation date and the billing period end date. Subsequent periods will be based off the plan interval. For a subscription with a trial period, this will change when the trial expires.

--- a/subscription_purchase.go
+++ b/subscription_purchase.go
@@ -37,7 +37,7 @@ type SubscriptionPurchase struct {
 	// If set, overrides the default trial behavior for the subscription. When the current date time or a past date time is provided the subscription will begin with no trial phase (overriding any plan default trial). When a future date time is provided the subscription will begin with a trial phase ending at the specified date time.
 	TrialEndsAt *time.Time `json:"trial_ends_at,omitempty"`
 
-	// If set, the subscription will begin in the future on this date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
+	// If set, the subscription will begin on this specified date. The subscription will apply the setup fee and trial period, unless the plan has no trial.
 	StartsAt *time.Time `json:"starts_at,omitempty"`
 
 	// If present, this sets the date the subscription's next billing period will start (`current_period_ends_at`). This can be used to align the subscription’s billing to a specific day of the month. The initial invoice will be prorated for the period between the subscription's activation date and the billing period end date. Subsequent periods will be based off the plan interval. For a subscription with a trial period, this will change when the trial expires.


### PR DESCRIPTION
- Adding the new `upi_vpa` payment gateway reference type
- Updated starts_at description to allow backdating subscriptions.