### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/account.go
+++ b/account.go
@@ -114,6 +114,9 @@ type Account struct {
 
 	// The Avalara AvaTax value that can be passed to identify the customer type for tax purposes. The range of values can be A - R (more info at Avalara). Value is case-sensitive.
 	EntityUseCode string `json:"entity_use_code,omitempty"`
+
+	// The preferred billing date for the account. This date will be used as the billing date for when activating new subscriptions on the account.
+	BillDate *time.Time `json:"bill_date,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/account_create.go
+++ b/account_create.go
@@ -4,7 +4,9 @@
 // need and we will usher them to the appropriate places.
 package recurly
 
-import ()
+import (
+	"time"
+)
 
 type AccountCreate struct {
 
@@ -78,4 +80,7 @@ type AccountCreate struct {
 
 	// The Avalara AvaTax value that can be passed to identify the customer type for tax purposes. The range of values can be A - R (more info at Avalara). Value is case-sensitive.
 	EntityUseCode *string `json:"entity_use_code,omitempty"`
+
+	// The preferred billing date for the account. This date will be used as the billing date for when activating new subscriptions on the account.
+	BillDate *time.Time `json:"bill_date,omitempty"`
 }

--- a/account_note_create.go
+++ b/account_note_create.go
@@ -1,0 +1,13 @@
+// This file is automatically created by Recurly's OpenAPI generation process
+// and thus any edits you make by hand will be lost. If you wish to make a
+// change to this file, please create a Github issue explaining the changes you
+// need and we will usher them to the appropriate places.
+package recurly
+
+import ()
+
+type AccountNoteCreate struct {
+
+	// The content of the account note.
+	Message *string `json:"message,omitempty"`
+}

--- a/account_purchase.go
+++ b/account_purchase.go
@@ -4,7 +4,9 @@
 // need and we will usher them to the appropriate places.
 package recurly
 
-import ()
+import (
+	"time"
+)
 
 type AccountPurchase struct {
 
@@ -76,4 +78,7 @@ type AccountPurchase struct {
 
 	// The Avalara AvaTax value that can be passed to identify the customer type for tax purposes. The range of values can be A - R (more info at Avalara). Value is case-sensitive.
 	EntityUseCode *string `json:"entity_use_code,omitempty"`
+
+	// The preferred billing date for the account. This date will be used as the billing date for when activating new subscriptions on the account.
+	BillDate *time.Time `json:"bill_date,omitempty"`
 }

--- a/account_update.go
+++ b/account_update.go
@@ -4,7 +4,9 @@
 // need and we will usher them to the appropriate places.
 package recurly
 
-import ()
+import (
+	"time"
+)
 
 type AccountUpdate struct {
 
@@ -68,4 +70,7 @@ type AccountUpdate struct {
 
 	// The Avalara AvaTax value that can be passed to identify the customer type for tax purposes. The range of values can be A - R (more info at Avalara). Value is case-sensitive.
 	EntityUseCode *string `json:"entity_use_code,omitempty"`
+
+	// The preferred billing date for the account. This date will be used as the billing date for when activating new subscriptions on the account.
+	BillDate *time.Time `json:"bill_date,omitempty"`
 }

--- a/add_on.go
+++ b/add_on.go
@@ -76,6 +76,9 @@ type AddOn struct {
 	// Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes. If `item_code`/`item_id` is part of the request then `tax_code` must be absent.
 	TaxCode string `json:"tax_code,omitempty"`
 
+	// The Harmonized System (HS) code is an internationally standardized system of names and numbers to classify traded products. The HS code, sometimes called Commodity Code, is used by customs authorities around the world to identify products when assessing duties and taxes. The HS code may also be referred to as the tariff code or customs code. Values should contain only digits and decimals.
+	HarmonizedSystemCode string `json:"harmonized_system_code,omitempty"`
+
 	// Determines if the quantity field is displayed on the hosted pages for the add-on.
 	DisplayQuantity bool `json:"display_quantity,omitempty"`
 

--- a/add_on_create.go
+++ b/add_on_create.go
@@ -82,6 +82,9 @@ type AddOnCreate struct {
 	// Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes. If `item_code`/`item_id` is part of the request then `tax_code` must be absent.
 	TaxCode *string `json:"tax_code,omitempty"`
 
+	// The Harmonized System (HS) code is an internationally standardized system of names and numbers to classify traded products. The HS code, sometimes called Commodity Code, is used by customs authorities around the world to identify products when assessing duties and taxes. The HS code may also be referred to as the tariff code or customs code. Values should contain only digits and decimals.
+	HarmonizedSystemCode *string `json:"harmonized_system_code,omitempty"`
+
 	// * If `item_code`/`item_id` is part of the request and the item
 	// has a default currency, then `currencies` is optional. If the item does
 	// not have a default currency, then `currencies` is required. If `item_code`/`item_id`

--- a/add_on_update.go
+++ b/add_on_update.go
@@ -59,6 +59,9 @@ type AddOnUpdate struct {
 	// Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes. If an `Item` is associated to the `AddOn` then `tax_code` must be absent.
 	TaxCode *string `json:"tax_code,omitempty"`
 
+	// The Harmonized System (HS) code is an internationally standardized system of names and numbers to classify traded products. The HS code, sometimes called Commodity Code, is used by customs authorities around the world to identify products when assessing duties and taxes. The HS code may also be referred to as the tariff code or customs code. Values should contain only digits and decimals.
+	HarmonizedSystemCode *string `json:"harmonized_system_code,omitempty"`
+
 	// Determines if the quantity field is displayed on the hosted pages for the add-on.
 	DisplayQuantity *bool `json:"display_quantity,omitempty"`
 

--- a/client_operations.go
+++ b/client_operations.go
@@ -130,8 +130,14 @@ type ClientInterface interface {
 
 	ListAccountNotes(accountId string, params *ListAccountNotesParams, opts ...Option) (AccountNoteLister, error)
 
+	CreateAccountNote(accountId string, body *AccountNoteCreate, opts ...Option) (*AccountNote, error)
+	CreateAccountNoteWithContext(ctx context.Context, accountId string, body *AccountNoteCreate, opts ...Option) (*AccountNote, error)
+
 	GetAccountNote(accountId string, accountNoteId string, opts ...Option) (*AccountNote, error)
 	GetAccountNoteWithContext(ctx context.Context, accountId string, accountNoteId string, opts ...Option) (*AccountNote, error)
+
+	RemoveAccountNote(accountId string, accountNoteId string, opts ...Option) (*Empty, error)
+	RemoveAccountNoteWithContext(ctx context.Context, accountId string, accountNoteId string, opts ...Option) (*Empty, error)
 
 	ListShippingAddresses(accountId string, params *ListShippingAddressesParams, opts ...Option) (ShippingAddressLister, error)
 
@@ -2096,6 +2102,35 @@ func (c *Client) ListAccountNotes(accountId string, params *ListAccountNotesPara
 	return NewAccountNoteList(c, path, requestOptions), nil
 }
 
+// CreateAccountNote wraps CreateAccountNoteWithContext using the background context
+func (c *Client) CreateAccountNote(accountId string, body *AccountNoteCreate, opts ...Option) (*AccountNote, error) {
+	ctx := context.Background()
+	return c.createAccountNote(ctx, accountId, body, opts...)
+}
+
+// CreateAccountNoteWithContext Create an account note
+//
+// API Documentation: https://developers.recurly.com/api/v2021-02-25#operation/create_account_note
+//
+// Returns: An account note.
+func (c *Client) CreateAccountNoteWithContext(ctx context.Context, accountId string, body *AccountNoteCreate, opts ...Option) (*AccountNote, error) {
+	return c.createAccountNote(ctx, accountId, body, opts...)
+}
+
+func (c *Client) createAccountNote(ctx context.Context, accountId string, body *AccountNoteCreate, opts ...Option) (*AccountNote, error) {
+	path, err := c.InterpolatePath("/accounts/{account_id}/notes", accountId)
+	if err != nil {
+		return nil, err
+	}
+	requestOptions := NewRequestOptions(opts...)
+	result := &AccountNote{}
+	err = c.Call(ctx, http.MethodPost, path, body, nil, requestOptions, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, err
+}
+
 // GetAccountNote wraps GetAccountNoteWithContext using the background context
 func (c *Client) GetAccountNote(accountId string, accountNoteId string, opts ...Option) (*AccountNote, error) {
 	ctx := context.Background()
@@ -2119,6 +2154,35 @@ func (c *Client) getAccountNote(ctx context.Context, accountId string, accountNo
 	requestOptions := NewRequestOptions(opts...)
 	result := &AccountNote{}
 	err = c.Call(ctx, http.MethodGet, path, nil, nil, requestOptions, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, err
+}
+
+// RemoveAccountNote wraps RemoveAccountNoteWithContext using the background context
+func (c *Client) RemoveAccountNote(accountId string, accountNoteId string, opts ...Option) (*Empty, error) {
+	ctx := context.Background()
+	return c.removeAccountNote(ctx, accountId, accountNoteId, opts...)
+}
+
+// RemoveAccountNoteWithContext Delete an account note
+//
+// API Documentation: https://developers.recurly.com/api/v2021-02-25#operation/remove_account_note
+//
+// Returns: Account note deleted.
+func (c *Client) RemoveAccountNoteWithContext(ctx context.Context, accountId string, accountNoteId string, opts ...Option) (*Empty, error) {
+	return c.removeAccountNote(ctx, accountId, accountNoteId, opts...)
+}
+
+func (c *Client) removeAccountNote(ctx context.Context, accountId string, accountNoteId string, opts ...Option) (*Empty, error) {
+	path, err := c.InterpolatePath("/accounts/{account_id}/notes/{account_note_id}", accountId, accountNoteId)
+	if err != nil {
+		return nil, err
+	}
+	requestOptions := NewRequestOptions(opts...)
+	result := &Empty{}
+	err = c.Call(ctx, http.MethodDelete, path, nil, nil, requestOptions, result)
 	if err != nil {
 		return nil, err
 	}

--- a/item.go
+++ b/item.go
@@ -64,6 +64,9 @@ type Item struct {
 	// Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes.
 	TaxCode string `json:"tax_code,omitempty"`
 
+	// The Harmonized System (HS) code is an internationally standardized system of names and numbers to classify traded products. The HS code, sometimes called Commodity Code, is used by customs authorities around the world to identify products when assessing duties and taxes. The HS code may also be referred to as the tariff code or customs code. Values should contain only digits and decimals.
+	HarmonizedSystemCode string `json:"harmonized_system_code,omitempty"`
+
 	// `true` exempts tax on the item, `false` applies tax on the item.
 	TaxExempt bool `json:"tax_exempt,omitempty"`
 

--- a/item_create.go
+++ b/item_create.go
@@ -50,6 +50,9 @@ type ItemCreate struct {
 	// Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes.
 	TaxCode *string `json:"tax_code,omitempty"`
 
+	// The Harmonized System (HS) code is an internationally standardized system of names and numbers to classify traded products. The HS code, sometimes called Commodity Code, is used by customs authorities around the world to identify products when assessing duties and taxes. The HS code may also be referred to as the tariff code or customs code. Values should contain only digits and decimals.
+	HarmonizedSystemCode *string `json:"harmonized_system_code,omitempty"`
+
 	// `true` exempts tax on the item, `false` applies tax on the item.
 	TaxExempt *bool `json:"tax_exempt,omitempty"`
 

--- a/item_update.go
+++ b/item_update.go
@@ -50,6 +50,9 @@ type ItemUpdate struct {
 	// Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes.
 	TaxCode *string `json:"tax_code,omitempty"`
 
+	// The Harmonized System (HS) code is an internationally standardized system of names and numbers to classify traded products. The HS code, sometimes called Commodity Code, is used by customs authorities around the world to identify products when assessing duties and taxes. The HS code may also be referred to as the tariff code or customs code. Values should contain only digits and decimals.
+	HarmonizedSystemCode *string `json:"harmonized_system_code,omitempty"`
+
 	// `true` exempts tax on the item, `false` applies tax on the item.
 	TaxExempt *bool `json:"tax_exempt,omitempty"`
 

--- a/line_item.go
+++ b/line_item.go
@@ -155,6 +155,9 @@ type LineItem struct {
 	// Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes.
 	TaxCode string `json:"tax_code,omitempty"`
 
+	// The Harmonized System (HS) code is an internationally standardized system of names and numbers to classify traded products. The HS code, sometimes called Commodity Code, is used by customs authorities around the world to identify products when assessing duties and taxes. The HS code may also be referred to as the tariff code or customs code. Values should contain only digits and decimals.
+	HarmonizedSystemCode string `json:"harmonized_system_code,omitempty"`
+
 	// Only for merchants using Recurly's In-The-Box taxes.
 	TaxInfo TaxInfo `json:"tax_info,omitempty"`
 

--- a/line_item_create.go
+++ b/line_item_create.go
@@ -73,6 +73,9 @@ type LineItemCreate struct {
 	// Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes.
 	TaxCode *string `json:"tax_code,omitempty"`
 
+	// The Harmonized System (HS) code is an internationally standardized system of names and numbers to classify traded products. The HS code, sometimes called Commodity Code, is used by customs authorities around the world to identify products when assessing duties and taxes. The HS code may also be referred to as the tariff code or customs code. Values should contain only digits and decimals. If `item_code`/`item_id` is part of the request then `harmonized_system_code` must be absent.
+	HarmonizedSystemCode *string `json:"harmonized_system_code,omitempty"`
+
 	// Optional field to track a product code or SKU for the line item. This can be used to later reporting on product purchases. For Vertex tax calculations, this field will be used as the Vertex `product` field. If `item_code`/`item_id` is part of the request then `product_code` must be absent.
 	ProductCode *string `json:"product_code,omitempty"`
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -4462,6 +4462,51 @@ paths:
           accountNotes.Fetch()\n\tif e, ok := err.(*recurly.Error); ok {\n\t\tfmt.Printf(\"Failed
           to retrieve next page: %v\", e)\n\t\tbreak\n\t}\n\tfor i, note := range
           accountNotes.Data() {\n\t\tfmt.Printf(\"Account Note %3d: %s\\n\",\n\t\t\ti,\n\t\t\tnote.Id,\n\t\t)\n\t}\n}"
+    post:
+      tags:
+      - note
+      operationId: create_account_note
+      summary: Create an account note
+      parameters:
+      - "$ref": "#/components/parameters/account_id"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/AccountNoteCreate"
+        required: true
+      responses:
+        '201':
+          description: An account note.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AccountNote"
+        '400':
+          description: Bad request; perhaps missing or invalid parameters.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Incorrect site or account ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '422':
+          description: A validation error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/accounts/{account_id}/notes/{account_note_id}":
     get:
       tags:
@@ -4470,12 +4515,7 @@ paths:
       summary: Fetch an account note
       parameters:
       - "$ref": "#/components/parameters/account_id"
-      - name: account_note_id
-        in: path
-        description: Account Note ID.
-        required: true
-        schema:
-          type: string
+      - "$ref": "#/components/parameters/account_note_id"
       responses:
         '200':
           description: An account note.
@@ -4588,6 +4628,30 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Account
           Note: %v\", accountNote)"
+    delete:
+      tags:
+      - note
+      operationId: remove_account_note
+      summary: Delete an account note
+      parameters:
+      - "$ref": "#/components/parameters/account_id"
+      - "$ref": "#/components/parameters/account_note_id"
+      responses:
+        '204':
+          description: Account note deleted.
+        '404':
+          description: Incorrect site, account or note ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/accounts/{account_id}/shipping_addresses":
     get:
       tags:
@@ -16941,6 +17005,13 @@ components:
       required: true
       schema:
         type: string
+    account_note_id:
+      name: account_note_id
+      in: path
+      description: Account Note ID.
+      required: true
+      schema:
+        type: string
     add_on_id:
       name: add_on_id
       in: path
@@ -18046,6 +18117,13 @@ components:
           description: The Avalara AvaTax value that can be passed to identify the
             customer type for tax purposes. The range of values can be A - R (more
             info at Avalara). Value is case-sensitive.
+        bill_date:
+          type: string
+          title: Bill Date
+          format: date-time
+          description: The preferred billing date for the account. This date will
+            be used as the billing date for when activating new subscriptions on the
+            account.
     AccountResponse:
       type: object
       properties:
@@ -18152,6 +18230,13 @@ components:
           description: The Avalara AvaTax value that can be passed to identify the
             customer type for tax purposes. The range of values can be A - R (more
             info at Avalara). Value is case-sensitive.
+        bill_date:
+          title: Bill Date
+          type: string
+          format: date-time
+          description: The preferred billing date for the account. This date will
+            be used as the billing date for when activating new subscriptions on the
+            account.
     AccountNote:
       type: object
       required:
@@ -18175,6 +18260,14 @@ components:
           type: string
           format: date-time
           readOnly: true
+    AccountNoteCreate:
+      type: object
+      required:
+      - message
+      properties:
+        message:
+          type: string
+          description: The content of the account note.
     AccountMini:
       type: object
       title: Account mini details
@@ -18488,6 +18581,17 @@ components:
             offering you can also choose to instead use simple values of `unknown`,
             `physical`, or `digital` tax codes. If `item_code`/`item_id` is part of
             the request then `tax_code` must be absent.
+        harmonized_system_code:
+          type: string
+          title: Harmonized System code
+          description: The Harmonized System (HS) code is an internationally standardized
+            system of names and numbers to classify traded products. The HS code,
+            sometimes called Commodity Code, is used by customs authorities around
+            the world to identify products when assessing duties and taxes. The HS
+            code may also be referred to as the tariff code or customs code. Values
+            should contain only digits and decimals.
+          pattern: "^\\d+(\\.\\d+)*$"
+          maxLength: 25
         display_quantity:
           type: boolean
           title: Display quantity?
@@ -18710,6 +18814,17 @@ components:
             offering you can also choose to instead use simple values of `unknown`,
             `physical`, or `digital` tax codes. If `item_code`/`item_id` is part of
             the request then `tax_code` must be absent.
+        harmonized_system_code:
+          type: string
+          title: Harmonized System code
+          description: The Harmonized System (HS) code is an internationally standardized
+            system of names and numbers to classify traded products. The HS code,
+            sometimes called Commodity Code, is used by customs authorities around
+            the world to identify products when assessing duties and taxes. The HS
+            code may also be referred to as the tariff code or customs code. Values
+            should contain only digits and decimals.
+          pattern: "^\\d+(\\.\\d+)*$"
+          maxLength: 25
         currencies:
           type: array
           title: Add-on pricing
@@ -18865,6 +18980,17 @@ components:
             offering you can also choose to instead use simple values of `unknown`,
             `physical`, or `digital` tax codes. If an `Item` is associated to the
             `AddOn` then `tax_code` must be absent.
+        harmonized_system_code:
+          type: string
+          title: Harmonized System code
+          description: The Harmonized System (HS) code is an internationally standardized
+            system of names and numbers to classify traded products. The HS code,
+            sometimes called Commodity Code, is used by customs authorities around
+            the world to identify products when assessing duties and taxes. The HS
+            code may also be referred to as the tariff code or customs code. Values
+            should contain only digits and decimals.
+          pattern: "^\\d+(\\.\\d+)*$"
+          maxLength: 25
         display_quantity:
           type: boolean
           title: Display quantity?
@@ -20207,6 +20333,17 @@ components:
             codes using any of these tax integrations. For Recurly's In-the-Box tax
             offering you can also choose to instead use simple values of `unknown`,
             `physical`, or `digital` tax codes.
+        harmonized_system_code:
+          type: string
+          title: Harmonized System code
+          description: The Harmonized System (HS) code is an internationally standardized
+            system of names and numbers to classify traded products. The HS code,
+            sometimes called Commodity Code, is used by customs authorities around
+            the world to identify products when assessing duties and taxes. The HS
+            code may also be referred to as the tariff code or customs code. Values
+            should contain only digits and decimals.
+          pattern: "^\\d+(\\.\\d+)*$"
+          maxLength: 25
         tax_exempt:
           type: boolean
           title: Tax exempt?
@@ -20317,6 +20454,17 @@ components:
             codes using any of these tax integrations. For Recurly's In-the-Box tax
             offering you can also choose to instead use simple values of `unknown`,
             `physical`, or `digital` tax codes.
+        harmonized_system_code:
+          type: string
+          title: Harmonized System code
+          description: The Harmonized System (HS) code is an internationally standardized
+            system of names and numbers to classify traded products. The HS code,
+            sometimes called Commodity Code, is used by customs authorities around
+            the world to identify products when assessing duties and taxes. The HS
+            code may also be referred to as the tariff code or customs code. Values
+            should contain only digits and decimals.
+          pattern: "^\\d+(\\.\\d+)*$"
+          maxLength: 25
         tax_exempt:
           type: boolean
           title: Tax exempt?
@@ -20415,6 +20563,17 @@ components:
             codes using any of these tax integrations. For Recurly's In-the-Box tax
             offering you can also choose to instead use simple values of `unknown`,
             `physical`, or `digital` tax codes.
+        harmonized_system_code:
+          type: string
+          title: Harmonized System Code
+          description: The Harmonized System (HS) code is an internationally standardized
+            system of names and numbers to classify traded products. The HS code,
+            sometimes called Commodity Code, is used by customs authorities around
+            the world to identify products when assessing duties and taxes. The HS
+            code may also be referred to as the tariff code or customs code. Values
+            should contain only digits and decimals.
+          pattern: "^\\d+(\\.\\d+)*$"
+          maxLength: 25
         tax_exempt:
           type: boolean
           title: Tax exempt?
@@ -21310,6 +21469,17 @@ components:
             codes using any of these tax integrations. For Recurly's In-the-Box tax
             offering you can also choose to instead use simple values of `unknown`,
             `physical`, or `digital` tax codes.
+        harmonized_system_code:
+          type: string
+          title: Harmonized System Code
+          description: The Harmonized System (HS) code is an internationally standardized
+            system of names and numbers to classify traded products. The HS code,
+            sometimes called Commodity Code, is used by customs authorities around
+            the world to identify products when assessing duties and taxes. The HS
+            code may also be referred to as the tariff code or customs code. Values
+            should contain only digits and decimals.
+          maxLength: 25
+          pattern: "^\\d+(\\.\\d+)*$"
         tax_info:
           "$ref": "#/components/schemas/TaxInfo"
         origin_tax_address_source:
@@ -21554,6 +21724,18 @@ components:
             codes using any of these tax integrations. For Recurly's In-the-Box tax
             offering you can also choose to instead use simple values of `unknown`,
             `physical`, or `digital` tax codes.
+        harmonized_system_code:
+          type: string
+          title: Harmonized System Code
+          description: The Harmonized System (HS) code is an internationally standardized
+            system of names and numbers to classify traded products. The HS code,
+            sometimes called Commodity Code, is used by customs authorities around
+            the world to identify products when assessing duties and taxes. The HS
+            code may also be referred to as the tariff code or customs code. Values
+            should contain only digits and decimals. If `item_code`/`item_id` is part
+            of the request then `harmonized_system_code` must be absent.
+          maxLength: 25
+          pattern: "^\\d+(\\.\\d+)*$"
         product_code:
           type: string
           title: Product code
@@ -21749,6 +21931,17 @@ components:
             codes using any of these tax integrations. For Recurly's In-the-Box tax
             offering you can also choose to instead use simple values of `unknown`,
             `physical`, or `digital` tax codes.
+        harmonized_system_code:
+          type: string
+          title: Harmonized System Code
+          description: The Harmonized System (HS) code is an internationally standardized
+            system of names and numbers to classify traded products. The HS code,
+            sometimes called Commodity Code, is used by customs authorities around
+            the world to identify products when assessing duties and taxes. The HS
+            code may also be referred to as the tariff code or customs code. Values
+            should contain only digits and decimals.
+          maxLength: 25
+          pattern: "^\\d+(\\.\\d+)*$"
         tax_exempt:
           type: boolean
           title: Tax exempt?
@@ -22182,6 +22375,22 @@ components:
       - full_amount
       - prorated_amount
       - none
+    SubscriptionCreateProrationSettings:
+      type: object
+      title: Proration Settings
+      description: Allows you to control how any resulting charges will be calculated
+        and prorated.
+      properties:
+        charge:
+          "$ref": "#/components/schemas/SubscriptionCreateProrationSettingsChargeEnum"
+    SubscriptionCreateProrationSettingsChargeEnum:
+      type: string
+      title: Charge
+      description: Determines how the amount charged is determined for this change
+      default: prorated_amount
+      enum:
+      - full_amount
+      - prorated_amount
     Settings:
       type: object
       properties:
@@ -23787,6 +23996,8 @@ components:
             second limit on creating subscriptions. Should only be used when creating
             subscriptions in bulk from the API.
           default: false
+        proration_settings:
+          "$ref": "#/components/schemas/SubscriptionCreateProrationSettings"
       required:
       - plan_code
       - currency
@@ -23898,6 +24109,8 @@ components:
             second limit on creating subscriptions. Should only be used when creating
             subscriptions in bulk from the API.
           default: false
+        proration_settings:
+          "$ref": "#/components/schemas/SubscriptionCreateProrationSettings"
       required:
       - plan_code
     SubscriptionUpdate:

--- a/plan.go
+++ b/plan.go
@@ -120,6 +120,9 @@ type Plan struct {
 	// Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes.
 	TaxCode string `json:"tax_code,omitempty"`
 
+	// The Harmonized System (HS) code is an internationally standardized system of names and numbers to classify traded products. The HS code, sometimes called Commodity Code, is used by customs authorities around the world to identify products when assessing duties and taxes. The HS code may also be referred to as the tariff code or customs code. Values should contain only digits and decimals.
+	HarmonizedSystemCode string `json:"harmonized_system_code,omitempty"`
+
 	// `true` exempts tax on the plan, `false` applies tax on the plan.
 	TaxExempt bool `json:"tax_exempt,omitempty"`
 

--- a/plan_create.go
+++ b/plan_create.go
@@ -109,6 +109,9 @@ type PlanCreate struct {
 	// Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes.
 	TaxCode *string `json:"tax_code,omitempty"`
 
+	// The Harmonized System (HS) code is an internationally standardized system of names and numbers to classify traded products. The HS code, sometimes called Commodity Code, is used by customs authorities around the world to identify products when assessing duties and taxes. The HS code may also be referred to as the tariff code or customs code. Values should contain only digits and decimals.
+	HarmonizedSystemCode *string `json:"harmonized_system_code,omitempty"`
+
 	// `true` exempts tax on the plan, `false` applies tax on the plan.
 	TaxExempt *bool `json:"tax_exempt,omitempty"`
 

--- a/plan_update.go
+++ b/plan_update.go
@@ -98,6 +98,9 @@ type PlanUpdate struct {
 	// Optional field used by Avalara, Vertex, and Recurly's In-the-Box tax solution to determine taxation rules. You can pass in specific tax codes using any of these tax integrations. For Recurly's In-the-Box tax offering you can also choose to instead use simple values of `unknown`, `physical`, or `digital` tax codes.
 	TaxCode *string `json:"tax_code,omitempty"`
 
+	// The Harmonized System (HS) code is an internationally standardized system of names and numbers to classify traded products. The HS code, sometimes called Commodity Code, is used by customs authorities around the world to identify products when assessing duties and taxes. The HS code may also be referred to as the tariff code or customs code. Values should contain only digits and decimals.
+	HarmonizedSystemCode *string `json:"harmonized_system_code,omitempty"`
+
 	// `true` exempts tax on the plan, `false` applies tax on the plan.
 	TaxExempt *bool `json:"tax_exempt,omitempty"`
 

--- a/scripts/clean
+++ b/scripts/clean
@@ -119,6 +119,7 @@ rm -f coupon_redemption_create.go
 rm -f external_account_update.go
 rm -f invoice_create.go
 rm -f line_item_create.go
+rm -f account_note_create.go
 rm -f shipping_address_update.go
 rm -f coupon_create.go
 rm -f coupon_pricing.go
@@ -171,6 +172,7 @@ rm -f subscription_add_on_create.go
 rm -f subscription_add_on_tier_create.go
 rm -f subscription_add_on_percentage_tier_create.go
 rm -f subscription_ramp_interval.go
+rm -f subscription_create_proration_settings.go
 rm -f subscription_update.go
 rm -f subscription_shipping_update.go
 rm -f subscription_cancel.go

--- a/subscription_create.go
+++ b/subscription_create.go
@@ -124,4 +124,7 @@ type SubscriptionCreate struct {
 
 	// Optional field to be used only when needing to bypass the 60 second limit on creating subscriptions. Should only be used when creating subscriptions in bulk from the API.
 	Bulk *bool `json:"bulk,omitempty"`
+
+	// Allows you to control how any resulting charges will be calculated and prorated.
+	ProrationSettings *SubscriptionCreateProrationSettings `json:"proration_settings,omitempty"`
 }

--- a/subscription_create_proration_settings.go
+++ b/subscription_create_proration_settings.go
@@ -1,0 +1,13 @@
+// This file is automatically created by Recurly's OpenAPI generation process
+// and thus any edits you make by hand will be lost. If you wish to make a
+// change to this file, please create a Github issue explaining the changes you
+// need and we will usher them to the appropriate places.
+package recurly
+
+import ()
+
+type SubscriptionCreateProrationSettings struct {
+
+	// Determines how the amount charged is determined for this change
+	Charge *string `json:"charge,omitempty"`
+}

--- a/subscription_purchase.go
+++ b/subscription_purchase.go
@@ -63,4 +63,7 @@ type SubscriptionPurchase struct {
 
 	// Optional field to be used only when needing to bypass the 60 second limit on creating subscriptions. Should only be used when creating subscriptions in bulk from the API.
 	Bulk *bool `json:"bulk,omitempty"`
+
+	// Allows you to control how any resulting charges will be calculated and prorated.
+	ProrationSettings *SubscriptionCreateProrationSettings `json:"proration_settings,omitempty"`
 }


### PR DESCRIPTION
This pull request introduces two main sets of changes: (1) it adds support for managing account notes through the API and client, and (2) it adds a new `HarmonizedSystemCode` field to various product and line item structures to support international trade classification. Additionally, it introduces a new `bill_date` field to account-related types to allow specifying a preferred billing date for subscriptions.

**Account Notes API Enhancements:**

* Added support for creating and deleting account notes via new endpoints in the OpenAPI specification (`/accounts/{account_id}/notes` for POST and `/accounts/{account_id}/notes/{account_note_id}` for DELETE), including relevant request/response schemas and parameters.
* Added the `AccountNoteCreate` struct and corresponding client methods (`CreateAccountNote`, `CreateAccountNoteWithContext`, `RemoveAccountNote`, `RemoveAccountNoteWithContext`) to support these operations in the SDK.

**Product and Line Item Enhancements:**

* Introduced the `HarmonizedSystemCode` field to `AddOn`, `AddOnCreate`, `AddOnUpdate`, `Item`, `ItemCreate`, `ItemUpdate`, `LineItem`, and `LineItemCreate` structs to support international customs classification for products and add-ons.

**Account Billing Enhancements:**

* Added a `BillDate` field to `Account`, `AccountCreate`, `AccountUpdate`, and `AccountPurchase` structs, allowing a preferred billing date to be set for new subscriptions on an account.

These changes improve the flexibility and internationalization of the API, particularly for billing and tax compliance.