### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/address.go
+++ b/address.go
@@ -33,7 +33,7 @@ type Address struct {
 	// Country, 2-letter ISO 3166-1 alpha-2 code.
 	Country string `json:"country,omitempty"`
 
-	// Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+	// Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
 	GeoCode string `json:"geo_code,omitempty"`
 }
 

--- a/address_create.go
+++ b/address_create.go
@@ -29,6 +29,6 @@ type AddressCreate struct {
 	// Country, 2-letter ISO 3166-1 alpha-2 code.
 	Country *string `json:"country,omitempty"`
 
-	// Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+	// Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
 	GeoCode *string `json:"geo_code,omitempty"`
 }

--- a/address_with_name.go
+++ b/address_with_name.go
@@ -39,7 +39,7 @@ type AddressWithName struct {
 	// Country, 2-letter ISO 3166-1 alpha-2 code.
 	Country string `json:"country,omitempty"`
 
-	// Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+	// Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
 	GeoCode string `json:"geo_code,omitempty"`
 }
 

--- a/coupon.go
+++ b/coupon.go
@@ -47,10 +47,10 @@ type Coupon struct {
 	// - "temporal" coupons will apply to invoices for the duration determined by the `temporal_unit` and `temporal_amount` attributes.
 	Duration string `json:"duration,omitempty"`
 
-	// If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for.
+	// If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for. When `temporal_unit` is "billing_period", this is the number of complete billing cycles.
 	TemporalAmount int `json:"temporal_amount,omitempty"`
 
-	// If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for.
+	// If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for. Use "billing_period" to apply the coupon for a fixed number of billing cycles. Requires `redemption_resource=subscription`.
 	TemporalUnit string `json:"temporal_unit,omitempty"`
 
 	// Description of the unit of time the coupon is for. Used with `free_trial_amount` to determine the duration of time the coupon is for.

--- a/coupon_create.go
+++ b/coupon_create.go
@@ -74,10 +74,10 @@ type CouponCreate struct {
 	// - "forever" coupons will apply to invoices forever.
 	Duration *string `json:"duration,omitempty"`
 
-	// If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for.
+	// If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for. When `temporal_unit` is "billing_period", this is the number of complete billing cycles.
 	TemporalAmount *int `json:"temporal_amount,omitempty"`
 
-	// If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for.
+	// If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for. Use "billing_period" to apply the coupon for a fixed number of billing cycles. Requires `redemption_resource=subscription`.
 	TemporalUnit *string `json:"temporal_unit,omitempty"`
 
 	// Whether the coupon is "single_code" or "bulk". Bulk coupons will require a `unique_code_template` and will generate unique codes through the `/generate` endpoint.

--- a/custom_field.go
+++ b/custom_field.go
@@ -17,6 +17,12 @@ type CustomField struct {
 
 	// Any values that resemble a credit card number or security code (CVV/CVC) will be rejected.
 	Value string `json:"value,omitempty"`
+
+	// The type of record this custom field was automatically copied from. Only present when the field was copied from another record.
+	SourceRecordType string `json:"source_record_type,omitempty"`
+
+	// The UUID of the record this custom field was automatically copied from. Only present when the field was copied from another record.
+	SourceRecordId string `json:"source_record_id,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/custom_field_create.go
+++ b/custom_field_create.go
@@ -13,4 +13,10 @@ type CustomFieldCreate struct {
 
 	// Any values that resemble a credit card number or security code (CVV/CVC) will be rejected.
 	Value *string `json:"value,omitempty"`
+
+	// The type of record this custom field was automatically copied from. Only present when the field was copied from another record.
+	SourceRecordType *string `json:"source_record_type,omitempty"`
+
+	// The UUID of the record this custom field was automatically copied from. Only present when the field was copied from another record.
+	SourceRecordId *string `json:"source_record_id,omitempty"`
 }

--- a/invoice.go
+++ b/invoice.go
@@ -159,6 +159,9 @@ type Invoice struct {
 
 	// Unique ID to identify the business entity assigned to the invoice. Available when the `Multiple Business Entities` feature is enabled.
 	BusinessEntityId string `json:"business_entity_id,omitempty"`
+
+	// A list of custom fields that were on the account at the time of invoice creation and were marked to be displayed on invoices. Read-only; cannot be set directly on the invoice.
+	CustomFields []CustomField `json:"custom_fields,omitempty"`
 }
 
 // GetResponse returns the ResponseMetadata that generated this resource

--- a/invoice_address.go
+++ b/invoice_address.go
@@ -39,7 +39,7 @@ type InvoiceAddress struct {
 	// Country, 2-letter ISO 3166-1 alpha-2 code.
 	Country string `json:"country,omitempty"`
 
-	// Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+	// Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
 	GeoCode string `json:"geo_code,omitempty"`
 
 	// First name

--- a/invoice_address_create.go
+++ b/invoice_address_create.go
@@ -35,7 +35,7 @@ type InvoiceAddressCreate struct {
 	// Country, 2-letter ISO 3166-1 alpha-2 code.
 	Country *string `json:"country,omitempty"`
 
-	// Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+	// Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
 	GeoCode *string `json:"geo_code,omitempty"`
 
 	// First name

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -200,14 +200,12 @@ x-tagGroups:
   - usage
   - automated_exports
   - gift_cards
-- name: App Management
+- name: Invoices and Payments
   tags:
-  - external_subscriptions
-  - external_invoices
-  - external_products
-  - external_accounts
-  - external_product_references
-  - external_payment_phases
+  - invoice
+  - line_item
+  - credit_payment
+  - transaction
 - name: Products and Promotions
   tags:
   - item
@@ -218,12 +216,6 @@ x-tagGroups:
   - coupon_redemption
   - unique_coupon_code
   - price_segment
-- name: Invoices and Payments
-  tags:
-  - invoice
-  - line_item
-  - credit_payment
-  - transaction
 - name: Configuration
   tags:
   - site
@@ -233,6 +225,14 @@ x-tagGroups:
   - business_entities
   - general_ledger_account
   - performance_obligations
+- name: App Management
+  tags:
+  - external_subscriptions
+  - external_invoices
+  - external_products
+  - external_accounts
+  - external_product_references
+  - external_payment_phases
 tags:
 - name: site
   x-displayName: Site
@@ -9245,7 +9245,6 @@ paths:
       description: Apply credit payment to the outstanding balance on an existing
         charge invoice from an account’s available balance from existing credit invoices.
       parameters:
-      - "$ref": "#/components/parameters/site_id"
       - "$ref": "#/components/parameters/invoice_id"
       responses:
         '200':
@@ -18621,7 +18620,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
     AddressWithName:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -19642,12 +19641,14 @@ components:
           title: Temporal amount
           description: If `duration` is "temporal" than `temporal_amount` is an integer
             which is multiplied by `temporal_unit` to define the duration that the
-            coupon will be applied to invoices for.
+            coupon will be applied to invoices for. When `temporal_unit` is "billing_period",
+            this is the number of complete billing cycles.
         temporal_unit:
           title: Temporal unit
           description: If `duration` is "temporal" than `temporal_unit` is multiplied
             by `temporal_amount` to define the duration that the coupon will be applied
-            to invoices for.
+            to invoices for. Use "billing_period" to apply the coupon for a fixed
+            number of billing cycles. Requires `redemption_resource=subscription`.
           "$ref": "#/components/schemas/TemporalUnitEnum"
         free_trial_unit:
           title: Free trial unit
@@ -19833,12 +19834,14 @@ components:
             title: Temporal amount
             description: If `duration` is "temporal" than `temporal_amount` is an
               integer which is multiplied by `temporal_unit` to define the duration
-              that the coupon will be applied to invoices for.
+              that the coupon will be applied to invoices for. When `temporal_unit`
+              is "billing_period", this is the number of complete billing cycles.
           temporal_unit:
             title: Temporal unit
             description: If `duration` is "temporal" than `temporal_unit` is multiplied
               by `temporal_amount` to define the duration that the coupon will be
-              applied to invoices for.
+              applied to invoices for. Use "billing_period" to apply the coupon for
+              a fixed number of billing cycles. Requires `redemption_resource=subscription`.
             "$ref": "#/components/schemas/TemporalUnitEnum"
           coupon_type:
             title: Coupon type
@@ -20195,6 +20198,19 @@ components:
           description: Any values that resemble a credit card number or security code
             (CVV/CVC) will be rejected.
           maxLength: 255
+        source_record_type:
+          type: string
+          title: Source record type
+          description: The type of record this custom field was automatically copied
+            from. Only present when the field was copied from another record.
+          readOnly: true
+          "$ref": "#/components/schemas/SourceRecordTypeEnum"
+        source_record_id:
+          type: string
+          title: Source record ID
+          description: The UUID of the record this custom field was automatically
+            copied from. Only present when the field was copied from another record.
+          readOnly: true
       required:
       - name
       - value
@@ -20204,6 +20220,15 @@ components:
       description: The custom fields will only be altered when they are included in
         a request. Sending an empty array will not remove any existing values. To
         remove a field send the name with a null or empty value.
+      items:
+        "$ref": "#/components/schemas/CustomField"
+    InvoiceCustomFields:
+      type: array
+      title: Custom fields
+      description: A list of custom fields that were on the account at the time of
+        invoice creation and were marked to be displayed on invoices. Read-only; cannot
+        be set directly on the invoice.
+      readOnly: true
       items:
         "$ref": "#/components/schemas/CustomField"
     CustomFieldDefinition:
@@ -21084,6 +21109,8 @@ components:
           title: Business Entity ID
           description: Unique ID to identify the business entity assigned to the invoice.
             Available when the `Multiple Business Entities` feature is enabled.
+        custom_fields:
+          "$ref": "#/components/schemas/InvoiceCustomFields"
     InvoiceCreate:
       type: object
       properties:
@@ -22735,7 +22762,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
         created_at:
           type: string
           title: Created at
@@ -22823,7 +22850,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
         country:
           type: string
           maxLength: 50
@@ -23154,7 +23181,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
     Site:
       type: object
       properties:
@@ -27196,11 +27223,16 @@ components:
       - temporal
     TemporalUnitEnum:
       type: string
+      description: The temporal unit for the coupon's duration. Used with temporal_amount
+        to define how long the coupon applies. When temporal_unit is billing_period,
+        the coupon applies for temporal_amount complete billing cycles rather than
+        a fixed calendar duration. billing_period requires redemption_resource=subscription.
       enum:
       - day
       - month
       - week
       - year
+      - billing_period
     FreeTrialUnitEnum:
       type: string
       enum:
@@ -28104,3 +28136,11 @@ components:
       enum:
       - customer
       - merchant
+    SourceRecordTypeEnum:
+      type: string
+      description: The type of record a custom field was automatically copied from.
+      enum:
+      - account
+      - plan
+      - product
+      - subscription

--- a/shipping_address.go
+++ b/shipping_address.go
@@ -51,7 +51,7 @@ type ShippingAddress struct {
 	// Country, 2-letter ISO 3166-1 alpha-2 code.
 	Country string `json:"country,omitempty"`
 
-	// Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+	// Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
 	GeoCode string `json:"geo_code,omitempty"`
 
 	// Created at

--- a/shipping_address_create.go
+++ b/shipping_address_create.go
@@ -33,7 +33,7 @@ type ShippingAddressCreate struct {
 	// Zip or postal code.
 	PostalCode *string `json:"postal_code,omitempty"`
 
-	// Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+	// Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
 	GeoCode *string `json:"geo_code,omitempty"`
 
 	// Country, 2-letter ISO 3166-1 alpha-2 code.

--- a/shipping_address_update.go
+++ b/shipping_address_update.go
@@ -40,6 +40,6 @@ type ShippingAddressUpdate struct {
 	// Country, 2-letter ISO 3166-1 alpha-2 code.
 	Country *string `json:"country,omitempty"`
 
-	// Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+	// Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
 	GeoCode *string `json:"geo_code,omitempty"`
 }


### PR DESCRIPTION
This PR includes the latest generated changes for the `v2021-02-25` API version.

**New fields**
- `CustomField` now exposes `source_record_id` and `source_record_type` (read-only) — populated when a custom field was automatically copied from another record.
- `Invoice` now exposes `custom_fields` (read-only) — the list of custom fields that were on the account at invoice creation time and were marked for display on invoices.

**New enum values**
- `TemporalUnit`: added `billing_period` — use with `temporal_amount` to apply a coupon for a fixed number of billing cycles (requires `redemption_resource=subscription`).
- `SourceRecordType` (new enum): `account`, `plan`, `product`, `subscription`.

**Documentation clarifications**
- `Coupon` / `CouponCreate`: clarified `temporal_amount` and `temporal_unit` descriptions to document `billing_period` behavior.
- `Address`, `AddressWithName`, `InvoiceAddress`, `ShippingAddress`: updated `geo_code` description — now reads "Only returned when Vertex or Avalara for Communications is enabled" (previously referenced Sling Vertex only).