### PR TITLE
ci: Remediate Node.js 20 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ on: [push]
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ on: [push]
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -11,9 +13,9 @@ jobs:
       matrix:
         go: ["1.17", "1.18", "1.19", "1.20", "1.21", "1.22", "1.23", "1.24"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6.0.2
       - name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6.4.0
         with:
           go-version: ${{ matrix.go }}
       - run: ./scripts/build

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -9,9 +9,6 @@ on:
       - main
       - master
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
     golang-security-action:
         runs-on: ubuntu-latest

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,4 +1,4 @@
-name: Security check - Go Sec 
+name: Security check - Go Sec
 
 on:
   pull_request:
@@ -9,10 +9,13 @@ on:
       - main
       - master
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
     golang-security-action:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v6.0.2
             - uses: ynniss/golang-security-action@master
               continue-on-error: true

--- a/.github/workflows/nancy.yml
+++ b/.github/workflows/nancy.yml
@@ -9,9 +9,6 @@ on:
       - main
       - master
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/nancy.yml
+++ b/.github/workflows/nancy.yml
@@ -9,15 +9,18 @@ on:
       - main
       - master
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6.0.2
 
     - name: Set up Go 1.x in order to write go.list file
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v6.4.0
       with:
         go-version: ^1.13
     - name: WriteGoList


### PR DESCRIPTION
## Description

### Problem
GitHub Actions is deprecating Node.js 20. Actions on node20 or earlier will be forced to run with Node.js 24 starting June 2, 2026, and node20 will be removed from runners on September 16, 2026.

### Fix
Updated the following actions to Node.js 24-compatible versions:
- `actions/checkout@v3` (node16) → `actions/checkout@v6.0.2` (node24)
- `actions/setup-go@v3` (node16) → `actions/setup-go@v6.4.0` (node24)

### Files Changed
- `.github/workflows/ci.yml` — updated `actions/checkout` and `actions/setup-go`, added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` validation flag
- `.github/workflows/gosec.yml` — updated `actions/checkout`, added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` validation flag
- `.github/workflows/nancy.yml` — updated `actions/checkout` and `actions/setup-go`, added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` validation flag

## Testing
Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` flag to validate that all JavaScript actions run successfully under Node.js 24. CI results: pending