### PR TITLE
chore: Upgrade client to 5.x

### DIFF
--- a/.changelog_config.yaml
+++ b/.changelog_config.yaml
@@ -1,9 +1,9 @@
 ---
 owner: recurly
 repo: recurly-client-go
-tag_matcher: ^v4\..*
+tag_matcher: ^v5\..*
 required_issue_labels:
-  - V4
+  - V5
 exclude_labels:
   - bug?
   - internal

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Check Labels
         uses: docker://agilepathway/pull-request-label-checker:latest
         with:
-          one_of: V4
+          one_of: V5
           repo_token: ${{ secrets.GITHUB_TOKEN }}
  

--- a/account.go
+++ b/account.go
@@ -46,13 +46,13 @@ type Account struct {
 	HasPastDueInvoice bool `json:"has_past_due_invoice,omitempty"`
 
 	// When the account was created.
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// When the account was last changed.
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// If present, when the account was last marked inactive.
-	DeletedAt time.Time `json:"deleted_at,omitempty"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
 
 	// The unique identifier of the account. This cannot be changed once the account is created.
 	Code string `json:"code,omitempty"`

--- a/account_acquisition.go
+++ b/account_acquisition.go
@@ -34,10 +34,10 @@ type AccountAcquisition struct {
 	Account AccountMini `json:"account,omitempty"`
 
 	// When the account acquisition data was created.
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// When the account acquisition data was last changed.
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/account_create.go
+++ b/account_create.go
@@ -14,9 +14,9 @@ type AccountCreate struct {
 	Acquisition *AccountAcquisitionUpdate `json:"acquisition,omitempty"`
 
 	// External Accounts
-	ExternalAccounts []ExternalAccountCreate `json:"external_accounts,omitempty"`
+	ExternalAccounts *[]ExternalAccountCreate `json:"external_accounts,omitempty"`
 
-	ShippingAddresses []ShippingAddressCreate `json:"shipping_addresses,omitempty"`
+	ShippingAddresses *[]ShippingAddressCreate `json:"shipping_addresses,omitempty"`
 
 	// A secondary value for the account.
 	Username *string `json:"username,omitempty"`
@@ -74,7 +74,7 @@ type AccountCreate struct {
 	BillingInfo *BillingInfoCreate `json:"billing_info,omitempty"`
 
 	// The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-	CustomFields []CustomFieldCreate `json:"custom_fields,omitempty"`
+	CustomFields *[]CustomFieldCreate `json:"custom_fields,omitempty"`
 
 	// The Avalara AvaTax value that can be passed to identify the customer type for tax purposes. The range of values can be A - R (more info at Avalara). Value is case-sensitive.
 	EntityUseCode *string `json:"entity_use_code,omitempty"`

--- a/account_note.go
+++ b/account_note.go
@@ -24,7 +24,7 @@ type AccountNote struct {
 
 	Message string `json:"message,omitempty"`
 
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/account_purchase.go
+++ b/account_purchase.go
@@ -72,7 +72,7 @@ type AccountPurchase struct {
 	BillingInfo *BillingInfoCreate `json:"billing_info,omitempty"`
 
 	// The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-	CustomFields []CustomFieldCreate `json:"custom_fields,omitempty"`
+	CustomFields *[]CustomFieldCreate `json:"custom_fields,omitempty"`
 
 	// The Avalara AvaTax value that can be passed to identify the customer type for tax purposes. The range of values can be A - R (more info at Avalara). Value is case-sensitive.
 	EntityUseCode *string `json:"entity_use_code,omitempty"`

--- a/account_update.go
+++ b/account_update.go
@@ -64,7 +64,7 @@ type AccountUpdate struct {
 	BillingInfo *BillingInfoCreate `json:"billing_info,omitempty"`
 
 	// The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-	CustomFields []CustomFieldCreate `json:"custom_fields,omitempty"`
+	CustomFields *[]CustomFieldCreate `json:"custom_fields,omitempty"`
 
 	// The Avalara AvaTax value that can be passed to identify the customer type for tax purposes. The range of values can be A - R (more info at Avalara). Value is case-sensitive.
 	EntityUseCode *string `json:"entity_use_code,omitempty"`

--- a/add_on.go
+++ b/add_on.go
@@ -110,13 +110,13 @@ type AddOn struct {
 	ExternalSku string `json:"external_sku,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Last updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// Deleted at
-	DeletedAt time.Time `json:"deleted_at,omitempty"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/add_on_create.go
+++ b/add_on_create.go
@@ -89,7 +89,7 @@ type AddOnCreate struct {
 	// * If the add-on's `tier_type` is `tiered`, `volume`, or `stairstep`,
 	// then `currencies` must be absent.
 	// * Must be absent if `add_on_type` is `usage` and `usage_type` is `percentage`.
-	Currencies []AddOnPricingCreate `json:"currencies,omitempty"`
+	Currencies *[]AddOnPricingCreate `json:"currencies,omitempty"`
 
 	// The pricing model for the add-on.  For more information,
 	// [click here](https://docs.recurly.com/docs/billing-models#section-quantity-based). See our
@@ -106,12 +106,12 @@ type AddOnCreate struct {
 	// must include one to many tiers with `ending_quantity` and `unit_amount` for
 	// the desired `currencies`. There must be one tier without an `ending_quantity` value
 	// which represents the final tier.
-	Tiers []TierCreate `json:"tiers,omitempty"`
+	Tiers *[]TierCreate `json:"tiers,omitempty"`
 
 	// Array of objects which must have at least one set of tiers
 	// per currency and the currency code. The tier_type must be `volume` or `tiered`,
 	// if not, it must be absent. There must be one tier without an `ending_amount` value
 	// which represents the final tier. This feature is currently in development and
 	// requires approval and enablement, please contact support.
-	PercentageTiers []PercentageTiersByCurrencyCreate `json:"percentage_tiers,omitempty"`
+	PercentageTiers *[]PercentageTiersByCurrencyCreate `json:"percentage_tiers,omitempty"`
 }

--- a/add_on_update.go
+++ b/add_on_update.go
@@ -71,18 +71,18 @@ type AddOnUpdate struct {
 	// If the add-on's `tier_type` is `tiered`, `volume`, or `stairstep`,
 	// then currencies must be absent. Must also be absent if `add_on_type` is
 	// `usage` and `usage_type` is `percentage`.
-	Currencies []AddOnPricingCreate `json:"currencies,omitempty"`
+	Currencies *[]AddOnPricingCreate `json:"currencies,omitempty"`
 
 	// If the tier_type is `flat`, then `tiers` must be absent. The `tiers` object
 	// must include one to many tiers with `ending_quantity` and `unit_amount` for
 	// the desired `currencies`. There must be one tier without an `ending_quantity` value
 	// which represents the final tier.
-	Tiers []TierCreate `json:"tiers,omitempty"`
+	Tiers *[]TierCreate `json:"tiers,omitempty"`
 
 	// `percentage_tiers` is an array of objects, which must have the set of tiers
 	// per currency and the currency code. The tier_type must be `volume` or `tiered`,
 	// if not, it must be absent. There must be one tier without an `ending_amount` value
 	// which represents the final tier. This feature is currently in development and
 	// requires approval and enablement, please contact support.
-	PercentageTiers []PercentageTiersByCurrencyCreate `json:"percentage_tiers,omitempty"`
+	PercentageTiers *[]PercentageTiersByCurrencyCreate `json:"percentage_tiers,omitempty"`
 }

--- a/billing_info.go
+++ b/billing_info.go
@@ -48,10 +48,10 @@ type BillingInfo struct {
 	PaymentGatewayReferences []PaymentGatewayReferences `json:"payment_gateway_references,omitempty"`
 
 	// When the billing information was created.
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// When the billing information was last changed.
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	UpdatedBy BillingInfoUpdatedBy `json:"updated_by,omitempty"`
 }

--- a/billing_info_create.go
+++ b/billing_info_create.go
@@ -50,7 +50,7 @@ type BillingInfoCreate struct {
 	GatewayCode *string `json:"gateway_code,omitempty"`
 
 	// Array of Payment Gateway References, each a reference to a third-party gateway object of varying types.
-	PaymentGatewayReferences []PaymentGatewayReferencesCreate `json:"payment_gateway_references,omitempty"`
+	PaymentGatewayReferences *[]PaymentGatewayReferencesCreate `json:"payment_gateway_references,omitempty"`
 
 	// Additional attributes to send to the gateway.
 	GatewayAttributes *GatewayAttributesCreate `json:"gateway_attributes,omitempty"`

--- a/business_entity.go
+++ b/business_entity.go
@@ -57,10 +57,10 @@ type BusinessEntity struct {
 	DefaultRevenueGlAccountId string `json:"default_revenue_gl_account_id,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Last updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/client_operations.go
+++ b/client_operations.go
@@ -526,7 +526,7 @@ type ListSitesParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -547,7 +547,7 @@ func (list *ListSitesParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -624,7 +624,7 @@ type ListAccountsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -660,7 +660,7 @@ func (list *ListAccountsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -1142,7 +1142,7 @@ type ListBillingInfosParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Sort - Sort field. You *really* only want to sort by `updated_at` in ascending
 	// order. In descending order updated records will move behind the cursor and could
@@ -1162,7 +1162,7 @@ func (list *ListBillingInfosParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Sort != nil {
@@ -1322,7 +1322,7 @@ type ListAccountCouponRedemptionsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Sort - Sort field. You *really* only want to sort by `updated_at` in ascending
 	// order. In descending order updated records will move behind the cursor and could
@@ -1345,7 +1345,7 @@ func (list *ListAccountCouponRedemptionsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Sort != nil {
@@ -1705,7 +1705,7 @@ type ListAccountInvoicesParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// State - Invoice state.
 	State *string
@@ -1741,7 +1741,7 @@ func (list *ListAccountInvoicesParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.State != nil {
@@ -1859,7 +1859,7 @@ type ListAccountLineItemsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -1894,7 +1894,7 @@ func (list *ListAccountLineItemsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -1987,14 +1987,14 @@ type ListAccountNotesParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 }
 
 func (list *ListAccountNotesParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	return options
@@ -2055,7 +2055,7 @@ type ListShippingAddressesParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -2081,7 +2081,7 @@ func (list *ListShippingAddressesParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -2249,7 +2249,7 @@ type ListAccountSubscriptionsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -2281,7 +2281,7 @@ func (list *ListAccountSubscriptionsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -2337,7 +2337,7 @@ type ListAccountTransactionsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -2369,7 +2369,7 @@ func (list *ListAccountTransactionsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -2429,7 +2429,7 @@ type ListChildAccountsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -2465,7 +2465,7 @@ func (list *ListChildAccountsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -2529,7 +2529,7 @@ type ListAccountAcquisitionParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -2555,7 +2555,7 @@ func (list *ListAccountAcquisitionParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -2607,7 +2607,7 @@ type ListCouponsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -2633,7 +2633,7 @@ func (list *ListCouponsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -2859,7 +2859,7 @@ type ListUniqueCouponCodesParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -2888,7 +2888,7 @@ func (list *ListUniqueCouponCodesParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -3036,7 +3036,7 @@ type ListCustomFieldDefinitionsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -3065,7 +3065,7 @@ func (list *ListCustomFieldDefinitionsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -3179,7 +3179,7 @@ type ListGeneralLedgerAccountsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -3200,7 +3200,7 @@ func (list *ListGeneralLedgerAccountsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -3349,7 +3349,7 @@ type ListInvoiceTemplateAccountsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -3385,7 +3385,7 @@ func (list *ListInvoiceTemplateAccountsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -3449,7 +3449,7 @@ type ListItemsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -3478,7 +3478,7 @@ func (list *ListItemsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -3679,7 +3679,7 @@ type ListMeasuredUnitParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -3708,7 +3708,7 @@ func (list *ListMeasuredUnitParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -4357,7 +4357,7 @@ type ListInvoicesParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// State - Invoice state.
 	State *string
@@ -4393,7 +4393,7 @@ func (list *ListInvoicesParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.State != nil {
@@ -4726,7 +4726,7 @@ type ListInvoiceLineItemsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -4761,7 +4761,7 @@ func (list *ListInvoiceLineItemsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -4825,7 +4825,7 @@ type ListInvoiceCouponRedemptionsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Sort - Sort field. You *really* only want to sort by `updated_at` in ascending
 	// order. In descending order updated records will move behind the cursor and could
@@ -4845,7 +4845,7 @@ func (list *ListInvoiceCouponRedemptionsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Sort != nil {
@@ -4932,7 +4932,7 @@ type ListLineItemsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -4967,7 +4967,7 @@ func (list *ListLineItemsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -5089,7 +5089,7 @@ type ListPlansParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -5118,7 +5118,7 @@ func (list *ListPlansParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -5290,7 +5290,7 @@ type ListPlanAddOnsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -5319,7 +5319,7 @@ func (list *ListPlanAddOnsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -5491,7 +5491,7 @@ type ListAddOnsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -5520,7 +5520,7 @@ func (list *ListAddOnsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -5605,7 +5605,7 @@ type ListShippingMethodsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -5631,7 +5631,7 @@ func (list *ListShippingMethodsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -5799,7 +5799,7 @@ type ListSubscriptionsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -5831,7 +5831,7 @@ func (list *ListSubscriptionsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -6333,7 +6333,7 @@ type ListSubscriptionInvoicesParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// State - Invoice state.
 	State *string
@@ -6369,7 +6369,7 @@ func (list *ListSubscriptionInvoicesParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.State != nil {
@@ -6429,7 +6429,7 @@ type ListSubscriptionLineItemsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -6464,7 +6464,7 @@ func (list *ListSubscriptionLineItemsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -6528,7 +6528,7 @@ type ListSubscriptionCouponRedemptionsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Sort - Sort field. You *really* only want to sort by `updated_at` in ascending
 	// order. In descending order updated records will move behind the cursor and could
@@ -6548,7 +6548,7 @@ func (list *ListSubscriptionCouponRedemptionsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Sort != nil {
@@ -6592,7 +6592,7 @@ type ListUsageParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -6621,7 +6621,7 @@ func (list *ListUsageParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -6793,7 +6793,7 @@ type ListTransactionsParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// Limit - Limit number of records 1-200.
 	Limit *int
@@ -6825,7 +6825,7 @@ func (list *ListTransactionsParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.Limit != nil {
@@ -7777,7 +7777,7 @@ type ListBusinessEntityInvoicesParams struct {
 	//   results correspond to your request.
 	// * Records are returned in an arbitrary order. Since results are all
 	//   returned at once you can sort the records yourself.
-	Ids []string
+	Ids *[]string
 
 	// State - Invoice state.
 	State *string
@@ -7813,7 +7813,7 @@ func (list *ListBusinessEntityInvoicesParams) URLParams() []KeyValue {
 	var options []KeyValue
 
 	if list.Ids != nil {
-		options = append(options, KeyValue{Key: "ids", Value: strings.Join(list.Ids, ",")})
+		options = append(options, KeyValue{Key: "ids", Value: strings.Join(*list.Ids, ",")})
 	}
 
 	if list.State != nil {

--- a/coupon.go
+++ b/coupon.go
@@ -93,16 +93,16 @@ type Coupon struct {
 	InvoiceDescription string `json:"invoice_description,omitempty"`
 
 	// The date and time the coupon will expire and can no longer be redeemed. Time is always 11:59:59, the end-of-day Pacific time.
-	RedeemBy time.Time `json:"redeem_by,omitempty"`
+	RedeemBy *time.Time `json:"redeem_by,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Last updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// The date and time the coupon was expired early or reached its `max_redemptions`.
-	ExpiredAt time.Time `json:"expired_at,omitempty"`
+	ExpiredAt *time.Time `json:"expired_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/coupon_create.go
+++ b/coupon_create.go
@@ -42,7 +42,7 @@ type CouponCreate struct {
 	FreeTrialAmount *int `json:"free_trial_amount,omitempty"`
 
 	// Fixed discount currencies by currency. Required if the coupon type is `fixed`. This parameter should contain the coupon discount values
-	Currencies []CouponPricing `json:"currencies,omitempty"`
+	Currencies *[]CouponPricing `json:"currencies,omitempty"`
 
 	// The coupon is valid for one-time, non-plan charges if true.
 	AppliesToNonPlanCharges *bool `json:"applies_to_non_plan_charges,omitempty"`
@@ -60,13 +60,13 @@ type CouponCreate struct {
 	// List of plan codes to which this coupon applies. Required
 	// if `applies_to_all_plans` is false. Overrides `applies_to_all_plans`
 	// when `applies_to_all_plans` is true.
-	PlanCodes []string `json:"plan_codes,omitempty"`
+	PlanCodes *[]string `json:"plan_codes,omitempty"`
 
 	// List of item codes to which this coupon applies. Sending
 	// `item_codes` is only permitted when `applies_to_all_items` is set to false.
 	// The following values are not permitted when `item_codes` is included:
 	// `free_trial_amount` and `free_trial_unit`.
-	ItemCodes []string `json:"item_codes,omitempty"`
+	ItemCodes *[]string `json:"item_codes,omitempty"`
 
 	// This field does not apply when the discount_type is `free_trial`.
 	// - "single_use" coupons applies to the first invoice only.

--- a/coupon_mini.go
+++ b/coupon_mini.go
@@ -36,7 +36,7 @@ type CouponMini struct {
 	CouponType string `json:"coupon_type,omitempty"`
 
 	// The date and time the coupon was expired early or reached its `max_redemptions`.
-	ExpiredAt time.Time `json:"expired_at,omitempty"`
+	ExpiredAt *time.Time `json:"expired_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/coupon_redemption.go
+++ b/coupon_redemption.go
@@ -37,13 +37,13 @@ type CouponRedemption struct {
 	Discounted float64 `json:"discounted,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Last updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// The date and time the redemption was removed from the account (un-redeemed).
-	RemovedAt time.Time `json:"removed_at,omitempty"`
+	RemovedAt *time.Time `json:"removed_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/coupon_redemption_mini.go
+++ b/coupon_redemption_mini.go
@@ -28,7 +28,7 @@ type CouponRedemptionMini struct {
 	Discounted float64 `json:"discounted,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/credit_payment.go
+++ b/credit_payment.go
@@ -46,13 +46,13 @@ type CreditPayment struct {
 	RefundTransaction Transaction `json:"refund_transaction,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Last updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// Voided at
-	VoidedAt time.Time `json:"voided_at,omitempty"`
+	VoidedAt *time.Time `json:"voided_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/custom_field_definition.go
+++ b/custom_field_definition.go
@@ -40,13 +40,13 @@ type CustomFieldDefinition struct {
 	Tooltip string `json:"tooltip,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Last updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// Definitions are initially soft deleted, and once all the values are removed from the accouts or subscriptions, will be hard deleted an no longer visible.
-	DeletedAt time.Time `json:"deleted_at,omitempty"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/dunning_campaign.go
+++ b/dunning_campaign.go
@@ -34,13 +34,13 @@ type DunningCampaign struct {
 	DunningCycles []DunningCycle `json:"dunning_cycles,omitempty"`
 
 	// When the current campaign was created in Recurly.
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// When the current campaign was updated in Recurly.
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// When the current campaign was deleted in Recurly.
-	DeletedAt time.Time `json:"deleted_at,omitempty"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/dunning_campaigns_bulk_update.go
+++ b/dunning_campaigns_bulk_update.go
@@ -9,8 +9,8 @@ import ()
 type DunningCampaignsBulkUpdate struct {
 
 	// List of `plan_codes` associated with the Plans for which the dunning campaign should be updated. Required unless `plan_ids` is present.
-	PlanCodes []string `json:"plan_codes,omitempty"`
+	PlanCodes *[]string `json:"plan_codes,omitempty"`
 
 	// List of `plan_ids` associated with the Plans for which the dunning campaign should be updated. Required unless `plan_codes` is present.
-	PlanIds []string `json:"plan_ids,omitempty"`
+	PlanIds *[]string `json:"plan_ids,omitempty"`
 }

--- a/dunning_cycle.go
+++ b/dunning_cycle.go
@@ -44,10 +44,10 @@ type DunningCycle struct {
 	Version int `json:"version,omitempty"`
 
 	// When the current settings were created in Recurly.
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// When the current settings were updated in Recurly.
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/entitlement.go
+++ b/entitlement.go
@@ -22,10 +22,10 @@ type Entitlement struct {
 	GrantedBy []GrantedBy `json:"granted_by,omitempty"`
 
 	// Time object was created.
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Time the object was last updated
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/external_account.go
+++ b/external_account.go
@@ -25,10 +25,10 @@ type ExternalAccount struct {
 	ExternalConnectionType string `json:"external_connection_type,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Last updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/external_charge.go
+++ b/external_charge.go
@@ -36,10 +36,10 @@ type ExternalCharge struct {
 	ExternalProductReference ExternalProductReferenceMini `json:"external_product_reference,omitempty"`
 
 	// When the external charge was created in Recurly.
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// When the external charge was updated in Recurly.
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/external_invoice.go
+++ b/external_invoice.go
@@ -39,13 +39,13 @@ type ExternalInvoice struct {
 	LineItems []ExternalCharge `json:"line_items,omitempty"`
 
 	// When the invoice was created in the external platform.
-	PurchasedAt time.Time `json:"purchased_at,omitempty"`
+	PurchasedAt *time.Time `json:"purchased_at,omitempty"`
 
 	// When the external invoice was created in Recurly.
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// When the external invoice was updated in Recurly.
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/external_invoice_create.go
+++ b/external_invoice_create.go
@@ -23,7 +23,7 @@ type ExternalInvoiceCreate struct {
 	// When the invoice was created in the external platform.
 	PurchasedAt *time.Time `json:"purchased_at,omitempty"`
 
-	LineItems []ExternalChargeCreate `json:"line_items,omitempty"`
+	LineItems *[]ExternalChargeCreate `json:"line_items,omitempty"`
 
 	ExternalPaymentPhase *ExternalPaymentPhaseBase `json:"external_payment_phase,omitempty"`
 

--- a/external_payment_phase.go
+++ b/external_payment_phase.go
@@ -20,10 +20,10 @@ type ExternalPaymentPhase struct {
 	Object string `json:"object,omitempty"`
 
 	// Started At
-	StartedAt time.Time `json:"started_at,omitempty"`
+	StartedAt *time.Time `json:"started_at,omitempty"`
 
 	// Ends At
-	EndsAt time.Time `json:"ends_at,omitempty"`
+	EndsAt *time.Time `json:"ends_at,omitempty"`
 
 	// Starting Billing Period Index
 	StartingBillingPeriodIndex int `json:"starting_billing_period_index,omitempty"`
@@ -50,10 +50,10 @@ type ExternalPaymentPhase struct {
 	Currency string `json:"currency,omitempty"`
 
 	// When the external subscription was created in Recurly.
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// When the external subscription was updated in Recurly.
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/external_product.go
+++ b/external_product.go
@@ -26,10 +26,10 @@ type ExternalProduct struct {
 	Plan PlanMini `json:"plan,omitempty"`
 
 	// When the external product was created in Recurly.
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// When the external product was updated in Recurly.
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// List of external product references of the external product.
 	ExternalProductReferences []ExternalProductReferenceMini `json:"external_product_references,omitempty"`

--- a/external_product_create.go
+++ b/external_product_create.go
@@ -15,5 +15,5 @@ type ExternalProductCreate struct {
 	PlanId *string `json:"plan_id,omitempty"`
 
 	// List of external product references of the external product.
-	ExternalProductReferences []ExternalProductReferenceBase `json:"external_product_references,omitempty"`
+	ExternalProductReferences *[]ExternalProductReferenceBase `json:"external_product_references,omitempty"`
 }

--- a/external_product_reference_mini.go
+++ b/external_product_reference_mini.go
@@ -26,10 +26,10 @@ type ExternalProductReferenceMini struct {
 	ExternalConnectionType string `json:"external_connection_type,omitempty"`
 
 	// When the external product was created in Recurly.
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// When the external product was updated in Recurly.
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/external_subscription.go
+++ b/external_subscription.go
@@ -35,7 +35,7 @@ type ExternalSubscription struct {
 	Uuid string `json:"uuid,omitempty"`
 
 	// When a new billing event occurred on the external subscription in conjunction with a recent billing period, reactivation or upgrade/downgrade.
-	LastPurchased time.Time `json:"last_purchased,omitempty"`
+	LastPurchased *time.Time `json:"last_purchased,omitempty"`
 
 	// An indication of whether or not the external subscription will auto-renew at the expiration date.
 	AutoRenew bool `json:"auto_renew,omitempty"`
@@ -53,19 +53,19 @@ type ExternalSubscription struct {
 	State string `json:"state,omitempty"`
 
 	// When the external subscription was activated in the external platform.
-	ActivatedAt time.Time `json:"activated_at,omitempty"`
+	ActivatedAt *time.Time `json:"activated_at,omitempty"`
 
 	// When the external subscription was canceled in the external platform.
-	CanceledAt time.Time `json:"canceled_at,omitempty"`
+	CanceledAt *time.Time `json:"canceled_at,omitempty"`
 
 	// When the external subscription expires in the external platform.
-	ExpiresAt time.Time `json:"expires_at,omitempty"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 
 	// When the external subscription trial period started in the external platform.
-	TrialStartedAt time.Time `json:"trial_started_at,omitempty"`
+	TrialStartedAt *time.Time `json:"trial_started_at,omitempty"`
 
 	// When the external subscription trial period ends in the external platform.
-	TrialEndsAt time.Time `json:"trial_ends_at,omitempty"`
+	TrialEndsAt *time.Time `json:"trial_ends_at,omitempty"`
 
 	// An indication of whether or not the external subscription was purchased in a sandbox environment.
 	Test bool `json:"test,omitempty"`
@@ -74,10 +74,10 @@ type ExternalSubscription struct {
 	Imported bool `json:"imported,omitempty"`
 
 	// When the external subscription was created in Recurly.
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// When the external subscription was updated in Recurly.
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/general_ledger_account.go
+++ b/general_ledger_account.go
@@ -32,10 +32,10 @@ type GeneralLedgerAccount struct {
 	AccountType string `json:"account_type,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Last updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/gift_card.go
+++ b/gift_card.go
@@ -65,19 +65,19 @@ type GiftCard struct {
 	RevenueGlAccountId string `json:"revenue_gl_account_id,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Last updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// When the gift card was sent to the recipient by Recurly via email, if method was email and the "Gift Card Delivery" email template was enabled. This will be empty for post delivery or email delivery where the email template was disabled.
-	DeliveredAt time.Time `json:"delivered_at,omitempty"`
+	DeliveredAt *time.Time `json:"delivered_at,omitempty"`
 
 	// When the gift card was redeemed by the recipient.
-	RedeemedAt time.Time `json:"redeemed_at,omitempty"`
+	RedeemedAt *time.Time `json:"redeemed_at,omitempty"`
 
 	// When the gift card was canceled.
-	CanceledAt time.Time `json:"canceled_at,omitempty"`
+	CanceledAt *time.Time `json:"canceled_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/gift_card_delivery.go
+++ b/gift_card_delivery.go
@@ -20,7 +20,7 @@ type GiftCardDelivery struct {
 	EmailAddress string `json:"email_address,omitempty"`
 
 	// When the gift card should be delivered to the recipient. If null, the gift card will be delivered immediately. If a datetime is provided, the delivery will be in an hourly window, rounding down. For example, 6:23 pm will be in the 6:00 pm hourly batch.
-	DeliverAt time.Time `json:"deliver_at,omitempty"`
+	DeliverAt *time.Time `json:"deliver_at,omitempty"`
 
 	// The first name of the recipient.
 	FirstName string `json:"first_name,omitempty"`

--- a/invoice.go
+++ b/invoice.go
@@ -134,16 +134,16 @@ type Invoice struct {
 	CreditPayments []CreditPayment `json:"credit_payments,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Last updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// Date invoice is due. This is the date the net terms are reached.
-	DueAt time.Time `json:"due_at,omitempty"`
+	DueAt *time.Time `json:"due_at,omitempty"`
 
 	// Date invoice was marked paid or failed.
-	ClosedAt time.Time `json:"closed_at,omitempty"`
+	ClosedAt *time.Time `json:"closed_at,omitempty"`
 
 	// Unique ID to identify the dunning campaign used when dunning the invoice. For sites without multiple dunning campaigns enabled, this will always be the default dunning campaign.
 	DunningCampaignId string `json:"dunning_campaign_id,omitempty"`

--- a/invoice_refund.go
+++ b/invoice_refund.go
@@ -19,7 +19,7 @@ type InvoiceRefund struct {
 	Percentage *int `json:"percentage,omitempty"`
 
 	// The line items to be refunded. This is required when `type=line_items`.
-	LineItems []LineItemRefund `json:"line_items,omitempty"`
+	LineItems *[]LineItemRefund `json:"line_items,omitempty"`
 
 	// Indicates how the invoice should be refunded when both a credit and transaction are present on the invoice:
 	// - `transaction_first` – Refunds the transaction first, then any amount is issued as credit back to the account. Default value when Credit Invoices feature is enabled.

--- a/invoice_template.go
+++ b/invoice_template.go
@@ -25,10 +25,10 @@ type InvoiceTemplate struct {
 	Description string `json:"description,omitempty"`
 
 	// When the invoice template was created in Recurly.
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// When the invoice template was updated in Recurly.
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/item.go
+++ b/item.go
@@ -74,13 +74,13 @@ type Item struct {
 	Currencies []Pricing `json:"currencies,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Last updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// Deleted at
-	DeletedAt time.Time `json:"deleted_at,omitempty"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/item_create.go
+++ b/item_create.go
@@ -54,8 +54,8 @@ type ItemCreate struct {
 	TaxExempt *bool `json:"tax_exempt,omitempty"`
 
 	// The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-	CustomFields []CustomFieldCreate `json:"custom_fields,omitempty"`
+	CustomFields *[]CustomFieldCreate `json:"custom_fields,omitempty"`
 
 	// Item Pricing
-	Currencies []PricingCreate `json:"currencies,omitempty"`
+	Currencies *[]PricingCreate `json:"currencies,omitempty"`
 }

--- a/item_update.go
+++ b/item_update.go
@@ -54,8 +54,8 @@ type ItemUpdate struct {
 	TaxExempt *bool `json:"tax_exempt,omitempty"`
 
 	// The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-	CustomFields []CustomFieldCreate `json:"custom_fields,omitempty"`
+	CustomFields *[]CustomFieldCreate `json:"custom_fields,omitempty"`
 
 	// Item Pricing
-	Currencies []PricingCreate `json:"currencies,omitempty"`
+	Currencies *[]PricingCreate `json:"currencies,omitempty"`
 }

--- a/line_item.go
+++ b/line_item.go
@@ -182,19 +182,19 @@ type LineItem struct {
 	ShippingAddress ShippingAddress `json:"shipping_address,omitempty"`
 
 	// If an end date is present, this is value indicates the beginning of a billing time range. If no end date is present it indicates billing for a specific date.
-	StartDate time.Time `json:"start_date,omitempty"`
+	StartDate *time.Time `json:"start_date,omitempty"`
 
 	// If this date is provided, it indicates the end of a time range.
-	EndDate time.Time `json:"end_date,omitempty"`
+	EndDate *time.Time `json:"end_date,omitempty"`
 
 	// The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
 	CustomFields []CustomField `json:"custom_fields,omitempty"`
 
 	// When the line item was created.
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// When the line item was last changed.
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/line_item_create.go
+++ b/line_item_create.go
@@ -80,7 +80,7 @@ type LineItemCreate struct {
 	Origin *string `json:"origin,omitempty"`
 
 	// The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-	CustomFields []CustomFieldCreate `json:"custom_fields,omitempty"`
+	CustomFields *[]CustomFieldCreate `json:"custom_fields,omitempty"`
 
 	// If an end date is present, this is value indicates the beginning of a billing time range. If no end date is present it indicates billing for a specific date. Defaults to the current date-time.
 	StartDate *time.Time `json:"start_date,omitempty"`

--- a/measured_unit.go
+++ b/measured_unit.go
@@ -32,13 +32,13 @@ type MeasuredUnit struct {
 	Description string `json:"description,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Last updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// Deleted at
-	DeletedAt time.Time `json:"deleted_at,omitempty"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -10830,7 +10830,7 @@ paths:
           }
       - lang: Go
         source: "planReq := &recurly.PlanCreate{\n\tCode: &planCode,\n\tName: recurly.String(\"Monthly
-          Coffee Subscription\"),\n\tCurrencies: []recurly.PlanPricingCreate{\n\t\t{\n\t\t\tCurrency:
+          Coffee Subscription\"),\n\tCurrencies: &[]recurly.PlanPricingCreate{\n\t\t{\n\t\t\tCurrency:
           \  recurly.String(\"USD\"),\n\t\t\tUnitAmount: recurly.Float(10000),\n\t\t},\n\t},\n}\n\nplan,
           err := client.CreatePlan(planReq)\nif e, ok := err.(*recurly.Error); ok
           {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
@@ -11499,7 +11499,7 @@ paths:
           }
       - lang: Go
         source: "addOnReq := &recurly.AddOnCreate{\n\tCode: &addOnCode,\n\tName: recurly.String(\"Fresh
-          beans shipped monthly\"),\n\tCurrencies: []recurly.AddOnPricingCreate{\n\t\t{\n\t\t\tCurrency:
+          beans shipped monthly\"),\n\tCurrencies: &[]recurly.AddOnPricingCreate{\n\t\t{\n\t\t\tCurrency:
           \  recurly.String(\"USD\"),\n\t\t\tUnitAmount: recurly.Float(10),\n\t\t},\n\t},\n}\n\nplanAddOn,
           err := client.CreatePlanAddOn(planID, addOnReq)\nif e, ok := err.(*recurly.Error);
           ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
@@ -15274,7 +15274,7 @@ paths:
       - lang: Go
         source: "purchaseReq := &recurly.PurchaseCreate{\n\tCurrency: recurly.String(\"USD\"),\n\tAccount:
           &recurly.AccountPurchase{\n\t\tCode: recurly.String(accountCode),\n\t},\n\tSubscriptions:
-          []recurly.SubscriptionPurchase{\n\t\t{\n\t\t\tPlanCode:     recurly.String(planCode),\n\t\t\tNextBillDate:
+          &[]recurly.SubscriptionPurchase{\n\t\t{\n\t\t\tPlanCode:     recurly.String(planCode),\n\t\t\tNextBillDate:
           recurly.Time(time.Date(2078, time.November, 10, 23, 0, 0, 0, time.UTC)),\n\t\t},\n\t},\n\tShipping:
           &recurly.ShippingPurchase{\n\t\tAddressId: recurly.String(shippingAddressID),\n\t},\n}\n\ncollection,
           err := client.CreatePurchase(purchaseReq)\nif e, ok := err.(*recurly.Error);
@@ -15508,7 +15508,7 @@ paths:
       - lang: Go
         source: "purchaseReq := &recurly.PurchaseCreate{\n\tCurrency: recurly.String(\"USD\"),\n\tAccount:
           &recurly.AccountPurchase{\n\t\tCode: recurly.String(account.Code),\n\t},\n\tSubscriptions:
-          []recurly.SubscriptionPurchase{\n\t\t{\n\t\t\tPlanCode:     recurly.String(plan.Code),\n\t\t\tNextBillDate:
+          &[]recurly.SubscriptionPurchase{\n\t\t{\n\t\t\tPlanCode:     recurly.String(plan.Code),\n\t\t\tNextBillDate:
           recurly.Time(time.Date(2078, time.November, 10, 23, 0, 0, 0, time.UTC)),\n\t\t},\n\t},\n\tShipping:
           &recurly.ShippingPurchase{\n\t\tAddressId: recurly.String(shippingAddressID),\n\t},\n}\ncollection,
           err := client.PreviewPurchase(purchaseReq)\nif e, ok := err.(*recurly.Error);
@@ -15776,12 +15776,12 @@ paths:
               var_dump($e);
           }
       - lang: Go
-        source: "purchaseReq := &recurly.PurchaseCreate{\n\tCurrency: recurly.String(\"EUR\"),\n\tAccount:
+        source: "purchaseReq := &recurly.PurchaseCreate{\n\tCurrency: recurly.String(\"USD\"),\n\tAccount:
           &recurly.AccountPurchase{\n\t\tCode:  recurly.String(accountCode),\n\t\tEmail:
           recurly.String(\"benjamin@example.com\"),\n\t\tBillingInfo: &recurly.BillingInfoCreate{\n\t\t\tFirstName:
           \               recurly.String(\"Benjamin\"),\n\t\t\tLastName:                 recurly.String(\"Du
           Monde\"),\n\t\t\tOnlineBankingPaymentType: recurly.String(\"ideal\"),\n\t\t},\n\t},\n\tLineItems:
-          []recurly.LineItemCreate{\n\t\t{\n\t\t\tCurrency:   recurly.String(\"EUR\"),\n\t\t\tUnitAmount:
+          &[]recurly.LineItemCreate{\n\t\t{\n\t\t\tCurrency:   recurly.String(\"USD\"),\n\t\t\tUnitAmount:
           recurly.Float(1000),\n\t\t\tType:       recurly.String(\"charge\"),\n\t\t},\n\t},\n}\ncollection,
           err := client.CreatePendingPurchase(purchaseReq)\nif e, ok := err.(*recurly.Error);
           ok {\n\tif e.Type == recurly.ErrorTypeValidation {\n\t\tfmt.Printf(\"Failed
@@ -24152,7 +24152,8 @@ components:
           description: Represents the billing cycle where a ramp interval starts.
           default: 1
         unit_amount:
-          type: integer
+          type: number
+          format: float
           description: Represents the price for the ramp interval.
     SubscriptionRampIntervalResponse:
       type: object

--- a/percentage_tiers_by_currency_create.go
+++ b/percentage_tiers_by_currency_create.go
@@ -12,5 +12,5 @@ type PercentageTiersByCurrencyCreate struct {
 	Currency *string `json:"currency,omitempty"`
 
 	// Tiers
-	Tiers []PercentageTierCreate `json:"tiers,omitempty"`
+	Tiers *[]PercentageTierCreate `json:"tiers,omitempty"`
 }

--- a/performance_obligation.go
+++ b/performance_obligation.go
@@ -22,10 +22,10 @@ type PerformanceObligation struct {
 	Name string `json:"name,omitempty"`
 
 	// Created At
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Last updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/plan.go
+++ b/plan.go
@@ -105,13 +105,13 @@ type Plan struct {
 	DunningCampaignId string `json:"dunning_campaign_id,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Last updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// Deleted at
-	DeletedAt time.Time `json:"deleted_at,omitempty"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/plan_create.go
+++ b/plan_create.go
@@ -47,10 +47,10 @@ type PlanCreate struct {
 	PricingModel *string `json:"pricing_model,omitempty"`
 
 	// Ramp Intervals
-	RampIntervals []PlanRampIntervalCreate `json:"ramp_intervals,omitempty"`
+	RampIntervals *[]PlanRampIntervalCreate `json:"ramp_intervals,omitempty"`
 
 	// The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-	CustomFields []CustomFieldCreate `json:"custom_fields,omitempty"`
+	CustomFields *[]CustomFieldCreate `json:"custom_fields,omitempty"`
 
 	// Revenue schedule type
 	RevenueScheduleType *string `json:"revenue_schedule_type,omitempty"`
@@ -107,13 +107,13 @@ type PlanCreate struct {
 	VertexTransactionType *string `json:"vertex_transaction_type,omitempty"`
 
 	// Pricing
-	Currencies []PlanPricingCreate `json:"currencies,omitempty"`
+	Currencies *[]PlanPricingCreate `json:"currencies,omitempty"`
 
 	// Hosted pages settings
 	HostedPages *PlanHostedPagesCreate `json:"hosted_pages,omitempty"`
 
 	// Add Ons
-	AddOns []AddOnCreate `json:"add_ons,omitempty"`
+	AddOns *[]AddOnCreate `json:"add_ons,omitempty"`
 
 	// Used to determine whether items can be assigned as add-ons to individual subscriptions.
 	// If `true`, items can be assigned as add-ons to individual subscription add-ons.

--- a/plan_ramp_interval_create.go
+++ b/plan_ramp_interval_create.go
@@ -12,5 +12,5 @@ type PlanRampIntervalCreate struct {
 	StartingBillingCycle *int `json:"starting_billing_cycle,omitempty"`
 
 	// Represents the price for the ramp interval.
-	Currencies []PlanRampPricingCreate `json:"currencies,omitempty"`
+	Currencies *[]PlanRampPricingCreate `json:"currencies,omitempty"`
 }

--- a/plan_update.go
+++ b/plan_update.go
@@ -39,10 +39,10 @@ type PlanUpdate struct {
 	AutoRenew *bool `json:"auto_renew,omitempty"`
 
 	// Ramp Intervals
-	RampIntervals []PlanRampIntervalCreate `json:"ramp_intervals,omitempty"`
+	RampIntervals *[]PlanRampIntervalCreate `json:"ramp_intervals,omitempty"`
 
 	// The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-	CustomFields []CustomFieldCreate `json:"custom_fields,omitempty"`
+	CustomFields *[]CustomFieldCreate `json:"custom_fields,omitempty"`
 
 	// Revenue schedule type
 	RevenueScheduleType *string `json:"revenue_schedule_type,omitempty"`
@@ -99,7 +99,7 @@ type PlanUpdate struct {
 	VertexTransactionType *string `json:"vertex_transaction_type,omitempty"`
 
 	// Optional when the pricing model is 'ramp'.
-	Currencies []PlanPricingCreate `json:"currencies,omitempty"`
+	Currencies *[]PlanPricingCreate `json:"currencies,omitempty"`
 
 	// Hosted pages settings
 	HostedPages *PlanHostedPagesCreate `json:"hosted_pages,omitempty"`

--- a/purchase_create.go
+++ b/purchase_create.go
@@ -69,13 +69,13 @@ type PurchaseCreate struct {
 	Shipping *ShippingPurchase `json:"shipping,omitempty"`
 
 	// A list of one time charges or credits to be created with the purchase.
-	LineItems []LineItemCreate `json:"line_items,omitempty"`
+	LineItems *[]LineItemCreate `json:"line_items,omitempty"`
 
 	// A list of subscriptions to be created with the purchase.
-	Subscriptions []SubscriptionPurchase `json:"subscriptions,omitempty"`
+	Subscriptions *[]SubscriptionPurchase `json:"subscriptions,omitempty"`
 
 	// A list of coupon_codes to be redeemed on the subscription or account during the purchase.
-	CouponCodes []string `json:"coupon_codes,omitempty"`
+	CouponCodes *[]string `json:"coupon_codes,omitempty"`
 
 	// A gift card redemption code to be redeemed on the purchase invoice.
 	GiftCardRedemptionCode *string `json:"gift_card_redemption_code,omitempty"`

--- a/shipping_address.go
+++ b/shipping_address.go
@@ -55,10 +55,10 @@ type ShippingAddress struct {
 	GeoCode string `json:"geo_code,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/shipping_method.go
+++ b/shipping_method.go
@@ -56,13 +56,13 @@ type ShippingMethod struct {
 	PerformanceObligationId string `json:"performance_obligation_id,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Last updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// Deleted at
-	DeletedAt time.Time `json:"deleted_at,omitempty"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/shipping_purchase.go
+++ b/shipping_purchase.go
@@ -14,5 +14,5 @@ type ShippingPurchase struct {
 	Address *ShippingAddressCreate `json:"address,omitempty"`
 
 	// A list of shipping fees to be created as charges with the purchase.
-	Fees []ShippingFeeCreate `json:"fees,omitempty"`
+	Fees *[]ShippingFeeCreate `json:"fees,omitempty"`
 }

--- a/site.go
+++ b/site.go
@@ -35,13 +35,13 @@ type Site struct {
 	Features []string `json:"features,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// Deleted at
-	DeletedAt time.Time `json:"deleted_at,omitempty"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/subscription.go
+++ b/subscription.go
@@ -41,22 +41,22 @@ type Subscription struct {
 	PendingChange SubscriptionChange `json:"pending_change,omitempty"`
 
 	// Current billing period started at
-	CurrentPeriodStartedAt time.Time `json:"current_period_started_at,omitempty"`
+	CurrentPeriodStartedAt *time.Time `json:"current_period_started_at,omitempty"`
 
 	// Current billing period ends at
-	CurrentPeriodEndsAt time.Time `json:"current_period_ends_at,omitempty"`
+	CurrentPeriodEndsAt *time.Time `json:"current_period_ends_at,omitempty"`
 
 	// The start date of the term when the first billing period starts. The subscription term is the length of time that a customer will be committed to a subscription. A term can span multiple billing periods.
-	CurrentTermStartedAt time.Time `json:"current_term_started_at,omitempty"`
+	CurrentTermStartedAt *time.Time `json:"current_term_started_at,omitempty"`
 
 	// When the term ends. This is calculated by a plan's interval and `total_billing_cycles` in a term. Subscription changes with a `timeframe=renewal` will be applied on this date.
-	CurrentTermEndsAt time.Time `json:"current_term_ends_at,omitempty"`
+	CurrentTermEndsAt *time.Time `json:"current_term_ends_at,omitempty"`
 
 	// Trial period started at
-	TrialStartedAt time.Time `json:"trial_started_at,omitempty"`
+	TrialStartedAt *time.Time `json:"trial_started_at,omitempty"`
 
 	// Trial period ends at
-	TrialEndsAt time.Time `json:"trial_ends_at,omitempty"`
+	TrialEndsAt *time.Time `json:"trial_ends_at,omitempty"`
 
 	// The remaining billing cycles in the current term.
 	RemainingBillingCycles int `json:"remaining_billing_cycles,omitempty"`
@@ -74,7 +74,7 @@ type Subscription struct {
 	RampIntervals []SubscriptionRampIntervalResponse `json:"ramp_intervals,omitempty"`
 
 	// Null unless subscription is paused or will pause at the end of the current billing period.
-	PausedAt time.Time `json:"paused_at,omitempty"`
+	PausedAt *time.Time `json:"paused_at,omitempty"`
 
 	// Null unless subscription is paused or will pause at the end of the current billing period.
 	RemainingPauseCycles int `json:"remaining_pause_cycles,omitempty"`
@@ -151,22 +151,22 @@ type Subscription struct {
 	CustomFields []CustomField `json:"custom_fields,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Last updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// Activated at
-	ActivatedAt time.Time `json:"activated_at,omitempty"`
+	ActivatedAt *time.Time `json:"activated_at,omitempty"`
 
 	// Canceled at
-	CanceledAt time.Time `json:"canceled_at,omitempty"`
+	CanceledAt *time.Time `json:"canceled_at,omitempty"`
 
 	// Expires at
-	ExpiresAt time.Time `json:"expires_at,omitempty"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 
 	// Recurring subscriptions paid with ACH will have this attribute set. This timestamp is used for alerting customers to reauthorize in 3 years in accordance with NACHA rules. If a subscription becomes inactive or the billing info is no longer a bank account, this timestamp is cleared.
-	BankAccountAuthorizedAt time.Time `json:"bank_account_authorized_at,omitempty"`
+	BankAccountAuthorizedAt *time.Time `json:"bank_account_authorized_at,omitempty"`
 
 	// If present, this subscription's transactions will use the payment gateway with this code.
 	GatewayCode string `json:"gateway_code,omitempty"`
@@ -184,7 +184,7 @@ type Subscription struct {
 	StartedWithGift bool `json:"started_with_gift,omitempty"`
 
 	// When the subscription was converted from a gift card.
-	ConvertedAt time.Time `json:"converted_at,omitempty"`
+	ConvertedAt *time.Time `json:"converted_at,omitempty"`
 
 	// Action result params to be used in Recurly-JS to complete a payment when using asynchronous payment methods, e.g., Boleto, iDEAL and Sofort.
 	ActionResult map[string]interface{} `json:"action_result,omitempty"`

--- a/subscription_add_on.go
+++ b/subscription_add_on.go
@@ -71,13 +71,13 @@ type SubscriptionAddOn struct {
 	UsagePercentage float64 `json:"usage_percentage,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// Expired at
-	ExpiredAt time.Time `json:"expired_at,omitempty"`
+	ExpiredAt *time.Time `json:"expired_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/subscription_add_on_create.go
+++ b/subscription_add_on_create.go
@@ -36,13 +36,13 @@ type SubscriptionAddOnCreate struct {
 	// There must be one tier without an `ending_quantity` value which represents the final tier.
 	// See our [Guide](https://recurly.com/developers/guides/item-addon-guide.html)
 	// for an overview of how to configure quantity-based pricing models.
-	Tiers []SubscriptionAddOnTierCreate `json:"tiers,omitempty"`
+	Tiers *[]SubscriptionAddOnTierCreate `json:"tiers,omitempty"`
 
 	// If percentage tiers are provided in the request, all existing percentage tiers on the Subscription Add-on will be
 	// removed and replaced by the percentage tiers in the request. There must be one tier without ending_amount value
 	// which represents the final tier. Use only if add_on.tier_type is tiered or volume and add_on.usage_type is
 	// percentage. This feature is currently in development and requires approval and enablement, please contact support.
-	PercentageTiers []SubscriptionAddOnPercentageTierCreate `json:"percentage_tiers,omitempty"`
+	PercentageTiers *[]SubscriptionAddOnPercentageTierCreate `json:"percentage_tiers,omitempty"`
 
 	// The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0. Required if `add_on_type` is usage and `usage_type` is percentage. Must be omitted otherwise. `usage_percentage` does not support tiers. See our [Guide](https://recurly.com/developers/guides/usage-based-billing-guide.html) for an overview of how to configure usage add-ons.
 	UsagePercentage *float64 `json:"usage_percentage,omitempty"`

--- a/subscription_add_on_update.go
+++ b/subscription_add_on_update.go
@@ -41,13 +41,13 @@ type SubscriptionAddOnUpdate struct {
 	// If the plan add-on's `tier_type` is `flat`, then `tiers` must be absent. The `tiers` object
 	// must include one to many tiers with `ending_quantity` and `unit_amount`.
 	// There must be one tier without an `ending_quantity` value which represents the final tier.
-	Tiers []SubscriptionAddOnTierCreate `json:"tiers,omitempty"`
+	Tiers *[]SubscriptionAddOnTierCreate `json:"tiers,omitempty"`
 
 	// If percentage tiers are provided in the request, all existing percentage tiers on the Subscription Add-on will be
 	// removed and replaced by the percentage tiers in the request. Use only if add_on.tier_type is tiered or volume and
 	// add_on.usage_type is percentage. There must be one tier without an `ending_amount` value which represents the
 	// final tier. This feature is currently in development and requires approval and enablement, please contact support.
-	PercentageTiers []SubscriptionAddOnPercentageTierCreate `json:"percentage_tiers,omitempty"`
+	PercentageTiers *[]SubscriptionAddOnPercentageTierCreate `json:"percentage_tiers,omitempty"`
 
 	// The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0. Required if add_on_type is usage and usage_type is percentage.
 	UsagePercentage *float64 `json:"usage_percentage,omitempty"`

--- a/subscription_change.go
+++ b/subscription_change.go
@@ -41,7 +41,7 @@ type SubscriptionChange struct {
 	Shipping SubscriptionShipping `json:"shipping,omitempty"`
 
 	// Activated at
-	ActivateAt time.Time `json:"activate_at,omitempty"`
+	ActivateAt *time.Time `json:"activate_at,omitempty"`
 
 	// Returns `true` if the subscription change is activated.
 	Activated bool `json:"activated,omitempty"`
@@ -59,13 +59,13 @@ type SubscriptionChange struct {
 	CustomFields []CustomField `json:"custom_fields,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// Deleted at
-	DeletedAt time.Time `json:"deleted_at,omitempty"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
 
 	// Accept nested attributes for three_d_secure_action_result_token_id
 	BillingInfo SubscriptionChangeBillingInfo `json:"billing_info,omitempty"`

--- a/subscription_change_create.go
+++ b/subscription_change_create.go
@@ -36,7 +36,7 @@ type SubscriptionChangeCreate struct {
 	Shipping *SubscriptionChangeShippingCreate `json:"shipping,omitempty"`
 
 	// A list of coupon_codes to be redeemed on the subscription during the change. Only allowed if timeframe is now and you change something about the subscription that creates an invoice.
-	CouponCodes []string `json:"coupon_codes,omitempty"`
+	CouponCodes *[]string `json:"coupon_codes,omitempty"`
 
 	// If you provide a value for this field it will replace any
 	// existing add-ons. So, when adding or modifying an add-on, you need to
@@ -53,7 +53,7 @@ type SubscriptionChangeCreate struct {
 	//   current values of the plan add-on
 	// - Attributes passed in as part of the request will override either of the
 	//   above scenarios
-	AddOns []SubscriptionAddOnUpdate `json:"add_ons,omitempty"`
+	AddOns *[]SubscriptionAddOnUpdate `json:"add_ons,omitempty"`
 
 	// Collection method
 	CollectionMethod *string `json:"collection_method,omitempty"`
@@ -62,7 +62,7 @@ type SubscriptionChangeCreate struct {
 	RevenueScheduleType *string `json:"revenue_schedule_type,omitempty"`
 
 	// The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-	CustomFields []CustomFieldCreate `json:"custom_fields,omitempty"`
+	CustomFields *[]CustomFieldCreate `json:"custom_fields,omitempty"`
 
 	// For manual invoicing, this identifies the PO number associated with the subscription.
 	PoNumber *string `json:"po_number,omitempty"`
@@ -86,7 +86,7 @@ type SubscriptionChangeCreate struct {
 	BillingInfo *SubscriptionChangeBillingInfoCreate `json:"billing_info,omitempty"`
 
 	// The new set of ramp intervals for the subscription.
-	RampIntervals []SubscriptionRampInterval `json:"ramp_intervals,omitempty"`
+	RampIntervals *[]SubscriptionRampInterval `json:"ramp_intervals,omitempty"`
 
 	// Allows you to control how any resulting charges and credits will be calculated and prorated.
 	ProrationSettings *ProrationSettings `json:"proration_settings,omitempty"`

--- a/subscription_create.go
+++ b/subscription_create.go
@@ -46,13 +46,13 @@ type SubscriptionCreate struct {
 	Quantity *int `json:"quantity,omitempty"`
 
 	// Add-ons
-	AddOns []SubscriptionAddOnCreate `json:"add_ons,omitempty"`
+	AddOns *[]SubscriptionAddOnCreate `json:"add_ons,omitempty"`
 
 	// A list of coupon_codes to be redeemed on the subscription or account during the purchase.
-	CouponCodes []string `json:"coupon_codes,omitempty"`
+	CouponCodes *[]string `json:"coupon_codes,omitempty"`
 
 	// The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-	CustomFields []CustomFieldCreate `json:"custom_fields,omitempty"`
+	CustomFields *[]CustomFieldCreate `json:"custom_fields,omitempty"`
 
 	// If set, overrides the default trial behavior for the subscription. When the current date time or a past date time is provided the subscription will begin with no trial phase (overriding any plan default trial). When a future date time is provided the subscription will begin with a trial phase ending at the specified date time.
 	TrialEndsAt *time.Time `json:"trial_ends_at,omitempty"`
@@ -73,7 +73,7 @@ type SubscriptionCreate struct {
 	AutoRenew *bool `json:"auto_renew,omitempty"`
 
 	// The new set of ramp intervals for the subscription.
-	RampIntervals []SubscriptionRampInterval `json:"ramp_intervals,omitempty"`
+	RampIntervals *[]SubscriptionRampInterval `json:"ramp_intervals,omitempty"`
 
 	// Revenue schedule type
 	RevenueScheduleType *string `json:"revenue_schedule_type,omitempty"`

--- a/subscription_purchase.go
+++ b/subscription_purchase.go
@@ -26,10 +26,10 @@ type SubscriptionPurchase struct {
 	Quantity *int `json:"quantity,omitempty"`
 
 	// Add-ons
-	AddOns []SubscriptionAddOnCreate `json:"add_ons,omitempty"`
+	AddOns *[]SubscriptionAddOnCreate `json:"add_ons,omitempty"`
 
 	// The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-	CustomFields []CustomFieldCreate `json:"custom_fields,omitempty"`
+	CustomFields *[]CustomFieldCreate `json:"custom_fields,omitempty"`
 
 	// Create a shipping address on the account and assign it to the subscription.
 	Shipping *SubscriptionShippingPurchase `json:"shipping,omitempty"`
@@ -56,7 +56,7 @@ type SubscriptionPurchase struct {
 	RevenueScheduleType *string `json:"revenue_schedule_type,omitempty"`
 
 	// The new set of ramp intervals for the subscription.
-	RampIntervals []SubscriptionRampInterval `json:"ramp_intervals,omitempty"`
+	RampIntervals *[]SubscriptionRampInterval `json:"ramp_intervals,omitempty"`
 
 	// Optional field to be used only when needing to bypass the 60 second limit on creating subscriptions. Should only be used when creating subscriptions in bulk from the API.
 	Bulk *bool `json:"bulk,omitempty"`

--- a/subscription_ramp_interval.go
+++ b/subscription_ramp_interval.go
@@ -12,5 +12,5 @@ type SubscriptionRampInterval struct {
 	StartingBillingCycle *int `json:"starting_billing_cycle,omitempty"`
 
 	// Represents the price for the ramp interval.
-	UnitAmount *int `json:"unit_amount,omitempty"`
+	UnitAmount *float64 `json:"unit_amount,omitempty"`
 }

--- a/subscription_ramp_interval_response.go
+++ b/subscription_ramp_interval_response.go
@@ -20,10 +20,10 @@ type SubscriptionRampIntervalResponse struct {
 	RemainingBillingCycles int `json:"remaining_billing_cycles,omitempty"`
 
 	// Date the ramp interval starts
-	StartingOn time.Time `json:"starting_on,omitempty"`
+	StartingOn *time.Time `json:"starting_on,omitempty"`
 
 	// Date the ramp interval ends
-	EndingOn time.Time `json:"ending_on,omitempty"`
+	EndingOn *time.Time `json:"ending_on,omitempty"`
 
 	// Represents the price for the ramp interval.
 	UnitAmount float64 `json:"unit_amount,omitempty"`

--- a/subscription_update.go
+++ b/subscription_update.go
@@ -14,7 +14,7 @@ type SubscriptionUpdate struct {
 	CollectionMethod *string `json:"collection_method,omitempty"`
 
 	// The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.
-	CustomFields []CustomFieldCreate `json:"custom_fields,omitempty"`
+	CustomFields *[]CustomFieldCreate `json:"custom_fields,omitempty"`
 
 	// The remaining billing cycles in the current term.
 	RemainingBillingCycles *int `json:"remaining_billing_cycles,omitempty"`

--- a/tier_create.go
+++ b/tier_create.go
@@ -15,5 +15,5 @@ type TierCreate struct {
 	UsagePercentage *string `json:"usage_percentage,omitempty"`
 
 	// Tier pricing
-	Currencies []TierPricingCreate `json:"currencies,omitempty"`
+	Currencies *[]TierPricingCreate `json:"currencies,omitempty"`
 }

--- a/transaction.go
+++ b/transaction.go
@@ -134,16 +134,16 @@ type Transaction struct {
 	AvsCheck string `json:"avs_check,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// Voided at
-	VoidedAt time.Time `json:"voided_at,omitempty"`
+	VoidedAt *time.Time `json:"voided_at,omitempty"`
 
 	// Collected at, or if not collected yet, the time the transaction was created.
-	CollectedAt time.Time `json:"collected_at,omitempty"`
+	CollectedAt *time.Time `json:"collected_at,omitempty"`
 
 	// Action result params to be used in Recurly-JS to complete a payment when using asynchronous payment methods, e.g., Boleto, iDEAL and Sofort.
 	ActionResult map[string]interface{} `json:"action_result,omitempty"`

--- a/unique_coupon_code.go
+++ b/unique_coupon_code.go
@@ -32,16 +32,16 @@ type UniqueCouponCode struct {
 	BulkCouponCode string `json:"bulk_coupon_code,omitempty"`
 
 	// Created at
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// Updated at
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// The date and time the unique coupon code was redeemed.
-	RedeemedAt time.Time `json:"redeemed_at,omitempty"`
+	RedeemedAt *time.Time `json:"redeemed_at,omitempty"`
 
 	// The date and time the coupon was expired early or reached its `max_redemptions`.
-	ExpiredAt time.Time `json:"expired_at,omitempty"`
+	ExpiredAt *time.Time `json:"expired_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/unique_coupon_code_params.go
+++ b/unique_coupon_code_params.go
@@ -23,7 +23,7 @@ type UniqueCouponCodeParams struct {
 	Sort string `json:"sort,omitempty"`
 
 	// The date-time to be included when listing UniqueCouponCodes
-	BeginTime time.Time `json:"begin_time,omitempty"`
+	BeginTime *time.Time `json:"begin_time,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/usage.go
+++ b/usage.go
@@ -43,10 +43,10 @@ type Usage struct {
 	MeasuredUnitId string `json:"measured_unit_id,omitempty"`
 
 	// When the usage was recorded in your system.
-	RecordingTimestamp time.Time `json:"recording_timestamp,omitempty"`
+	RecordingTimestamp *time.Time `json:"recording_timestamp,omitempty"`
 
 	// When the usage actually happened. This will define the line item dates this usage is billed under and is important for revenue recognition.
-	UsageTimestamp time.Time `json:"usage_timestamp,omitempty"`
+	UsageTimestamp *time.Time `json:"usage_timestamp,omitempty"`
 
 	// The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0.
 	UsagePercentage float64 `json:"usage_percentage,omitempty"`
@@ -58,13 +58,13 @@ type Usage struct {
 	UnitAmountDecimal string `json:"unit_amount_decimal,omitempty"`
 
 	// When the usage record was billed on an invoice.
-	BilledAt time.Time `json:"billed_at,omitempty"`
+	BilledAt *time.Time `json:"billed_at,omitempty"`
 
 	// When the usage record was created in Recurly.
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
 	// When the usage record was billed on an invoice.
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/user.go
+++ b/user.go
@@ -26,9 +26,9 @@ type User struct {
 
 	TimeZone string `json:"time_zone,omitempty"`
 
-	CreatedAt time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
 
-	DeletedAt time.Time `json:"deleted_at,omitempty"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource


### PR DESCRIPTION
- Fixes #239 by updating the type of `UnitAmount` in `SubscriptionRampInterval` to `float64`
- Fixes #99 by updating all `time.Time` field types to be pointers.
- Fixes #213  by updating request structs to use pointers for slices